### PR TITLE
fix: Add layout, categories, and image to article frontmatter

### DIFF
--- a/src/crews/stage3_crew.py
+++ b/src/crews/stage3_crew.py
@@ -111,11 +111,17 @@ DO NOT describe the article or summarize what it contains.
 DO NOT say "Above is..." or "Here is..." or reference the article.
 OUTPUT the actual article text directly, starting with:
 ---
+layout: post
 title: "Your Title"
 date: YYYY-MM-DD
 author: "The Economist"
+categories: ["Quality Engineering"]
+image: /assets/images/SLUG.png
 summary: "One-sentence summary of the article"
 ---
+
+IMPORTANT for categories: Choose 1-3 from: Quality Engineering, Test Automation, AI Testing, Software Engineering, DevOps, Performance.
+IMPORTANT for image: Replace SLUG with a lowercase-hyphenated version of the title (e.g., "ai-testing-costs").
 
 Then the full article body (minimum 800 words).
 


### PR DESCRIPTION
## Summary
Added `layout: post`, `categories`, and `image` fields to the Stage3Crew writer task prompt. Published articles were missing the theme image and blog tags because the frontmatter template only included title/date/author/summary.

## Visual bugs fixed
1. No theme image — now generates `image: /assets/images/{slug}.png`
2. No tags/classification — now generates `categories: ["Quality Engineering"]` (1-3 tags)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)