### PR TITLE
feat: Wire end-to-end content pipeline with revision loop

### DIFF
--- a/src/economist_agents/adapters.py
+++ b/src/economist_agents/adapters.py
@@ -1,0 +1,25 @@
+"""Adapter module bridging scripts/ legacy modules into src/ namespace.
+
+Centralises the sys.path manipulation so that flow.py can import
+topic_scout, editorial_board, publication_validator, and llm_client
+without scattering path hacks across the codebase.
+"""
+
+import sys
+from pathlib import Path
+
+_scripts_dir = str(Path(__file__).parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+from editorial_board import run_editorial_board  # noqa: E402
+from llm_client import create_llm_client  # noqa: E402
+from publication_validator import PublicationValidator  # noqa: E402
+from topic_scout import scout_topics  # noqa: E402
+
+__all__ = [
+    "create_llm_client",
+    "run_editorial_board",
+    "scout_topics",
+    "PublicationValidator",
+]

--- a/src/economist_agents/flow.py
+++ b/src/economist_agents/flow.py
@@ -14,12 +14,23 @@ Usage:
     result = flow.kickoff()
 """
 
+from datetime import datetime
 from typing import Any
 
 from crewai.flow.flow import Flow, listen, router, start
 
 from src.crews.stage3_crew import Stage3Crew
 from src.crews.stage4_crew import Stage4Crew
+from src.economist_agents.adapters import (
+    PublicationValidator,
+    create_llm_client,
+    run_editorial_board,
+    scout_topics,
+)
+
+# Editorial score threshold (0-100 scale) for publication
+PUBLISH_THRESHOLD = 80
+MAX_REVISIONS = 1
 
 
 class EconomistContentFlow(Flow):
@@ -27,232 +38,304 @@ class EconomistContentFlow(Flow):
     Production-grade content generation flow with deterministic orchestration.
 
     Flow Stages:
-    1. discover_topics() - @start - Entry point, generates topic candidates
-    2. editorial_review() - @listen - Selects winning topic for production
+    1. discover_topics() - @start - LLM-based topic scouting
+    2. editorial_review() - @listen - 6-persona weighted board voting
     3. generate_content() - @listen - Research → Write → Graphics pipeline
-    4. quality_gate() - @router - Editor evaluation with publish/revision routing
-
-    State Management:
-    - topics: List of topic candidates with scores
-    - selected_topic: Editorial board winner
-    - article_draft: Generated content with metadata
-    - quality_score: Editor evaluation (0-10 scale)
-    - decision: "publish" or "revision"
+    4. quality_gate() - @router - Stage4Crew + PublicationValidator routing
+    5a. publish_article() - @listen("publish") - Terminal success
+    5b. request_revision() - @listen("revision") - 1-retry with feedback
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize flow with crew dependencies."""
         super().__init__()
-        # Note: Crews will be initialized on-demand in generate_content()
-        # Stage3Crew requires topic parameter
         self.stage4_crew = Stage4Crew()
 
     @start()
     def discover_topics(self) -> dict[str, Any]:
-        """
-        Entry point: Generate topic candidates via Topic Scout.
+        """Stage 1: Discover topic candidates via Topic Scout.
 
-        STUB: Currently returns mock topics for Flow architecture validation.
-        TODO (Sprint 14): Integrate with Stage1Crew/Stage2Crew (Topic Scout + Editorial Board)
+        Makes 2 LLM calls (trend research + topic generation).
 
         Returns:
-            dict: {
-                "topics": [{"topic": str, "score": float, "hook": str}, ...],
-                "timestamp": str
-            }
+            dict with "topics" list and "timestamp".
         """
-        # STUB: Mock topics for Flow validation
-        mock_topics = {
-            "topics": [
-                {
-                    "topic": "The AI Testing Paradox: Why Automation Creates More Work",
-                    "score": 8.5,
-                    "hook": "Companies adopting AI testing tools report 40% more maintenance work",
-                    "thesis": "Self-healing tests promise to reduce overhead but create new complexity",
-                },
-                {
-                    "topic": "Quality Engineering's Invisible Tax",
-                    "score": 7.2,
-                    "hook": "Flaky tests cost Fortune 500 companies $2.1B annually in lost productivity",
-                    "thesis": "Test reliability is the new technical debt",
-                },
-            ],
-            "timestamp": "2026-01-07T00:00:00Z",
-        }
-
         print("🔭 Flow Stage 1: Topic Discovery")
-        print(f"   Generated {len(mock_topics['topics'])} topic candidates")
 
-        return mock_topics
+        client = create_llm_client()
+        raw_topics = scout_topics(client, focus_area=None)
+
+        # Normalise scout scores (0-25 sum) to 0-10 scale for display
+        topics = []
+        for t in raw_topics:
+            topics.append(
+                {
+                    "topic": t["topic"],
+                    "score": round(t.get("total_score", 0) * 10 / 25, 1),
+                    "hook": t.get("hook", ""),
+                    "thesis": t.get("thesis", ""),
+                    "data_sources": t.get("data_sources", []),
+                    "contrarian_angle": t.get("contrarian_angle", ""),
+                    "talking_points": t.get("talking_points", ""),
+                    "raw": t,
+                }
+            )
+
+        print(f"   Generated {len(topics)} topic candidates")
+
+        return {"topics": topics, "timestamp": datetime.now().isoformat()}
 
     @listen(discover_topics)
     def editorial_review(self, topics: dict[str, Any]) -> dict[str, Any]:
-        """
-        Sequential stage: Editorial board selects winning topic.
+        """Stage 2: Editorial board selects winning topic.
 
-        STUB: Currently selects top-scored topic for Flow validation.
-        TODO (Sprint 14): Integrate with Stage2Crew (Editorial Board persona voting)
+        6 personas vote in parallel with weighted scoring.
 
         Args:
-            topics: Output from discover_topics()
+            topics: Output from discover_topics().
 
         Returns:
-            dict: {
-                "selected_topic": str,
-                "score": float,
-                "hook": str,
-                "thesis": str
-            }
+            dict with selected topic, score, consensus info.
         """
-        # STUB: Select top-scored topic
+        print("📋 Flow Stage 2: Editorial Review")
+
         topic_list = topics.get("topics", [])
         if not topic_list:
             raise ValueError("No topics available for editorial review")
 
-        selected = max(topic_list, key=lambda t: t.get("score", 0))
+        client = create_llm_client()
+        raw_topics = [t.get("raw", t) for t in topic_list]
 
-        print("📋 Flow Stage 2: Editorial Review")
+        board_result = run_editorial_board(client, raw_topics, parallel=True)
+
+        top = board_result.get("top_pick")
+        if not top:
+            # Fallback: pick highest-scored topic
+            selected = max(topic_list, key=lambda t: t.get("score", 0))
+            print(f"   Fallback selection: {selected['topic']}")
+            return selected
+
+        original = top.get("original_topic", {})
+        selected = {
+            "topic": top["topic"],
+            "score": top.get("weighted_score", 0),
+            "hook": original.get("hook", ""),
+            "thesis": original.get("thesis", ""),
+            "consensus": board_result.get("consensus", False),
+            "dissenting_views": board_result.get("dissenting_views", []),
+        }
+
         print(f"   Selected: {selected['topic']}")
-        print(f"   Score: {selected['score']}/10")
+        print(f"   Score: {selected['score']:.1f}/10")
+        print(f"   Consensus: {selected['consensus']}")
 
         return selected
 
     @listen(editorial_review)
     def generate_content(self, selected_topic: dict[str, Any]) -> dict[str, Any]:
-        """
-        Sequential stage: Research → Write → Graphics pipeline via Stage3Crew.
-
-        Executes Stage3Crew.kickoff() with selected topic as input.
-        Stage3Crew orchestrates: ResearchAgent → WriterAgent → GraphicsAgent
+        """Stage 3: Research → Write → Graphics pipeline via Stage3Crew.
 
         Args:
-            selected_topic: Output from editorial_review()
+            selected_topic: Output from editorial_review().
 
         Returns:
-            dict: {
-                "article": str (markdown with YAML frontmatter),
-                "chart_path": str | None,
-                "word_count": int,
-                "metadata": dict
-            }
+            dict with "article" (markdown) and "chart_data" (dict).
         """
+        # Preserve for revision loop
+        self.state["selected_topic"] = selected_topic
+
         topic = selected_topic.get("topic", "")
 
         print("✍️  Flow Stage 3: Content Generation (Stage3Crew)")
         print(f"   Topic: {topic}")
 
-        # Initialize Stage3Crew with topic (required parameter)
         stage3_crew = Stage3Crew(topic=topic)
-
-        # Execute Stage3Crew workflow
-        # Stage3Crew.kickoff() returns: {article, chart_path, word_count, metadata}
         result = stage3_crew.kickoff()
 
-        print(f"   ✅ Article generated: {result.get('word_count', 0)} words")
-        if result.get("chart_path"):
-            print(f"   ✅ Chart created: {result['chart_path']}")
+        article = result.get("article", "")
+        print(f"   ✅ Article generated: {len(article.split())} words")
 
         return result
 
     @router(generate_content)
     def quality_gate(self, article_draft: dict[str, Any]) -> str:
-        """
-        Router stage: Editor evaluation with publish/revision routing.
+        """Stage 4: Editorial review + publication validation.
 
-        Executes Stage4Crew.kickoff() for 5-gate editorial review.
-        Routes based on quality score threshold (≥8 = publish, <8 = revision).
+        Runs Stage4Crew (5-gate editorial review) then PublicationValidator.
+        Routes to "publish" if both pass, "revision" otherwise.
 
         Args:
-            article_draft: Output from generate_content()
+            article_draft: Output from generate_content().
 
         Returns:
-            str: "publish" or "revision" (routing decision)
+            "publish" or "revision" routing decision.
         """
-        print("🔍 Flow Stage 4: Quality Gate (Stage4Crew)")
+        print("🔍 Flow Stage 4: Quality Gate")
 
-        # Execute Stage4Crew workflow (5-gate editorial review)
-        # Stage4Crew.kickoff() returns: {edited_article, gates_passed, quality_score}
+        # Preserve draft for revision loop
+        self.state["article_draft"] = article_draft
+
+        # Stage4Crew expects positional dict with "article" key
         result = self.stage4_crew.kickoff(
-            inputs={
-                "draft": article_draft.get("article", ""),
-                "chart_data": article_draft.get("chart_path"),
+            {
+                "article": article_draft.get("article", ""),
+                "chart_data": article_draft.get("chart_data"),
             }
         )
 
-        quality_score = result.get("quality_score", 0)
+        editorial_score = result.get("editorial_score", 0)
         gates_passed = result.get("gates_passed", 0)
+        edited_article = result.get("article", article_draft.get("article", ""))
 
-        print(f"   Quality Score: {quality_score}/10")
+        print(f"   Editorial Score: {editorial_score}/100")
         print(f"   Gates Passed: {gates_passed}/5")
 
-        # Routing decision: ≥8 publish, <8 revision
-        decision = "publish" if quality_score >= 8 else "revision"
-
-        print(f"   Decision: {decision.upper()}")
-
-        # Store result in flow state for downstream access
         self.state["quality_result"] = result
-        self.state["decision"] = decision
 
-        return decision
+        # Gate 1: Editorial score
+        if editorial_score < PUBLISH_THRESHOLD:
+            self.state["decision"] = "revision"
+            self.state["revision_reason"] = (
+                f"Editorial score {editorial_score}/100 below {PUBLISH_THRESHOLD} threshold"
+            )
+            self.state["revision_feedback"] = result.get("specific_edits", [])
+            print(
+                f"   Decision: REVISION (score {editorial_score} < {PUBLISH_THRESHOLD})"
+            )
+            return "revision"
+
+        # Gate 2: Publication validator
+        validator = PublicationValidator(
+            expected_date=datetime.now().strftime("%Y-%m-%d")
+        )
+        is_valid, issues = validator.validate(edited_article)
+        self.state["validation_issues"] = issues
+
+        if not is_valid:
+            critical = [i for i in issues if i["severity"] == "CRITICAL"]
+            self.state["decision"] = "revision"
+            self.state["revision_reason"] = (
+                f"Publication validation failed: {len(critical)} critical issues"
+            )
+            self.state["revision_feedback"] = [i["message"] for i in critical]
+            print(f"   Decision: REVISION ({len(critical)} critical validation issues)")
+            return "revision"
+
+        self.state["decision"] = "publish"
+        print("   Decision: PUBLISH ✅")
+        return "publish"
 
     @listen("publish")
     def publish_article(self) -> dict[str, Any]:
-        """
-        Terminal stage (publish path): Finalize article for publication.
-
-        TODO (Future): Integrate with Stage5Crew (DevOps publishing automation)
+        """Terminal stage (publish path): Article approved for publication.
 
         Returns:
-            dict: {
-                "status": "published",
-                "article_path": str,
-                "quality_score": float
-            }
+            dict with status, article, editorial_score, gates_passed.
         """
         quality_result = self.state.get("quality_result", {})
 
-        print("✅ Flow Complete: PUBLISH PATH")
-        print(f"   Quality Score: {quality_result.get('quality_score', 0)}/10")
+        print("✅ Flow Complete: PUBLISHED")
+        print(f"   Editorial Score: {quality_result.get('editorial_score', 0)}/100")
 
         return {
             "status": "published",
-            "article": quality_result.get("edited_article", ""),
-            "quality_score": quality_result.get("quality_score", 0),
+            "article": quality_result.get("article", ""),
+            "editorial_score": quality_result.get("editorial_score", 0),
             "gates_passed": quality_result.get("gates_passed", 0),
         }
 
     @listen("revision")
     def request_revision(self) -> dict[str, Any]:
-        """
-        Terminal stage (revision path): Flag article for rework.
+        """Revision path: retry content generation once with feedback.
 
-        TODO (Future): Implement revision loop (Writer re-attempt with Editor feedback)
+        Re-runs Stage3Crew with revision instructions, then re-runs
+        Stage4Crew + PublicationValidator. Returns final result regardless
+        of pass/fail (max 1 retry to avoid runaway LLM costs).
 
         Returns:
-            dict: {
-                "status": "needs_revision",
-                "quality_score": float,
-                "failed_gates": list[str]
-            }
+            dict with status, article (if published), scores, retry_count.
         """
-        quality_result = self.state.get("quality_result", {})
+        retry_count = self.state.get("retry_count", 0)
 
-        print("⚠️  Flow Complete: REVISION REQUIRED")
-        print(f"   Quality Score: {quality_result.get('quality_score', 0)}/10")
+        if retry_count >= MAX_REVISIONS:
+            quality_result = self.state.get("quality_result", {})
+            print(f"⛔ Revision exhausted ({retry_count}/{MAX_REVISIONS} retries used)")
+            return {
+                "status": "needs_revision",
+                "editorial_score": quality_result.get("editorial_score", 0),
+                "gates_passed": quality_result.get("gates_passed", 0),
+                "revision_reason": self.state.get("revision_reason", "Unknown"),
+                "retry_count": retry_count,
+            }
 
+        self.state["retry_count"] = retry_count + 1
+        revision_feedback = self.state.get("revision_feedback", [])
+        revision_reason = self.state.get("revision_reason", "")
+        feedback_text = (
+            "\n".join(revision_feedback) if revision_feedback else revision_reason
+        )
+
+        print(f"🔄 Revision attempt {retry_count + 1}/{MAX_REVISIONS}")
+        print(f"   Feedback: {feedback_text[:200]}")
+
+        # Re-run Stage3Crew with revision instructions appended to topic
+        topic = self.state.get("selected_topic", {}).get("topic", "")
+        enhanced_topic = (
+            f"{topic}\n\n"
+            f"REVISION INSTRUCTIONS — the previous draft failed review. "
+            f"Fix these issues:\n{feedback_text}"
+        )
+
+        stage3_crew = Stage3Crew(topic=enhanced_topic)
+        new_draft = stage3_crew.kickoff()
+
+        # Re-run Stage4Crew
+        result = self.stage4_crew.kickoff(
+            {
+                "article": new_draft.get("article", ""),
+                "chart_data": new_draft.get("chart_data"),
+            }
+        )
+
+        editorial_score = result.get("editorial_score", 0)
+        gates_passed = result.get("gates_passed", 0)
+        edited_article = result.get("article", new_draft.get("article", ""))
+
+        self.state["quality_result"] = result
+
+        # Run publication validator
+        validator = PublicationValidator(
+            expected_date=datetime.now().strftime("%Y-%m-%d")
+        )
+        is_valid, issues = validator.validate(edited_article)
+
+        if editorial_score >= PUBLISH_THRESHOLD and is_valid:
+            print(f"   ✅ Revision succeeded (score: {editorial_score}/100)")
+            return {
+                "status": "published",
+                "article": edited_article,
+                "editorial_score": editorial_score,
+                "gates_passed": gates_passed,
+                "retry_count": self.state["retry_count"],
+            }
+
+        critical = [i for i in issues if i.get("severity") == "CRITICAL"]
+        print(
+            f"   ⚠️  Revision still failing (score: {editorial_score}, issues: {len(critical)})"
+        )
         return {
             "status": "needs_revision",
-            "quality_score": quality_result.get("quality_score", 0),
-            "gates_passed": quality_result.get("gates_passed", 0),
-            "gates_failed": 5 - quality_result.get("gates_passed", 0),
+            "editorial_score": editorial_score,
+            "gates_passed": gates_passed,
+            "validation_issues": [i["message"] for i in critical],
+            "retry_count": self.state["retry_count"],
         }
 
 
-def main():
+def main() -> None:
     """CLI entry point for standalone Flow execution."""
     print("╔════════════════════════════════════════════════════════════════╗")
-    print("║ ECONOMIST CONTENT FLOW - Deterministic Orchestration           ║")
+    print("║ ECONOMIST CONTENT FLOW - End-to-End Pipeline                  ║")
     print("╚════════════════════════════════════════════════════════════════╝\n")
 
     flow = EconomistContentFlow()
@@ -264,7 +347,9 @@ def main():
         print("║ FLOW RESULT                                                     ║")
         print("╚════════════════════════════════════════════════════════════════╝")
         print(f"Status: {result.get('status', 'unknown')}")
-        print(f"Quality Score: {result.get('quality_score', 0)}/10")
+        print(f"Editorial Score: {result.get('editorial_score', 0)}/100")
+        if result.get("retry_count"):
+            print(f"Retries: {result['retry_count']}")
 
     except Exception as e:
         print(f"\n❌ Flow execution failed: {e}")

--- a/tests/test_economist_flow.py
+++ b/tests/test_economist_flow.py
@@ -6,10 +6,12 @@ Tests the Flow-based state-machine orchestration with @start/@listen/@router dec
 
 Test Coverage:
 1. Flow initialization and state management
-2. Stage3Crew integration via generate_content()
-3. Stage4Crew routing logic via quality_gate()
-4. End-to-end publish path
-5. End-to-end revision path
+2. Topic discovery via scout_topics adapter
+3. Editorial review via run_editorial_board adapter
+4. Stage3Crew integration via generate_content()
+5. Stage4Crew + PublicationValidator routing (publish/revision)
+6. Revision loop with feedback (1 retry)
+7. Revision exhaustion
 
 Usage:
     pytest tests/test_economist_flow.py -v
@@ -18,13 +20,12 @@ Usage:
 import os
 import sys
 from pathlib import Path
-
-# Add src/ to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
-
 from unittest.mock import Mock, patch
 
 import pytest
+
+# Add src/ to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from src.economist_agents.flow import EconomistContentFlow
 
@@ -34,71 +35,93 @@ from src.economist_agents.flow import EconomistContentFlow
     reason="OPENAI_API_KEY required for CrewAI agent initialization",
 )
 class TestEconomistFlow:
-    """Integration tests for EconomistContentFlow"""
+    """Integration tests for EconomistContentFlow."""
 
     @pytest.fixture
-    def flow(self):
-        """Create Flow instance for testing"""
+    def flow(self) -> EconomistContentFlow:
+        """Create Flow instance for testing."""
         return EconomistContentFlow()
 
-    def test_flow_initialization(self, flow):
-        """
-        Test 1: Flow initialization and state management
-
-        Given: EconomistContentFlow class
-        When: Instance created
-        Then: Flow initialized with crew dependencies and state
-        """
+    def test_flow_initialization(self, flow: EconomistContentFlow) -> None:
+        """Flow initializes with stage4_crew and state."""
         assert flow is not None
         assert hasattr(flow, "stage4_crew")
         assert hasattr(flow, "state")
-        # Note: stage3_crew initialized on-demand in generate_content()
-        print("✅ Test 1: Flow initialized with stage4_crew and state")
 
-    def test_discover_topics_stage(self, flow):
-        """
-        Test 2: @start stage returns topic candidates
+    @patch("src.economist_agents.flow.scout_topics")
+    @patch("src.economist_agents.flow.create_llm_client")
+    def test_discover_topics_stage(
+        self,
+        mock_create_client: Mock,
+        mock_scout: Mock,
+        flow: EconomistContentFlow,
+    ) -> None:
+        """discover_topics() calls scout_topics and normalises scores."""
+        mock_create_client.return_value = Mock()
+        mock_scout.return_value = [
+            {
+                "topic": "AI Testing Paradox",
+                "total_score": 20,
+                "hook": "Hook A",
+                "thesis": "Thesis A",
+                "data_sources": [],
+                "contrarian_angle": "Angle A",
+                "talking_points": "Points A",
+            },
+            {
+                "topic": "Quality Tax",
+                "total_score": 15,
+                "hook": "Hook B",
+                "thesis": "Thesis B",
+                "data_sources": [],
+                "contrarian_angle": "Angle B",
+                "talking_points": "Points B",
+            },
+        ]
 
-        Given: Flow discover_topics() method
-        When: Called as entry point
-        Then: Returns mock topics with structure {topics: [...], timestamp}
-        """
         result = flow.discover_topics()
 
         assert "topics" in result
         assert "timestamp" in result
-        assert len(result["topics"]) > 0
-        assert all("topic" in t for t in result["topics"])
-        assert all("score" in t for t in result["topics"])
-        print("✅ Test 2: discover_topics() returns structured topic data")
+        assert len(result["topics"]) == 2
+        # 20/25 * 10 = 8.0
+        assert result["topics"][0]["score"] == 8.0
+        # 15/25 * 10 = 6.0
+        assert result["topics"][1]["score"] == 6.0
+        assert result["topics"][0]["topic"] == "AI Testing Paradox"
+        mock_scout.assert_called_once()
 
-    def test_editorial_review_stage(self, flow):
-        """
-        Test 3: @listen stage selects winning topic
-
-        Given: Mock topics from discover_topics()
-        When: editorial_review() called
-        Then: Returns single topic with highest score
-        """
-        topics = {
-            "topics": [
-                {
-                    "topic": "Topic A",
-                    "score": 7.5,
+    @patch("src.economist_agents.flow.run_editorial_board")
+    @patch("src.economist_agents.flow.create_llm_client")
+    def test_editorial_review_stage(
+        self,
+        mock_create_client: Mock,
+        mock_board: Mock,
+        flow: EconomistContentFlow,
+    ) -> None:
+        """editorial_review() calls run_editorial_board and selects top pick."""
+        mock_create_client.return_value = Mock()
+        mock_board.return_value = {
+            "top_pick": {
+                "topic": "AI Testing Paradox",
+                "weighted_score": 8.5,
+                "original_topic": {
                     "hook": "Hook A",
                     "thesis": "Thesis A",
                 },
+            },
+            "consensus": True,
+            "dissenting_views": [],
+        }
+
+        topics = {
+            "topics": [
                 {
-                    "topic": "Topic B",
-                    "score": 8.5,
-                    "hook": "Hook B",
-                    "thesis": "Thesis B",
-                },
-                {
-                    "topic": "Topic C",
-                    "score": 6.2,
-                    "hook": "Hook C",
-                    "thesis": "Thesis C",
+                    "topic": "AI Testing Paradox",
+                    "score": 8.0,
+                    "hook": "Hook A",
+                    "thesis": "Thesis A",
+                    "raw": {"topic": "AI Testing Paradox"},
                 },
             ],
             "timestamp": "2026-01-07T00:00:00Z",
@@ -106,197 +129,234 @@ class TestEconomistFlow:
 
         result = flow.editorial_review(topics)
 
-        assert result["topic"] == "Topic B"  # Highest score
+        assert result["topic"] == "AI Testing Paradox"
         assert result["score"] == 8.5
-        assert "hook" in result
-        assert "thesis" in result
-        print("✅ Test 3: editorial_review() selects top-scored topic")
+        assert result["consensus"] is True
+        mock_board.assert_called_once()
+
+    def test_editorial_review_fallback_no_top_pick(
+        self, flow: EconomistContentFlow
+    ) -> None:
+        """editorial_review() falls back to highest score if board returns no top_pick."""
+        with (
+            patch("src.economist_agents.flow.create_llm_client") as mock_client,
+            patch("src.economist_agents.flow.run_editorial_board") as mock_board,
+        ):
+            mock_client.return_value = Mock()
+            mock_board.return_value = {
+                "top_pick": None,
+                "consensus": False,
+                "dissenting_views": [],
+            }
+
+            topics = {
+                "topics": [
+                    {"topic": "Topic A", "score": 6.0, "hook": "", "thesis": ""},
+                    {"topic": "Topic B", "score": 9.0, "hook": "", "thesis": ""},
+                ],
+            }
+
+            result = flow.editorial_review(topics)
+            assert result["topic"] == "Topic B"
+
+    def test_editorial_review_empty_topics_raises(
+        self, flow: EconomistContentFlow
+    ) -> None:
+        """editorial_review() raises ValueError on empty topic list."""
+        with pytest.raises(ValueError, match="No topics"):
+            flow.editorial_review({"topics": []})
 
     @patch("src.economist_agents.flow.Stage3Crew")
-    def test_stage3_crew_integration(self, mock_stage3_class, flow):
-        """
-        Test 4: Stage3Crew kickoff via generate_content()
-
-        Given: Mocked Stage3Crew
-        When: generate_content() called with selected topic
-        Then: Stage3Crew.kickoff() executed with topic parameter
-        """
-        # Mock Stage3Crew.kickoff() return value
-        mock_crew_instance = Mock()
-        mock_crew_instance.kickoff.return_value = {
-            "article": "# Test Article\n\nContent here...",
-            "chart_path": "/path/to/chart.png",
-            "word_count": 750,
-            "metadata": {"category": "quality-engineering"},
+    def test_generate_content(
+        self, mock_stage3_class: Mock, flow: EconomistContentFlow
+    ) -> None:
+        """generate_content() initializes Stage3Crew and preserves topic in state."""
+        mock_instance = Mock()
+        mock_instance.kickoff.return_value = {
+            "article": "---\ntitle: Test\n---\n\nContent here",
+            "chart_data": {"title": "Chart"},
         }
-        mock_stage3_class.return_value = mock_crew_instance
+        mock_stage3_class.return_value = mock_instance
 
-        selected_topic = {
-            "topic": "The AI Testing Paradox",
-            "score": 8.5,
-            "hook": "Companies report 40% more maintenance",
-            "thesis": "Self-healing tests create new complexity",
-        }
+        selected = {"topic": "AI Testing", "score": 8.5, "hook": "", "thesis": ""}
+        result = flow.generate_content(selected)
 
-        result = flow.generate_content(selected_topic)
-
-        # Verify Stage3Crew was initialized with topic
-        mock_stage3_class.assert_called_once_with(topic="The AI Testing Paradox")
-
-        # Verify Stage3Crew.kickoff() was called
-        mock_crew_instance.kickoff.assert_called_once()
-
-        # Verify result structure
+        mock_stage3_class.assert_called_once_with(topic="AI Testing")
+        mock_instance.kickoff.assert_called_once()
         assert "article" in result
-        assert "word_count" in result
-        print(
-            "✅ Test 4: Stage3Crew initialized and kickoff() called via generate_content()"
+        assert flow.state["selected_topic"] == selected
+
+    @patch("src.economist_agents.flow.PublicationValidator")
+    @patch("src.economist_agents.flow.Stage4Crew")
+    def test_quality_gate_publish(
+        self, mock_stage4_class: Mock, mock_validator_class: Mock
+    ) -> None:
+        """quality_gate() routes to 'publish' when editorial score >= 80 and validation passes."""
+        mock_s4 = Mock()
+        mock_s4.kickoff.return_value = {
+            "article": "Polished article",
+            "editorial_score": 92,
+            "gates_passed": 5,
+        }
+        mock_stage4_class.return_value = mock_s4
+
+        mock_validator = Mock()
+        mock_validator.validate.return_value = (True, [])
+        mock_validator_class.return_value = mock_validator
+
+        flow = EconomistContentFlow()
+        draft = {"article": "Draft", "chart_data": {"title": "Chart"}}
+        decision = flow.quality_gate(draft)
+
+        assert decision == "publish"
+        assert flow.state["decision"] == "publish"
+        # Verify Stage4Crew called with correct signature
+        mock_s4.kickoff.assert_called_once_with(
+            {"article": "Draft", "chart_data": {"title": "Chart"}}
         )
 
     @patch("src.economist_agents.flow.Stage4Crew")
-    def test_stage4_crew_routing_publish(self, mock_stage4_class, flow):
-        """
-        Test 5: Stage4Crew router - publish path
-
-        Given: Mocked Stage4Crew with quality_score ≥ 8
-        When: quality_gate() called
-        Then: Returns "publish" routing decision
-        """
-        # Mock Stage4Crew.kickoff() with high quality score
-        mock_crew_instance = Mock()
-        mock_crew_instance.kickoff.return_value = {
-            "edited_article": "# Edited Article\n\nPolished content...",
-            "gates_passed": 5,
-            "quality_score": 9.2,
-        }
-        mock_stage4_class.return_value = mock_crew_instance
-
-        flow_with_mock = EconomistContentFlow()
-
-        article_draft = {
-            "article": "# Draft Article\n\nDraft content...",
-            "chart_path": None,
-            "word_count": 750,
-        }
-
-        decision = flow_with_mock.quality_gate(article_draft)
-
-        assert decision == "publish"
-        assert flow_with_mock.state["decision"] == "publish"
-        assert flow_with_mock.state["quality_result"]["quality_score"] == 9.2
-        print("✅ Test 5: quality_gate() routes to publish (score ≥8)")
-
-    @patch("src.economist_agents.flow.Stage4Crew")
-    def test_stage4_crew_routing_revision(self, mock_stage4_class, flow):
-        """
-        Test 6: Stage4Crew router - revision path
-
-        Given: Mocked Stage4Crew with quality_score < 8
-        When: quality_gate() called
-        Then: Returns "revision" routing decision
-        """
-        # Mock Stage4Crew.kickoff() with low quality score
-        mock_crew_instance = Mock()
-        mock_crew_instance.kickoff.return_value = {
-            "edited_article": "# Draft Article\n\nNeeds work...",
+    def test_quality_gate_revision_low_score(self, mock_stage4_class: Mock) -> None:
+        """quality_gate() routes to 'revision' when editorial score < 80."""
+        mock_s4 = Mock()
+        mock_s4.kickoff.return_value = {
+            "article": "Weak article",
+            "editorial_score": 65,
             "gates_passed": 3,
-            "quality_score": 6.5,
+            "specific_edits": ["Fix opening", "Add sources"],
         }
-        mock_stage4_class.return_value = mock_crew_instance
+        mock_stage4_class.return_value = mock_s4
 
-        flow_with_mock = EconomistContentFlow()
-
-        article_draft = {
-            "article": "# Draft Article\n\nDraft content...",
-            "chart_path": None,
-            "word_count": 750,
-        }
-
-        decision = flow_with_mock.quality_gate(article_draft)
+        flow = EconomistContentFlow()
+        draft = {"article": "Draft", "chart_data": {}}
+        decision = flow.quality_gate(draft)
 
         assert decision == "revision"
-        assert flow_with_mock.state["decision"] == "revision"
-        assert flow_with_mock.state["quality_result"]["quality_score"] == 6.5
-        print("✅ Test 6: quality_gate() routes to revision (score <8)")
+        assert flow.state["revision_reason"].startswith("Editorial score 65")
+        assert flow.state["revision_feedback"] == ["Fix opening", "Add sources"]
 
-    def test_publish_terminal_stage(self, flow):
-        """
-        Test 7: Publish path terminal stage
-
-        Given: Flow state with publish decision
-        When: publish_article() called
-        Then: Returns published status with quality metadata
-        """
-        # Set flow state as if quality_gate() routed to publish
-        flow.state["quality_result"] = {
-            "edited_article": "# Published Article",
+    @patch("src.economist_agents.flow.PublicationValidator")
+    @patch("src.economist_agents.flow.Stage4Crew")
+    def test_quality_gate_revision_validation_fails(
+        self, mock_stage4_class: Mock, mock_validator_class: Mock
+    ) -> None:
+        """quality_gate() routes to 'revision' when validation fails despite good score."""
+        mock_s4 = Mock()
+        mock_s4.kickoff.return_value = {
+            "article": "Good score but bad format",
+            "editorial_score": 90,
             "gates_passed": 5,
-            "quality_score": 9.0,
         }
-        flow.state["decision"] = "publish"
+        mock_stage4_class.return_value = mock_s4
+
+        mock_validator = Mock()
+        mock_validator.validate.return_value = (
+            False,
+            [{"severity": "CRITICAL", "message": "Missing YAML frontmatter"}],
+        )
+        mock_validator_class.return_value = mock_validator
+
+        flow = EconomistContentFlow()
+        draft = {"article": "Draft", "chart_data": {}}
+        decision = flow.quality_gate(draft)
+
+        assert decision == "revision"
+        assert "validation failed" in flow.state["revision_reason"]
+        assert "Missing YAML frontmatter" in flow.state["revision_feedback"]
+
+    def test_publish_article(self, flow: EconomistContentFlow) -> None:
+        """publish_article() returns publication metadata from state."""
+        flow.state["quality_result"] = {
+            "article": "# Published Article",
+            "editorial_score": 92,
+            "gates_passed": 5,
+        }
 
         result = flow.publish_article()
 
         assert result["status"] == "published"
-        assert result["quality_score"] == 9.0
+        assert result["editorial_score"] == 92
         assert result["gates_passed"] == 5
-        assert "article" in result
-        print("✅ Test 7: publish_article() returns publication metadata")
+        assert result["article"] == "# Published Article"
 
-    def test_revision_terminal_stage(self, flow):
-        """
-        Test 8: Revision path terminal stage
+    @patch("src.economist_agents.flow.PublicationValidator")
+    @patch("src.economist_agents.flow.Stage3Crew")
+    def test_revision_loop_succeeds(
+        self,
+        mock_stage3_class: Mock,
+        mock_validator_class: Mock,
+        flow: EconomistContentFlow,
+    ) -> None:
+        """request_revision() retries and succeeds on second attempt."""
+        # Setup state as if quality_gate routed to revision
+        flow.state["selected_topic"] = {"topic": "AI Testing"}
+        flow.state["revision_reason"] = "Editorial score 65/100"
+        flow.state["revision_feedback"] = ["Fix opening"]
+        flow.state["quality_result"] = {"editorial_score": 65, "gates_passed": 3}
+        flow.state["retry_count"] = 0
 
-        Given: Flow state with revision decision
-        When: request_revision() called
-        Then: Returns needs_revision status with failed gates count
-        """
-        # Set flow state as if quality_gate() routed to revision
-        flow.state["quality_result"] = {
-            "edited_article": "# Draft Needs Revision",
-            "gates_passed": 2,
-            "quality_score": 5.5,
+        # Mock Stage3Crew for revision
+        mock_s3 = Mock()
+        mock_s3.kickoff.return_value = {
+            "article": "Improved article",
+            "chart_data": {},
         }
-        flow.state["decision"] = "revision"
+        mock_stage3_class.return_value = mock_s3
+
+        # Mock Stage4Crew (already on flow instance)
+        flow.stage4_crew = Mock()
+        flow.stage4_crew.kickoff.return_value = {
+            "article": "Polished improved article",
+            "editorial_score": 88,
+            "gates_passed": 5,
+        }
+
+        # Mock PublicationValidator
+        mock_validator = Mock()
+        mock_validator.validate.return_value = (True, [])
+        mock_validator_class.return_value = mock_validator
+
+        result = flow.request_revision()
+
+        assert result["status"] == "published"
+        assert result["editorial_score"] == 88
+        assert result["retry_count"] == 1
+        # Verify Stage3Crew was called with revision instructions
+        topic_arg = mock_stage3_class.call_args[1]["topic"]
+        assert "REVISION INSTRUCTIONS" in topic_arg
+        assert "Fix opening" in topic_arg
+
+    def test_revision_exhausted(self, flow: EconomistContentFlow) -> None:
+        """request_revision() gives up after max retries."""
+        flow.state["retry_count"] = 1  # Already used 1 retry
+        flow.state["quality_result"] = {"editorial_score": 50, "gates_passed": 2}
+        flow.state["revision_reason"] = "Still failing"
 
         result = flow.request_revision()
 
         assert result["status"] == "needs_revision"
-        assert result["quality_score"] == 5.5
-        assert result["gates_passed"] == 2
-        assert result["gates_failed"] == 3
-        print("✅ Test 8: request_revision() returns revision metadata")
+        assert result["retry_count"] == 1
+        assert result["revision_reason"] == "Still failing"
 
 
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"),
     reason="OPENAI_API_KEY required for CrewAI agent initialization",
 )
-def test_flow_decorators_registered():
-    """
-    Test 9: Verify Flow decorators are properly registered
-
-    Given: EconomistContentFlow class
-    When: Inspected for decorated methods
-    Then: @start, @listen, @router decorators present
-    """
+def test_flow_decorators_registered() -> None:
+    """All Flow decorated methods are registered and callable."""
     flow = EconomistContentFlow()
 
-    # Check method existence
-    assert hasattr(flow, "discover_topics")
-    assert hasattr(flow, "editorial_review")
-    assert hasattr(flow, "generate_content")
-    assert hasattr(flow, "quality_gate")
-    assert hasattr(flow, "publish_article")
-    assert hasattr(flow, "request_revision")
-
-    # Verify methods are callable
-    assert callable(flow.discover_topics)
-    assert callable(flow.editorial_review)
-    assert callable(flow.generate_content)
-    assert callable(flow.quality_gate)
-
-    print("✅ Test 9: All Flow decorated methods registered")
+    for method_name in [
+        "discover_topics",
+        "editorial_review",
+        "generate_content",
+        "quality_gate",
+        "publish_article",
+        "request_revision",
+    ]:
+        assert hasattr(flow, method_name)
+        assert callable(getattr(flow, method_name))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Stages 1-2 live**: Replaced stubbed `discover_topics()` and `editorial_review()` with real LLM-based topic scouting (2 API calls) and 6-persona weighted editorial board voting (6 parallel API calls)
- **Fixed 3 bugs in quality_gate()**: Wrong Stage4Crew call signature (`inputs=` vs positional), wrong dict key (`"draft"` vs `"article"`), wrong score key and threshold (`quality_score` 0-10 vs `editorial_score` 0-100)
- **Added PublicationValidator** as second quality gate after Stage4Crew editorial review
- **Implemented revision loop**: 1-retry with specific feedback injection — when an article fails, the Writer Agent gets the exact validation failures to fix
- **Created adapters.py**: Clean import bridge from `src/` to `scripts/` modules, centralising sys.path manipulation

## What this enables
Running `python -m src.economist_agents.flow` now executes the full pipeline:
1. Topic Scout discovers 5 candidate topics via LLM
2. Editorial Board (6 personas) votes with weighted scoring
3. Stage3Crew generates article (Research → Write → Graphics → Edit)
4. Stage4Crew runs 5-gate editorial review
5. PublicationValidator enforces YAML, word count, references
6. If quality fails, revision loop retries with targeted feedback

## Test plan
- [x] 13 new/updated flow tests — all pass
- [x] Full suite: 579 passed, 2 skipped (production integration tests need real API key)
- [x] ruff format + check: clean
- [x] Pre-push hooks: all pass

## Files changed
- `src/economist_agents/adapters.py` — new (import bridge)
- `src/economist_agents/flow.py` — rewritten (6 methods)
- `tests/test_economist_flow.py` — rewritten (13 tests)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)