### PR TITLE
fix: handle dict items in actionPlan when building action_summary

### DIFF
--- a/.github/workflows/remediation-sync.yml
+++ b/.github/workflows/remediation-sync.yml
@@ -121,7 +121,14 @@ jobs:
               title = post.get("title", post_file)
               score = post.get("currentScore", 0)
               actions = post.get("actionPlan", post.get("actions", []))
-              action_summary = ", ".join(actions[:3]) if isinstance(actions, list) else str(actions)
+              if isinstance(actions, list):
+                  str_actions = [
+                      a.get("action", str(a)) if isinstance(a, dict) else str(a)
+                      for a in actions[:3]
+                  ]
+                  action_summary = ", ".join(str_actions)
+              else:
+                  action_summary = str(actions)
 
               if post_file in triggered_this_week:
                   skipped.append(post_file)


### PR DESCRIPTION
## Problem

`remediation-sync.yml` failed with `TypeError: sequence item 0: expected str instance, dict found` because `actionPlan` entries are objects (`{"action": "...", ...}`) not bare strings.

Discovered during smoke test of #191 (run 24034767996).

## Fix

Replace the bare `", ".join(actions[:3])` with a comprehension that safely extracts `.get("action", str(a))` from each item regardless of type.

## Validation
- [x] YAML syntax valid
- [x] Smoke-test re-run will follow merge

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>