### PR TITLE
fix: fetch remediation-queue from Actions artifact instead of raw URL

### DIFF
--- a/.github/workflows/remediation-sync.yml
+++ b/.github/workflows/remediation-sync.yml
@@ -28,13 +28,39 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch content remediation queue
+        env:
+          GH_TOKEN: ${{ secrets.BLOG_REPO_TOKEN }}
         run: |
-          curl -sf "https://raw.githubusercontent.com/oviney/blog/main/content-remediation-queue.json" \
-            -o queue.json
+          # Try to fetch the latest remediation-queue artifact from content-remediation.yml
+          RUN_ID=$(gh api repos/oviney/blog/actions/workflows/content-remediation.yml/runs \
+            --jq '.workflow_runs[] | select(.conclusion=="success") | .id' | head -1)
+
+          if [ -z "$RUN_ID" ]; then
+            echo "No successful content-remediation run found — falling back to committed file"
+            curl -sf "https://raw.githubusercontent.com/oviney/blog/main/content-remediation-queue.json" \
+              -o queue.json
+          else
+            ARTIFACT_ID=$(gh api repos/oviney/blog/actions/runs/$RUN_ID/artifacts \
+              --jq '.artifacts[] | select(.name=="remediation-queue") | .id' | head -1)
+
+            if [ -n "$ARTIFACT_ID" ]; then
+              echo "Downloading remediation-queue artifact (id=$ARTIFACT_ID) from run $RUN_ID"
+              gh api repos/oviney/blog/actions/artifacts/$ARTIFACT_ID/zip > queue.zip
+              unzip -o queue.zip -d queue-dir
+              cp queue-dir/content-remediation-queue.json queue.json
+              rm -rf queue.zip queue-dir
+            else
+              echo "Artifact not found in run $RUN_ID — falling back to committed file"
+              curl -sf "https://raw.githubusercontent.com/oviney/blog/main/content-remediation-queue.json" \
+                -o queue.json
+            fi
+          fi
+
           echo "Queue fetched:"
-          cat queue.json | python3 -c "
+          python3 -c "
           import json, sys
-          data = json.load(sys.stdin)
+          with open('queue.json') as f:
+              data = json.load(f)
           queue = data.get('queue', [])
           print(f'  Total items in queue: {len(queue)}')
           "


### PR DESCRIPTION
## Problem

`remediation-sync.yml` was fetching `content-remediation-queue.json` directly from `raw.githubusercontent.com/oviney/blog/main/...`. Since `content-remediation.yml` can no longer push that file to `main` (blocked by branch protection — fixed in oviney/blog#603), the raw URL would return a stale committed file.

## Changes

### `.github/workflows/remediation-sync.yml`
- Replaced the static `curl` fetch with a `gh api` lookup that:
  1. Finds the latest successful run of `content-remediation.yml` in `oviney/blog`
  2. Downloads the `remediation-queue` artifact from that run
  3. Falls back to the committed raw file if no artifact exists (cold-start safety)
- Step uses `GH_TOKEN: ${{ secrets.BLOG_REPO_TOKEN }}` (secret already configured)

## Validation
- [x] YAML syntax valid
- [x] Fallback path preserved for cold-start scenarios

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>