### PR TITLE
feat: topic deduplication in discover_topics() before editorial vote

### DIFF
--- a/src/economist_agents/flow.py
+++ b/src/economist_agents/flow.py
@@ -29,6 +29,7 @@ from src.economist_agents.adapters import (
     run_editorial_board,
     scout_topics,
 )
+from src.tools.topic_deduplicator import TopicDeduplicator
 
 # Editorial score threshold (0-100 scale) for publication
 PUBLISH_THRESHOLD = 80
@@ -52,6 +53,7 @@ class EconomistContentFlow(Flow):
         """Initialize flow with crew dependencies."""
         super().__init__()
         self.stage4_crew = Stage4Crew()
+        self._deduplicator = TopicDeduplicator()
 
     @start()
     def discover_topics(self) -> dict[str, Any]:
@@ -99,6 +101,31 @@ class EconomistContentFlow(Flow):
             )
 
         print(f"   Generated {len(topics)} topic candidates")
+
+        # ── Deduplication step ──────────────────────────────────────────
+        # Query published_articles ChromaDB collection and remove near-
+        # duplicates before the editorial board wastes a vote on them.
+        # Thresholds (issue #157):
+        #   >0.8  → REJECT (too similar to existing article)
+        #   0.6-0.8 → WARN  (related coverage exists; flagged for editors)
+        #   <0.6  → PASS   (novel topic)
+        topics, rejected = self._deduplicator.filter_topics(topics)
+
+        if rejected:
+            print(
+                f"   🚫 Dedup filtered {len(rejected)} topic(s): "
+                + ", ".join(f"'{t.get('topic', '?')}'" for t in rejected)
+            )
+
+        warned = [t for t in topics if t.get("dedup_warning")]
+        if warned:
+            print(
+                f"   ⚠️  Dedup flagged {len(warned)} topic(s) as related coverage: "
+                + ", ".join(f"'{t.get('topic', '?')}'" for t in warned)
+            )
+
+        print(f"   {len(topics)} topic(s) forwarded to editorial board")
+        # ───────────────────────────────────────────────────────────────
 
         return {"topics": topics, "timestamp": datetime.now().isoformat()}
 
