### PR TITLE
fix: Add featured image generation and enforce blog frontmatter

### DIFF
--- a/.github/workflows/content-pipeline.yml
+++ b/.github/workflows/content-pipeline.yml
@@ -102,6 +102,7 @@ jobs:
           path: |
             output/*.md
             output/charts/*.png
+            output/images/*.png
 
       # Publish directly to blog repo main branch (no PR needed —
       # article already passed 5 editorial gates + publication validator)

--- a/src/crews/stage4_crew.py
+++ b/src/crews/stage4_crew.py
@@ -145,7 +145,18 @@ def _apply_editorial_fixes(article: str, current_date: str | None = None) -> str
     text = re.sub(r"\s*\[UNVERIFIED\]", "", text)
     text = re.sub(r"\s*\[REPLACE[-_]?ME\]", "", text, flags=re.IGNORECASE)
 
-    # 8. Clean up double spaces from phrase/placeholder removal
+    # 8. Enforce required frontmatter fields (layout, categories)
+    if text.startswith("---"):
+        parts = text.split("---", 2)
+        if len(parts) >= 3:
+            fm = parts[1]
+            if "layout:" not in fm:
+                fm = "\nlayout: post" + fm
+            if "categories:" not in fm:
+                fm = fm.rstrip() + '\ncategories: ["Quality Engineering"]\n'
+            text = "---" + fm + "---" + parts[2]
+
+    # 9. Clean up double spaces from phrase/placeholder removal
     text = re.sub(r"  +", " ", text)
 
     return text

--- a/src/economist_agents/adapters.py
+++ b/src/economist_agents/adapters.py
@@ -13,12 +13,14 @@ if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
 
 from editorial_board import run_editorial_board  # noqa: E402
+from featured_image_agent import generate_featured_image  # noqa: E402
 from llm_client import create_llm_client  # noqa: E402
 from publication_validator import PublicationValidator  # noqa: E402
 from topic_scout import scout_topics  # noqa: E402
 
 __all__ = [
     "create_llm_client",
+    "generate_featured_image",
     "run_editorial_board",
     "scout_topics",
     "PublicationValidator",

--- a/src/economist_agents/flow.py
+++ b/src/economist_agents/flow.py
@@ -15,6 +15,7 @@ Usage:
 """
 
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 from crewai.flow.flow import Flow, listen, router, start
@@ -24,6 +25,7 @@ from src.crews.stage4_crew import Stage4Crew
 from src.economist_agents.adapters import (
     PublicationValidator,
     create_llm_client,
+    generate_featured_image,
     run_editorial_board,
     scout_topics,
 )
@@ -170,6 +172,34 @@ class EconomistContentFlow(Flow):
         article = result.get("article", "")
         print(f"   ✅ Article generated: {len(article.split())} words")
 
+        # Generate featured image via DALL-E
+        slug = topic.lower()
+        for ch in " :?!,.'\"()":
+            slug = slug.replace(ch, "-")
+        slug = slug.strip("-")[:60]
+
+        output_dir = Path("output/images")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        image_path = str(output_dir / f"{slug}.png")
+
+        print("🎨 Generating featured image...")
+        try:
+            generated = generate_featured_image(
+                topic=topic,
+                article_summary=article[:200],
+                output_path=image_path,
+            )
+            if generated:
+                result["featured_image"] = f"/assets/images/{slug}.png"
+                result["featured_image_local"] = image_path
+                print(f"   ✅ Featured image: {image_path}")
+            else:
+                result["featured_image"] = "/assets/images/blog-default.svg"
+                print("   ℹ️  Using default image")
+        except Exception as e:
+            result["featured_image"] = "/assets/images/blog-default.svg"
+            print(f"   ℹ️  Image generation failed ({e}), using default")
+
         return result
 
     @router(generate_content)
@@ -190,10 +220,29 @@ class EconomistContentFlow(Flow):
         # Preserve draft for revision loop
         self.state["article_draft"] = article_draft
 
+        # Inject featured image into frontmatter before review
+        article_text = article_draft.get("article", "")
+        featured_image = article_draft.get(
+            "featured_image", "/assets/images/blog-default.svg"
+        )
+        if (
+            article_text.startswith("---")
+            and "image:" not in article_text.split("---", 2)[1]
+        ):
+            parts = article_text.split("---", 2)
+            if len(parts) >= 3:
+                article_text = (
+                    "---"
+                    + parts[1].rstrip()
+                    + f"\nimage: {featured_image}\n"
+                    + "---"
+                    + parts[2]
+                )
+
         # Stage4Crew expects positional dict with "article" key
         result = self.stage4_crew.kickoff(
             {
-                "article": article_draft.get("article", ""),
+                "article": article_text,
                 "chart_data": article_draft.get("chart_data"),
             }
         )


### PR DESCRIPTION
## Summary
- **Featured image generation**: Wired `generate_featured_image()` (DALL-E 3) into the Flow pipeline — generates Economist-style editorial illustrations for each article
- **Frontmatter enforcement**: Deterministic polish now guarantees `layout: post` and `categories` fields are present, even if the LLM omits them
- **Image injection**: Featured image path injected into YAML frontmatter before Stage4 review
- **Fallback**: Uses `blog-default.svg` if DALL-E generation fails
- **Workflow**: Updated to deploy `output/images/*.png` to blog repo

## Bugs fixed
1. Broken blog post "Is AI Really Slashing..." — patched directly on blog repo (missing layout, categories, image)
2. New post "The Real Cost of Test Automation" — image path pointed to non-existent file, patched to default
3. Future posts now have all required fields enforced deterministically

## Test plan
- [x] 28 tests pass (flow + editorial fixes)
- [x] Pre-push hooks pass
- [x] Both broken blog posts patched on oviney/blog

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)