### PR TITLE
fix: Require 5/5 editorial gates to publish

### DIFF
--- a/src/economist_agents/flow.py
+++ b/src/economist_agents/flow.py
@@ -30,7 +30,7 @@ from src.economist_agents.adapters import (
 
 # Editorial score threshold (0-100 scale) for publication
 PUBLISH_THRESHOLD = 80
-MAX_REVISIONS = 1
+MAX_REVISIONS = 2
 
 
 class EconomistContentFlow(Flow):
@@ -207,7 +207,17 @@ class EconomistContentFlow(Flow):
 
         self.state["quality_result"] = result
 
-        # Gate 1: Editorial score
+        # Gate 1: All 5 editorial gates must pass
+        if gates_passed < 5:
+            self.state["decision"] = "revision"
+            self.state["revision_reason"] = (
+                f"Only {gates_passed}/5 editorial gates passed"
+            )
+            self.state["revision_feedback"] = result.get("specific_edits", [])
+            print(f"   Decision: REVISION ({gates_passed}/5 gates, need 5/5)")
+            return "revision"
+
+        # Gate 2: Editorial score
         if editorial_score < PUBLISH_THRESHOLD:
             self.state["decision"] = "revision"
             self.state["revision_reason"] = (
@@ -219,7 +229,7 @@ class EconomistContentFlow(Flow):
             )
             return "revision"
 
-        # Gate 2: Publication validator
+        # Gate 3: Publication validator
         validator = PublicationValidator(
             expected_date=datetime.now().strftime("%Y-%m-%d")
         )

--- a/tests/test_economist_flow.py
+++ b/tests/test_economist_flow.py
@@ -216,8 +216,8 @@ class TestEconomistFlow:
         )
 
     @patch("src.economist_agents.flow.Stage4Crew")
-    def test_quality_gate_revision_low_score(self, mock_stage4_class: Mock) -> None:
-        """quality_gate() routes to 'revision' when editorial score < 80."""
+    def test_quality_gate_revision_failed_gates(self, mock_stage4_class: Mock) -> None:
+        """quality_gate() routes to 'revision' when any editorial gate fails."""
         mock_s4 = Mock()
         mock_s4.kickoff.return_value = {
             "article": "Weak article",
@@ -232,7 +232,7 @@ class TestEconomistFlow:
         decision = flow.quality_gate(draft)
 
         assert decision == "revision"
-        assert flow.state["revision_reason"].startswith("Editorial score 65")
+        assert "3/5" in flow.state["revision_reason"]
         assert flow.state["revision_feedback"] == ["Fix opening", "Add sources"]
 
     @patch("src.economist_agents.flow.PublicationValidator")
@@ -328,14 +328,14 @@ class TestEconomistFlow:
 
     def test_revision_exhausted(self, flow: EconomistContentFlow) -> None:
         """request_revision() gives up after max retries."""
-        flow.state["retry_count"] = 1  # Already used 1 retry
+        flow.state["retry_count"] = 2  # Already used 2 retries (MAX_REVISIONS)
         flow.state["quality_result"] = {"editorial_score": 50, "gates_passed": 2}
         flow.state["revision_reason"] = "Still failing"
 
         result = flow.request_revision()
 
         assert result["status"] == "needs_revision"
-        assert result["retry_count"] == 1
+        assert result["retry_count"] == 2
         assert result["revision_reason"] == "Still failing"
 
 


### PR DESCRIPTION
## Summary
- Articles now require **all 5 editorial gates to pass** before publishing, not just a score threshold
- Previously, an article with a banned opening phrase ("In today's world") published at 80/100 with 4/5 gates — a known defect shipped to readers
- Increased max revision retries from 1 to 2 to handle cascading fixes (gate failures → then validation issues)

## Root cause
Quality gate routing was score-based only (`editorial_score >= 80`). An article could fail a gate (banned phrase, unsourced stats) but still publish if the overall score was high enough. A real editorial team wouldn't publish an article with a known banned phrase.

## Verified behavior
- First attempt: 4/5 gates (unsourced stats) → routed to revision
- Revision: fixed sources, 5/5 gates, 98/100 → publication validator caught remaining placeholder
- Second revision: clean article published

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)