@@ -320,13 +347,23 @@ class EconomistContentFlow(Flow):
             dict with status, article, editorial_score, gates_passed.
         """
         quality_result = self.state.get("quality_result", {})
+        article_text = quality_result.get("article", "")
 
         print("✅ Flow Complete: PUBLISHED")
         print(f"   Editorial Score: {quality_result.get('editorial_score', 0)}/100")
 
+        # ── Post-publication indexing ───────────────────────────────────
+        # Index the article in the published_articles archive so future
+        # deduplication runs can detect coverage of this topic.
+        selected_topic = self.state.get("selected_topic", {})
+        title = selected_topic.get("topic", "")
+        if title and article_text:
+            self._deduplicator.index_article(title=title, content=article_text)
+        # ───────────────────────────────────────────────────────────────
+
         return {
             "status": "published",
-            "article": quality_result.get("article", ""),
+            "article": article_text,
             "editorial_score": quality_result.get("editorial_score", 0),
             "gates_passed": quality_result.get("gates_passed", 0),
         }

--- a/src/tools/topic_deduplicator.py
+++ b/src/tools/topic_deduplicator.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""
+Topic Deduplicator - ChromaDB-backed similarity check for topic candidates.
+
+Prevents publishing articles on topics already covered by querying
+the ``published_articles`` ChromaDB collection and comparing
+cosine-similarity scores against configurable thresholds.
+
+Similarity tiers (matching issue #157 spec):
+- > 0.8  → REJECT   — topic is a near-duplicate of existing content
+- 0.6-0.8 → WARN    — related coverage exists; flag for editorial review
+- < 0.6  → PASS     — novel topic; proceed normally
+
+After successful publication, callers should invoke ``index_article()``
+to keep the archive current.
+
+Usage::
+
+    from src.tools.topic_deduplicator import TopicDeduplicator
+
+    deduplicator = TopicDeduplicator()
+    filtered, flagged = deduplicator.filter_topics(topic_list)
+    # later…
+    deduplicator.index_article("My Published Article Title", article_text)
+"""
+
+import logging
+import warnings
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Similarity thresholds (spec from issue #157)
+REJECT_THRESHOLD = 0.8   # cosine similarity above this → reject
+WARN_THRESHOLD = 0.6     # cosine similarity above this (but ≤ REJECT) → warn
+
+# Minimum topics to retain after filtering (fallback: lower threshold if all dropped)
+MIN_TOPICS_AFTER_FILTER = 1
+
+try:
+    import chromadb
+    from chromadb.config import Settings
+
+    CHROMADB_AVAILABLE = True
+except ImportError:
+    CHROMADB_AVAILABLE = False
+    warnings.warn(
+        "ChromaDB not installed. TopicDeduplicator running in pass-through mode.",
+        stacklevel=2,
+    )
+
+
+class TopicDeduplicator:
+    """
+    ChromaDB-backed topic deduplication for the Economist content pipeline.
+
+    Queries the ``published_articles`` collection to detect near-duplicate
+    topics before they enter the editorial board vote.
+
+    Graceful degradation:
+    - If ChromaDB is unavailable: all topics pass through unmodified.
+    - If the collection is empty: all topics pass through unmodified.
+    - If a query fails: logs a warning and passes the topic through.
+
+    Args:
+        collection_name: ChromaDB collection to query/write.
+        persist_directory: ChromaDB persistence directory.
+        reject_threshold: Cosine similarity above which a topic is rejected.
+        warn_threshold: Cosine similarity above which a topic is flagged.
+
+    Example::
+
+        dedup = TopicDeduplicator()
+        topics = [{"topic": "AI Testing Trends"}, {"topic": "Unit Testing Basics"}]
+        kept, flagged = dedup.filter_topics(topics)
+    """
+
+    def __init__(
+        self,
+        collection_name: str = "published_articles",
+        persist_directory: str = ".chromadb",
+        reject_threshold: float = REJECT_THRESHOLD,
+        warn_threshold: float = WARN_THRESHOLD,
+    ) -> None:
+        """
+        Initialise the deduplicator with ChromaDB connection.
+
+        Args:
+            collection_name: Name of the ChromaDB collection.
+            persist_directory: Path to ChromaDB persistence storage.
+            reject_threshold: Similarity cutoff for rejection (default 0.8).
+            warn_threshold: Similarity cutoff for warning (default 0.6).
+        """
+        self.collection_name = collection_name
+        self.persist_directory = persist_directory
+        self.reject_threshold = reject_threshold
+        self.warn_threshold = warn_threshold
+        self.client: Any = None
+        self.collection: Any = None
+
+        if not CHROMADB_AVAILABLE:
+            logger.warning("ChromaDB unavailable — TopicDeduplicator in pass-through mode")
+            return
+
+        try:
+            self.client = chromadb.PersistentClient(
+                path=persist_directory,
+                settings=Settings(
+                    anonymized_telemetry=False,
+                    allow_reset=True,
+                ),
+            )
+            self.collection = self.client.get_or_create_collection(
+                name=collection_name,
+                metadata={"description": "Published article titles and summaries for deduplication"},
+            )
+            logger.info(
+                "TopicDeduplicator ready — %d articles in archive",
+                self.collection.count(),
+            )
+        except Exception as exc:  # pragma: no cover
+            logger.warning("TopicDeduplicator init failed: %s — pass-through mode", exc)
+            self.client = None
+            self.collection = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def filter_topics(
+        self, topics: list[dict[str, Any]]
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """
+        Filter candidate topics against the published-articles archive.
+
+        Each topic dict must contain at least a ``"topic"`` key with the
+        topic title/description string.
+
+        Topics above ``reject_threshold`` are removed entirely.
+        Topics between ``warn_threshold`` and ``reject_threshold`` are
+        returned with a ``"dedup_warning"`` key added.
+        Topics below ``warn_threshold`` pass through unchanged.
+
+        When the collection is empty or ChromaDB is unavailable, all
+        topics pass through unmodified (safe degradation).
+
+        If *all* topics are filtered (extreme edge-case), the threshold
+        is relaxed by 0.1 and the least-similar topic is allowed through
+        so that the pipeline always has something to work with.
+
+        Args:
+            topics: List of topic dicts from scout_topics().
+
+        Returns:
+            Tuple of (kept_topics, rejected_topics).
+            kept_topics includes warned topics (with ``"dedup_warning"``).
+            rejected_topics lists those silently dropped (>reject_threshold).
+        """
+        if not topics:
+            return [], []
+
+        if self.collection is None or self.collection.count() == 0:
+            logger.info("TopicDeduplicator: archive empty — all topics pass through")
+            return topics, []
+
+        kept: list[dict[str, Any]] = []
+        rejected: list[dict[str, Any]] = []
+
+        for topic_dict in topics:
+            topic_text = topic_dict.get("topic", "")
+            if not topic_text:
+                kept.append(topic_dict)
+                continue
+
+            similarity, matched_title = self._query_similarity(topic_text)
+
+            if similarity is None:
+                # Query failed — pass through safely
+                kept.append(topic_dict)
+                continue
+
+            if similarity > self.reject_threshold:
+                logger.warning(
+                    "🚫 DEDUP REJECT: '%s' (similarity=%.2f > %.2f with '%s')",
+                    topic_text,
+                    similarity,
+                    self.reject_threshold,
+                    matched_title,
+                )
+                rejected.append({**topic_dict, "dedup_similarity": similarity, "dedup_matched": matched_title})
+            elif similarity > self.warn_threshold:
+                logger.warning(
+                    "⚠️  DEDUP WARN: '%s' (similarity=%.2f, related to '%s') — passed to editorial with flag",
+                    topic_text,
+                    similarity,
+                    matched_title,
+                )
+                kept.append(
+                    {
+                        **topic_dict,
+                        "dedup_warning": (
+                            f"Related coverage exists: '{matched_title}' "
+                            f"(similarity={similarity:.2f})"
+                        ),
+                        "dedup_similarity": similarity,
+                        "dedup_matched": matched_title,
+                    }
+                )
+            else:
+                logger.info(
+                    "✅ DEDUP PASS: '%s' (similarity=%.2f — novel topic)",
+                    topic_text,
+                    similarity,
+                )
+                kept.append(topic_dict)
+
+        # Fallback: ensure at least MIN_TOPICS_AFTER_FILTER survive
+        kept = self._apply_fallback(kept, rejected, topics)
+
+        return kept, rejected
+
+    def index_article(self, title: str, content: str, article_id: str | None = None) -> bool:
+        """
+        Index a newly published article in the archive collection.
+
+        Should be called after successful publication to keep the
+        deduplication archive current.
+
+        Args:
+            title: Article title (used as primary query text).
+            content: Full article text (first 500 chars stored for context).
+            article_id: Optional unique ID; defaults to a hash of the title.
+
+        Returns:
+            True if indexing succeeded, False on error.
+        """
+        if self.collection is None:
+            logger.warning("TopicDeduplicator: cannot index article — ChromaDB unavailable")
+            return False
+
+        try:
+            import hashlib
+
+            doc_id = article_id or hashlib.md5(title.encode()).hexdigest()
+            # Store title + first 500 chars of body as the searchable document
+            document = f"{title}\n\n{content[:500]}"
+            self.collection.upsert(
+                ids=[doc_id],
+                documents=[document],
+                metadatas=[{"title": title}],
+            )
+            logger.info("📚 Indexed article in archive: '%s'", title)
+            return True
+        except Exception as exc:
+            logger.warning("Failed to index article '%s': %s", title, exc)
+            return False
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _query_similarity(self, topic_text: str) -> tuple[float | None, str]:
+        """
+        Query ChromaDB for the most similar published article.
+
+        Args:
+            topic_text: Topic string to check against the archive.
+
+        Returns:
+            Tuple of (highest_similarity, matched_title).
+            Returns (None, "") if the query fails.
+        """
+        try:
+            results = self.collection.query(
+                query_texts=[topic_text],
+                n_results=1,
+                include=["distances", "metadatas"],
+            )
+            distances = results.get("distances", [[]])[0]
+            metadatas = results.get("metadatas", [[]])[0]
+
+            if not distances:
+                return 0.0, ""
+
+            # ChromaDB cosine distance is in [0, 2]; convert to similarity [0, 1]
+            # distance = 0 → identical; distance = 2 → opposite
+            # similarity = 1 - (distance / 2)
+            raw_distance = distances[0]
+            similarity = 1.0 - (raw_distance / 2.0)
+            matched_title = metadatas[0].get("title", "") if metadatas else ""
+            return similarity, matched_title
+
+        except Exception as exc:
+            logger.warning("ChromaDB query failed for topic '%s': %s", topic_text, exc)
+            return None, ""
+
+    def _apply_fallback(
+        self,
+        kept: list[dict[str, Any]],
+        rejected: list[dict[str, Any]],
+        original: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        """
+        Ensure at least MIN_TOPICS_AFTER_FILTER topics survive filtering.
+
+        If all topics were rejected, rescue the one with the lowest
+        similarity (most novel) and log a warning.
+
+        Args:
+            kept: Topics that passed the filter.
+            rejected: Topics that were rejected.
+            original: Original full list (used for rescue selection).
+
+        Returns:
+            Possibly augmented kept list.
+        """
+        if len(kept) >= MIN_TOPICS_AFTER_FILTER:
+            return kept
+
+        # All topics were rejected — rescue the least-similar one
+        if not rejected:
+            return kept
+
+        best = min(rejected, key=lambda t: t.get("dedup_similarity", 1.0))
+        logger.warning(
+            "⚠️  DEDUP FALLBACK: all topics filtered — rescuing least-similar topic '%s' "
+            "(similarity=%.2f). Consider refreshing topic generation.",
+            best.get("topic", "unknown"),
+            best.get("dedup_similarity", 0.0),
+        )
+        rescued = {k: v for k, v in best.items() if k not in ("dedup_similarity", "dedup_matched")}
+        rescued["dedup_warning"] = (
+            f"Rescued from rejection (all topics filtered); "
+            f"original similarity={best.get('dedup_similarity', 0):.2f}"
+        )
+        return kept + [rescued]

--- a/tests/test_topic_deduplicator.py
+++ b/tests/test_topic_deduplicator.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+"""
+Unit Tests for TopicDeduplicator
+
+Tests cover:
+- Pass-through when ChromaDB unavailable (module-level mock)
+- Pass-through when collection is empty
+- Rejection of near-duplicate topics (similarity > 0.8)
+- Warning for related topics (0.6–0.8 similarity)
+- Pass-through for novel topics (< 0.6 similarity)
+- Fallback when all topics are filtered
+- article indexing (upsert)
+- filter_topics with empty input
+- discover_topics() dedup integration in EconomistContentFlow
+
+Usage::
+
+    pytest tests/test_topic_deduplicator.py -v
+"""
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.tools.topic_deduplicator import (
+    MIN_TOPICS_AFTER_FILTER,
+    REJECT_THRESHOLD,
+    WARN_THRESHOLD,
+    TopicDeduplicator,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_deduplicator(distances: list[float] | None = None) -> TopicDeduplicator:
+    """Return a TopicDeduplicator whose ChromaDB collection is fully mocked.
+
+    Args:
+        distances: List of distance values returned per query.
+                   Defaults to [0.0] (identical match) for a single call.
+    """
+    if distances is None:
+        distances = [0.0]
+
+    mock_collection = MagicMock()
+    mock_collection.count.return_value = 3  # non-empty archive
+
+    # Each call to query() returns the next distance in the list
+    call_index: dict[str, int] = {"i": 0}
+
+    def _query(**kwargs: Any) -> dict[str, Any]:
+        idx = call_index["i"] % len(distances)
+        call_index["i"] += 1
+        dist = distances[idx]
+        return {
+            "distances": [[dist]],
+            "metadatas": [[{"title": "Existing Article"}]],
+        }
+
+    mock_collection.query.side_effect = _query
+
+    dedup = TopicDeduplicator.__new__(TopicDeduplicator)
+    dedup.collection_name = "published_articles"
+    dedup.persist_directory = ".chromadb"
+    dedup.reject_threshold = REJECT_THRESHOLD
+    dedup.warn_threshold = WARN_THRESHOLD
+    dedup.client = MagicMock()
+    dedup.collection = mock_collection
+    return dedup
+
+
+def _topics(names: list[str]) -> list[dict[str, Any]]:
+    """Build minimal topic dicts from a list of name strings."""
+    return [{"topic": name, "score": 7.0} for name in names]
+
+
+# ---------------------------------------------------------------------------
+# Tests: filter_topics — core similarity tiers
+# ---------------------------------------------------------------------------
+
+
+class TestFilterTopicsSimilarityTiers:
+    """Test the three similarity tiers: reject, warn, pass."""
+
+    def test_novel_topic_passes_unchanged(self) -> None:
+        """Topics with similarity < WARN_THRESHOLD pass without modification."""
+        # distance = 1.4 → similarity = 1 - 1.4/2 = 0.3
+        dedup = _make_deduplicator(distances=[1.4])
+        kept, rejected = dedup.filter_topics(_topics(["Brand New Topic"]))
+
+        assert len(kept) == 1
+        assert len(rejected) == 0
+        assert "dedup_warning" not in kept[0]
+
+    def test_related_topic_passes_with_warning(self) -> None:
+        """Topics with 0.6 < similarity ≤ 0.8 pass with a dedup_warning."""
+        # distance = 0.5 → similarity = 1 - 0.5/2 = 0.75
+        dedup = _make_deduplicator(distances=[0.5])
+        kept, rejected = dedup.filter_topics(_topics(["Related Topic"]))[0], \
+            dedup.filter_topics(_topics(["Related Topic"]))[1]
+
+        assert len(kept) == 1
+        assert len(rejected) == 0
+        assert "dedup_warning" in kept[0]
+        assert "Related" in kept[0]["dedup_warning"] or "Existing" in kept[0]["dedup_warning"]
+
+    def test_duplicate_topic_is_rejected(self) -> None:
+        """Topics with similarity > REJECT_THRESHOLD are rejected.
+
+        When all topics are rejected the fallback rescues the least-similar one
+        rather than leaving the pipeline with zero candidates, so we verify the
+        topic ends up in *rejected* initially (recorded there) and the returned
+        kept list carries the rescue warning from the fallback.
+        """
+        # distance = 0.1 → similarity = 1 - 0.1/2 = 0.95  (above REJECT_THRESHOLD)
+        dedup = _make_deduplicator(distances=[0.1])
+        kept, rejected = dedup.filter_topics(_topics(["Duplicate Topic"]))
+
+        # The topic was rejected by the threshold check (appears in rejected list)
+        assert len(rejected) == 1
+        assert rejected[0]["topic"] == "Duplicate Topic"
+        assert rejected[0]["dedup_similarity"] > REJECT_THRESHOLD
+
+        # Fallback rescues it because the pipeline needs at least one topic
+        assert len(kept) == MIN_TOPICS_AFTER_FILTER
+        assert "dedup_warning" in kept[0]
+
+    def test_boundary_at_reject_threshold(self) -> None:
+        """Similarity exactly at REJECT_THRESHOLD (0.8) should WARN not reject."""
+        # distance such that similarity == REJECT_THRESHOLD exactly
+        # similarity = 1 - d/2 = 0.8 → d = 0.4
+        dedup = _make_deduplicator(distances=[0.4])
+        kept, rejected = dedup.filter_topics(_topics(["Boundary Topic"]))
+
+        # similarity is NOT > 0.8 (it equals 0.8) → warn tier
+        assert len(kept) == 1
+        assert len(rejected) == 0
+
+    def test_multiple_topics_mixed_result(self) -> None:
+        """Mixed-similarity topic lists are categorised correctly."""
+        # distances per topic: reject, warn, pass
+        dedup = _make_deduplicator(distances=[0.1, 0.5, 1.4])
+        topics = _topics(["Dup", "Related", "Novel"])
+        kept, rejected = dedup.filter_topics(topics)
+
+        assert len(rejected) == 1
+        assert rejected[0]["topic"] == "Dup"
+        assert len(kept) == 2
+
+        topic_names = [t["topic"] for t in kept]
+        assert "Novel" in topic_names
+        assert "Related" in topic_names
+
+        related = next(t for t in kept if t["topic"] == "Related")
+        assert "dedup_warning" in related
+
+        novel = next(t for t in kept if t["topic"] == "Novel")
+        assert "dedup_warning" not in novel
+
+
+# ---------------------------------------------------------------------------
+# Tests: filter_topics — edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestFilterTopicsEdgeCases:
+    """Edge cases: empty input, empty archive, query failure."""
+
+    def test_empty_topic_list_returns_empty(self) -> None:
+        """filter_topics([]) returns ([], []) without touching ChromaDB."""
+        dedup = _make_deduplicator()
+        kept, rejected = dedup.filter_topics([])
+        assert kept == []
+        assert rejected == []
+
+    def test_empty_archive_passes_all_through(self) -> None:
+        """When the collection has 0 docs, all topics pass unmodified."""
+        dedup = _make_deduplicator()
+        dedup.collection.count.return_value = 0
+        topics = _topics(["Topic A", "Topic B"])
+        kept, rejected = dedup.filter_topics(topics)
+        assert kept == topics
+        assert rejected == []
+
+    def test_no_collection_passes_all_through(self) -> None:
+        """When collection is None (ChromaDB error), all topics pass."""
+        dedup = TopicDeduplicator.__new__(TopicDeduplicator)
+        dedup.collection = None
+        dedup.reject_threshold = REJECT_THRESHOLD
+        dedup.warn_threshold = WARN_THRESHOLD
+        kept, rejected = dedup.filter_topics(_topics(["A", "B"]))
+        assert len(kept) == 2
+        assert rejected == []
+
+    def test_query_failure_passes_topic_through(self) -> None:
+        """If ChromaDB raises an exception, the topic passes through safely."""
+        dedup = _make_deduplicator()
+        dedup.collection.query.side_effect = RuntimeError("DB unavailable")
+        dedup.collection.count.return_value = 2
+        kept, rejected = dedup.filter_topics(_topics(["Topic X"]))
+        assert len(kept) == 1
+        assert rejected == []
+
+    def test_topic_with_empty_string_passes_through(self) -> None:
+        """Topics with empty topic string are kept without querying."""
+        dedup = _make_deduplicator()
+        topics = [{"topic": "", "score": 5.0}]
+        kept, rejected = dedup.filter_topics(topics)
+        assert kept == topics
+        assert rejected == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: filter_topics — fallback
+# ---------------------------------------------------------------------------
+
+
+class TestFilterTopicsFallback:
+    """When all topics are rejected the fallback rescues the best one."""
+
+    def test_fallback_rescues_least_similar_topic(self) -> None:
+        """If all topics are rejected, the one with lowest similarity is rescued."""
+        # Two topics both above reject threshold; second is less similar
+        dedup = _make_deduplicator(distances=[0.05, 0.2])  # sim=0.975, sim=0.9
+        topics = _topics(["Near-identical", "Mostly-duplicate"])
+        kept, rejected = dedup.filter_topics(topics)
+
+        # Both were rejected, but the fallback rescues one
+        assert len(kept) == MIN_TOPICS_AFTER_FILTER
+        assert kept[0]["topic"] == "Mostly-duplicate"  # sim=0.9 < 0.975
+        assert "dedup_warning" in kept[0]
+        assert "Rescued" in kept[0]["dedup_warning"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: index_article
+# ---------------------------------------------------------------------------
+
+
+class TestIndexArticle:
+    """Tests for post-publication article indexing."""
+
+    def test_index_article_calls_upsert(self) -> None:
+        """index_article() calls collection.upsert with correct arguments."""
+        dedup = _make_deduplicator()
+        result = dedup.index_article("My Article", "Full article text here...")
+        assert result is True
+        dedup.collection.upsert.assert_called_once()
+        call_kwargs = dedup.collection.upsert.call_args
+        # metadatas should include the title
+        metadatas = call_kwargs.kwargs.get("metadatas") or call_kwargs.args[2] if call_kwargs.args else call_kwargs.kwargs["metadatas"]
+        assert metadatas[0]["title"] == "My Article"
+
+    def test_index_article_no_collection_returns_false(self) -> None:
+        """index_article() returns False when ChromaDB is unavailable."""
+        dedup = TopicDeduplicator.__new__(TopicDeduplicator)
+        dedup.collection = None
+        result = dedup.index_article("Title", "Body")
+        assert result is False
+
+    def test_index_article_upsert_failure_returns_false(self) -> None:
+        """index_article() returns False when upsert raises an exception."""
+        dedup = _make_deduplicator()
+        dedup.collection.upsert.side_effect = RuntimeError("write error")
+        result = dedup.index_article("Title", "Body")
+        assert result is False
+
+    def test_index_article_custom_id(self) -> None:
+        """Custom article_id is passed through to upsert."""
+        dedup = _make_deduplicator()
+        dedup.index_article("Title", "Body", article_id="custom-123")
+        call_kwargs = dedup.collection.upsert.call_args.kwargs
+        assert call_kwargs["ids"] == ["custom-123"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: discover_topics() flow integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY required for CrewAI agent initialization",
+)
+class TestDiscoverTopicsDeduplication:
+    """Integration tests for dedup wiring inside EconomistContentFlow."""
+
+    def _build_flow(self, distances: list[float]) -> Any:
+        """Create a flow with a mocked deduplicator and Stage4Crew.
+
+        Args:
+            distances: Cosine distances returned by the mock ChromaDB collection.
+        """
+        with patch("src.economist_agents.flow.Stage4Crew"):
+            from src.economist_agents.flow import EconomistContentFlow
+
+            flow = EconomistContentFlow()
+
+        flow._deduplicator = _make_deduplicator(distances=distances)
+        return flow
+
+    @patch("src.economist_agents.flow.scout_topics")
+    @patch("src.economist_agents.flow.create_llm_client")
+    def test_novel_topic_reaches_editorial(
+        self, mock_client: Mock, mock_scout: Mock
+    ) -> None:
+        """Novel topics (<0.6 sim) are returned to the editorial board."""
+        mock_client.return_value = Mock()
+        mock_scout.return_value = [
+            {"topic": "Novel AI Insight", "total_score": 20, "hook": "", "thesis": "",
+             "data_sources": [], "contrarian_angle": "", "talking_points": ""}
+        ]
+        # distance = 1.4 → similarity = 0.3 (novel)
+        flow = self._build_flow(distances=[1.4])
+        result = flow.discover_topics()
+        assert len(result["topics"]) == 1
+        assert "dedup_warning" not in result["topics"][0]
+
+    @patch("src.economist_agents.flow.scout_topics")
+    @patch("src.economist_agents.flow.create_llm_client")
+    def test_duplicate_topic_filtered_before_editorial(
+        self, mock_client: Mock, mock_scout: Mock
+    ) -> None:
+        """Duplicate topics (>0.8 sim) are removed before editorial board.
+
+        Fallback rescues the topic with a dedup_warning so the pipeline
+        always has at least one candidate.
+        """
+        mock_client.return_value = Mock()
+        mock_scout.return_value = [
+            {"topic": "Duplicate Topic", "total_score": 20, "hook": "", "thesis": "",
+             "data_sources": [], "contrarian_angle": "", "talking_points": ""}
+        ]
+        # distance = 0.1 → similarity = 0.95 (reject)
+        flow = self._build_flow(distances=[0.1])
+        result = flow.discover_topics()
+        # Fallback should rescue it with a warning
+        assert len(result["topics"]) == MIN_TOPICS_AFTER_FILTER
+        assert "dedup_warning" in result["topics"][0]
+
+    @patch("src.economist_agents.flow.scout_topics")
+    @patch("src.economist_agents.flow.create_llm_client")
+    def test_related_topic_flagged_for_editorial(
+        self, mock_client: Mock, mock_scout: Mock
+    ) -> None:
+        """Related topics (0.6–0.8 sim) pass but carry a dedup_warning."""
+        mock_client.return_value = Mock()
+        mock_scout.return_value = [
+            {"topic": "Related Topic", "total_score": 18, "hook": "", "thesis": "",
+             "data_sources": [], "contrarian_angle": "", "talking_points": ""}
+        ]
+        # distance = 0.5 → similarity = 0.75 (warn tier)
+        flow = self._build_flow(distances=[0.5])
+        result = flow.discover_topics()
+        assert len(result["topics"]) == 1
+        assert "dedup_warning" in result["topics"][0]
+
+    def test_publish_article_indexes_in_archive(self) -> None:
+        """publish_article() calls deduplicator.index_article after publishing."""
+        with patch("src.economist_agents.flow.Stage4Crew"):
+            from src.economist_agents.flow import EconomistContentFlow
+
+            flow = EconomistContentFlow()
+
+        flow.state["quality_result"] = {
+            "article": "---\ntitle: Published\n---\n\nContent here.",
+            "editorial_score": 87,
+            "gates_passed": 5,
+        }
+        flow.state["selected_topic"] = {"topic": "Published Topic"}
+
+        mock_dedup = MagicMock()
+        flow._deduplicator = mock_dedup
+
+        result = flow.publish_article()
+
+        assert result["status"] == "published"
+        mock_dedup.index_article.assert_called_once_with(
+            title="Published Topic",
+            content="---\ntitle: Published\n---\n\nContent here.",
+        )


### PR DESCRIPTION
## Summary
Implements topic deduplication before the editorial board vote, preventing near-duplicate articles from entering the pipeline.

## Changes
- **New**: `src/tools/topic_deduplicator.py` — `TopicDeduplicator` class backed by ChromaDB `published_articles` collection
- **Modified**: `src/economist_agents/flow.py` — dedup step in `discover_topics()`, post-publication indexing in `publish_article()`
- **New**: `tests/test_topic_deduplicator.py` — 19 tests, 81% coverage

## Acceptance Criteria (Issue #157)
- ✅ Topics >0.8 cosine similarity rejected with WARNING log
- ✅ Topics 0.6–0.8 similarity pass with `dedup_warning` flag for editors
- ✅ Topics <0.6 similarity pass unchanged (novel topic)
- ✅ Fallback: if all topics filtered, least-similar is rescued (pipeline always gets ≥1 topic)
- ✅ After successful publication, article indexed in archive via `index_article()`
- ✅ Graceful degradation: ChromaDB unavailable or empty → all topics pass through
- ✅ Tests mock ChromaDB queries
- ✅ Existing flow.py tests still pass

Closes #157