### PR TITLE
fix: Retry topic scout on empty result

### DIFF
--- a/src/economist_agents/flow.py
+++ b/src/economist_agents/flow.py
@@ -63,7 +63,22 @@ class EconomistContentFlow(Flow):
         print("🔭 Flow Stage 1: Topic Discovery")
 
         client = create_llm_client()
-        raw_topics = scout_topics(client, focus_area=None)
+
+        # Retry once if scout returns empty (LLM JSON parsing can fail)
+        raw_topics: list[dict[str, Any]] = []
+        for attempt in range(2):
+            raw_topics = scout_topics(client, focus_area=None)
+            if raw_topics:
+                break
+            print(
+                f"   ⚠️  Topic scout returned empty (attempt {attempt + 1}/2), retrying..."
+            )
+
+        if not raw_topics:
+            raise ValueError(
+                "Topic scout returned no topics after 2 attempts. "
+                "Check LLM connectivity and scout_topics() JSON parsing."
+            )
 
         # Normalise scout scores (0-25 sum) to 0-10 scale for display
         topics = []


### PR DESCRIPTION
## Summary
- Added 1 automatic retry when `scout_topics()` returns an empty list
- Root cause: LLM JSON parsing failures in topic scout cause empty returns ~20% of the time
- Improves pipeline reliability from 80% (4/5 runs) toward near-100%

## Test plan
- [x] 13 flow tests pass
- [x] Full pre-push suite passes
- [x] Verified via 5-run consistency test: 1 run failed with empty topics before this fix

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)