### PR TITLE
feat: add remaining MCP servers (publication-validator, web-researcher, image-generator, published-topics)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,18 +7,59 @@
     },
     "playwright": {
       "command": "npx",
-      "args": ["@playwright/mcp@latest", "--extension"],
+      "args": [
+        "@playwright/mcp@latest",
+        "--extension"
+      ],
       "description": "Browser automation for navigating web UIs, taking screenshots, and interacting with pages"
     },
     "article-evaluator": {
       "command": "python3",
-      "args": ["mcp_servers/article_evaluator_server.py"],
+      "args": [
+        "mcp_servers/article_evaluator_server.py"
+      ],
       "description": "Scores article drafts across 5 quality dimensions and returns a pass/fail verdict before publishing"
     },
     "style-memory": {
       "command": "python3",
-      "args": ["mcp_servers/style_memory_server.py"],
+      "args": [
+        "mcp_servers/style_memory_server.py"
+      ],
       "description": "Query and update the ChromaDB-backed style memory store for Economist voice consistency"
+    },
+    "publication-validator": {
+      "command": "python3",
+      "args": [
+        "mcp_servers/publication_validator_server.py"
+      ],
+      "description": "Publication validation \u2014 checks front-matter fields (layout, title, date, author, categories, image) and image-path existence before a post is published"
+    },
+    "web-researcher": {
+      "command": "python3",
+      "args": [
+        "mcp_servers/web_researcher_server.py"
+      ],
+      "env": {
+        "SERPER_API_KEY": "${SERPER_API_KEY}"
+      },
+      "description": "Web search (Serper/Google), Google Scholar, arXiv academic search, and page fetching as MCP tools"
+    },
+    "image-generator": {
+      "command": "python3",
+      "args": [
+        "mcp_servers/image_generator_server.py"
+      ],
+      "env": {
+        "OPENAI_API_KEY": "${OPENAI_API_KEY}"
+      },
+      "description": "DALL-E 3 image generation for the content pipeline"
+    },
+    "published-topics": {
+      "command": "python3",
+      "args": [
+        "mcp_servers/published_topics_server.py"
+      ],
+      "description": "Query the published article archive for topic similarity and duplicate detection before commissioning new content"
     }
   }
 }

--- a/mcp_servers/image_generator_server.py
+++ b/mcp_servers/image_generator_server.py
@@ -18,6 +18,7 @@ import binascii
 import logging
 import os
 from pathlib import Path
+from typing import Literal
 
 import openai
 import requests
@@ -243,6 +244,59 @@ def generate_editorial_image(
             "path": None,
             "size_bytes": 0,
         }
+
+
+@mcp.tool()
+def generate_image(
+    prompt: str,
+    size: Literal["1024x1024", "1792x1024", "1024x1792"] = "1792x1024",
+) -> dict:
+    """Generate an image using DALL-E 3 and return its URL.
+
+    A lightweight wrapper around the DALL-E 3 API that accepts a raw prompt
+    and returns the hosted image URL together with the revised prompt that
+    OpenAI used.
+
+    Args:
+        prompt: Text description of the image to generate.
+        size: Image dimensions — one of ``"1792x1024"`` (default, landscape),
+              ``"1024x1024"`` (square), or ``"1024x1792"`` (portrait).
+
+    Returns:
+        A dictionary with keys:
+
+        - ``url`` (str): HTTPS URL to the generated image.
+        - ``revised_prompt`` (str): The prompt OpenAI actually used
+          (may differ from the input if DALL-E rewrote it for safety).
+
+    Raises:
+        ValueError: If ``OPENAI_API_KEY`` is not set in the environment.
+        openai.OpenAIError: If the API call fails.
+    """
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "OPENAI_API_KEY environment variable is not set. "
+            "Please export OPENAI_API_KEY=<your-key> before using this tool."
+        )
+
+    client = openai.OpenAI(api_key=api_key)
+    logger.info("Calling DALL-E 3 for prompt (first 60 chars): %r", prompt[:60])
+
+    response = client.images.generate(
+        model="dall-e-3",
+        prompt=prompt,
+        size=size,
+        quality="hd",
+        n=1,
+    )
+
+    image_data = response.data[0]
+    url = image_data.url or ""
+    revised_prompt = image_data.revised_prompt or prompt
+
+    logger.info("Image generated: url=%r", url[:80] if url else "(empty)")
+    return {"url": url, "revised_prompt": revised_prompt}
 
 
 if __name__ == "__main__":

--- a/mcp_servers/publication_validator_server.py
+++ b/mcp_servers/publication_validator_server.py
@@ -9,9 +9,11 @@ Transport: stdio (default FastMCP behaviour)
 """
 
 import logging
+import re
 import sys
 from pathlib import Path
 
+import yaml
 from mcp.server.fastmcp import FastMCP
 
 # Ensure the repo root is on sys.path so the scripts package is importable
@@ -21,6 +23,24 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from scripts.publication_validator import PublicationValidator  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+#: Categories accepted by the publication pipeline.
+#: Keep in sync with the ``categories`` enum in ``scripts/schema_validator.py``
+#: (``FRONT_MATTER_SCHEMA["properties"]["categories"]["items"]["enum"]``).
+VALID_CATEGORIES: list[str] = [
+    "quality-engineering",
+    "test-automation",
+    "performance",
+    "ai-testing",
+    "software-engineering",
+    "devops",
+]
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +97,175 @@ def validate_for_publication(
     )
 
     return {"is_valid": is_valid, "issues": issues}
+
+
+@mcp.tool()
+def validate_post(post_path: str) -> dict:
+    """Validate a blog-post file against publication front-matter requirements.
+
+    Reads the markdown file at *post_path* and checks:
+
+    * YAML front-matter delimiters are present (``---`` … ``---``).
+    * Required fields are present: ``layout``, ``title``, ``date``,
+      ``author``, ``categories``, ``image``.
+    * ``layout`` equals ``"post"``.
+    * ``title`` is a non-empty string.
+    * ``date`` matches ``YYYY-MM-DD`` format.
+    * ``author`` is a non-empty string.
+    * Every item in ``categories`` is one of :data:`VALID_CATEGORIES`.
+    * ``image`` refers to a path that exists on the filesystem (local paths
+      only; ``http://`` / ``https://`` URLs are accepted without checking).
+
+    Args:
+        post_path: Absolute or relative path to the markdown post file.
+
+    Returns:
+        A dictionary with three keys:
+
+        * ``valid`` (bool): ``True`` when *errors* is empty.
+        * ``errors`` (list[str]): Fatal validation failures; the post must
+          be fixed before publication.
+        * ``warnings`` (list[str]): Non-fatal advisories.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    # ------------------------------------------------------------------
+    # Read the file
+    # ------------------------------------------------------------------
+    post_file = Path(post_path)
+    try:
+        content = post_file.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {
+            "valid": False,
+            "errors": [f"File not found: {post_path}"],
+            "warnings": [],
+        }
+    except OSError as exc:
+        return {
+            "valid": False,
+            "errors": [f"Error reading file: {exc}"],
+            "warnings": [],
+        }
+
+    logger.info("validate_post: reading %s (%d bytes)", post_path, len(content))
+
+    # ------------------------------------------------------------------
+    # Front-matter delimiters
+    # ------------------------------------------------------------------
+    if not content.lstrip("\n").startswith("---"):
+        errors.append("Missing YAML front-matter opening delimiter (---)")
+        return {"valid": False, "errors": errors, "warnings": warnings}
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        errors.append("Missing YAML front-matter closing delimiter (---)")
+        return {"valid": False, "errors": errors, "warnings": warnings}
+
+    # ------------------------------------------------------------------
+    # Parse YAML
+    # ------------------------------------------------------------------
+    try:
+        frontmatter: dict = yaml.safe_load(parts[1]) or {}
+    except yaml.YAMLError as exc:
+        errors.append(f"Invalid YAML in front matter: {exc}")
+        return {"valid": False, "errors": errors, "warnings": warnings}
+
+    if not isinstance(frontmatter, dict):
+        errors.append("Front matter must be a YAML dictionary")
+        return {"valid": False, "errors": errors, "warnings": warnings}
+
+    # ------------------------------------------------------------------
+    # Required fields
+    # ------------------------------------------------------------------
+    required_fields = ["layout", "title", "date", "author", "categories", "image"]
+    for field in required_fields:
+        if field not in frontmatter:
+            errors.append(f"Missing required field: {field}")
+
+    if errors:
+        return {"valid": False, "errors": errors, "warnings": warnings}
+
+    # ------------------------------------------------------------------
+    # layout
+    # ------------------------------------------------------------------
+    layout = frontmatter.get("layout")
+    if layout != "post":
+        errors.append(f"layout must be 'post', got '{layout}'")
+
+    # ------------------------------------------------------------------
+    # title
+    # ------------------------------------------------------------------
+    title = frontmatter.get("title")
+    if not isinstance(title, str) or not title.strip():
+        errors.append("title must be a non-empty string")
+
+    # ------------------------------------------------------------------
+    # date (YYYY-MM-DD)
+    # ------------------------------------------------------------------
+    date_val = frontmatter.get("date")
+    date_str = (
+        date_val.strftime("%Y-%m-%d")
+        if hasattr(date_val, "strftime")
+        else str(date_val)
+    )
+    if not _DATE_RE.match(date_str):
+        errors.append(f"date must be in YYYY-MM-DD format, got '{date_str}'")
+
+    # ------------------------------------------------------------------
+    # author
+    # ------------------------------------------------------------------
+    author = frontmatter.get("author")
+    if not isinstance(author, str) or not author.strip():
+        errors.append("author must be a non-empty string")
+
+    # ------------------------------------------------------------------
+    # categories — each must be in VALID_CATEGORIES
+    # ------------------------------------------------------------------
+    categories = frontmatter.get("categories")
+    if not isinstance(categories, list):
+        errors.append("categories must be a list")
+    elif not categories:
+        errors.append("categories must contain at least one entry")
+    else:
+        for cat in categories:
+            if cat not in VALID_CATEGORIES:
+                errors.append(
+                    f"Invalid category '{cat}'. "
+                    f"Must be one of: {', '.join(VALID_CATEGORIES)}"
+                )
+
+    # ------------------------------------------------------------------
+    # image — local paths must exist on the filesystem
+    # ------------------------------------------------------------------
+    image = frontmatter.get("image")
+    if image is None or (isinstance(image, str) and not image.strip()):
+        errors.append("image field must be a non-empty value")
+    else:
+        image_str = str(image).strip()
+        if not image_str.startswith(("http://", "https://")):
+            image_path = Path(image_str)
+            # Check candidates in priority order:
+            # 1. As-is:            /abs/path/chart.png → /abs/path/chart.png
+            # 2. Repo-root-rel:    /assets/chart.png   → <repo_root>/assets/chart.png
+            # 3. Post-dir-rel:     chart.png           → <post_dir>/chart.png
+            candidates = [
+                image_path,
+                _REPO_ROOT / image_str.lstrip("/"),
+                post_file.parent / image_str.lstrip("/"),
+            ]
+            if not any(c.exists() for c in candidates):
+                errors.append(f"image path does not exist: {image_str}")
+
+    logger.info(
+        "validate_post: %s — %d error(s), %d warning(s)",
+        post_path,
+        len(errors),
+        len(warnings),
+    )
+
+    return {"valid": len(errors) == 0, "errors": errors, "warnings": warnings}
 
 
 if __name__ == "__main__":

--- a/mcp_servers/published_topics_server.py
+++ b/mcp_servers/published_topics_server.py
@@ -9,7 +9,9 @@ deduplication works from both interactive (Claude Code) and automated
 Transport: stdio (FastMCP)
 
 Tools:
-    search_published_topics   — semantic similarity search over the archive
+    query_published_topics    — semantic similarity search over the archive
+    is_topic_duplicate        — check whether a topic has already been published
+    search_published_topics   — semantic similarity search with threshold filter
     index_published_article   — add / update an article in the archive
     get_archive_stats         — summary statistics about the archive
 
@@ -22,13 +24,20 @@ Usage:
 import logging
 from typing import Any
 
-from fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP
 
 from scripts.article_archive import ArticleArchive
 
 logger = logging.getLogger(__name__)
 
-mcp = FastMCP("published-topics")
+mcp = FastMCP(
+    "published-topics",
+    instructions=(
+        "Query the published article archive to detect duplicate topics before "
+        "commissioning new content. Use query_published_topics for similarity "
+        "search and is_topic_duplicate for a structured duplicate verdict."
+    ),
+)
 
 # Module-level archive instance (lazy-initialised on first use)
 _archive: ArticleArchive | None = None
@@ -36,10 +45,73 @@ _archive: ArticleArchive | None = None
 
 def _get_archive() -> ArticleArchive:
     """Return the shared :class:`ArticleArchive`, creating it on first call."""
-    global _archive
+    global _archive  # noqa: PLW0603
     if _archive is None:
         _archive = ArticleArchive()
     return _archive
+
+
+def _set_archive_for_testing(archive: ArticleArchive) -> None:
+    """Replace the shared archive instance (for tests only).
+
+    Allows tests to inject an in-memory ChromaDB-backed archive so that no
+    persistent state is written to disk.
+    """
+    global _archive  # noqa: PLW0603
+    _archive = archive
+
+
+@mcp.tool()
+def query_published_topics(
+    query: str,
+    n_results: int = 5,
+) -> list[dict[str, Any]]:
+    """
+    Return the *n_results* most similar published articles for a topic query.
+
+    Unlike ``search_published_topics``, this tool applies no similarity
+    threshold — it always returns the closest matches sorted by descending
+    cosine similarity.
+
+    Args:
+        query: Topic description or title to search for.
+        n_results: Maximum number of results to return. Default 5.
+
+    Returns:
+        List of matching articles, each with title, thesis, date,
+        categories, file_path, and similarity score.
+    """
+    return _get_archive().search(query, threshold=0.0, n_results=n_results)
+
+
+@mcp.tool()
+def is_topic_duplicate(topic: str) -> dict[str, Any]:
+    """
+    Check whether a proposed topic has already been covered.
+
+    Thresholds:
+      - similarity > 0.8  -> duplicate (is_duplicate=True)
+      - 0.6 <= similarity <= 0.8 -> warning zone
+      - similarity < 0.6  -> safe to publish
+
+    Args:
+        topic: Proposed article topic or title to check for duplication.
+
+    Returns:
+        dict with:
+          - is_duplicate (bool): True when the best match exceeds 0.8.
+          - confidence (float): Similarity score of the closest match (0-1).
+          - similar_articles (list): Up to 5 similar articles with metadata.
+          - warning (bool): True when 0.6 <= confidence <= 0.8.
+    """
+    similar = _get_archive().search(topic, threshold=0.6, n_results=5)
+    confidence = similar[0]["similarity"] if similar else 0.0
+    return {
+        "is_duplicate": confidence > 0.8,
+        "confidence": confidence,
+        "similar_articles": similar,
+        "warning": 0.6 <= confidence <= 0.8,
+    }
 
 
 @mcp.tool()
@@ -53,7 +125,7 @@ def search_published_topics(
 
     Args:
         query: Topic description or title to search for.
-        threshold: Minimum similarity score (0–1). Default 0.6.
+        threshold: Minimum similarity score (0-1). Default 0.6.
         n_results: Maximum number of results to return. Default 5.
 
     Returns:
@@ -87,23 +159,7 @@ def index_published_article(
         dict with success (bool), id (str), and total_indexed (int).
         On failure, includes an error (str) field instead of total_indexed.
     """
-    try:
-        doc_id = _get_archive().index_article(
-            title=title,
-            thesis=thesis,
-            summary=summary,
-            categories=categories,
-            date=date,
-            file_path=file_path,
-        )
-        return {
-            "success": True,
-            "id": doc_id,
-            "total_indexed": _get_archive().count(),
-        }
-    except Exception as exc:
-        logger.error("index_published_article failed: %s", exc)
-        return {"success": False, "error": str(exc)}
+    return _get_archive().index_article(title, thesis, date, categories, file_path)
 
 
 @mcp.tool()
@@ -120,4 +176,4 @@ def get_archive_stats() -> dict[str, Any]:
 
 
 if __name__ == "__main__":
-    mcp.run()
+    mcp.run(transport="stdio")


### PR DESCRIPTION
Resolves concurrent `.mcp.json` conflicts across PRs #217, #218, #219, #220 by merging all four server registrations into a single clean commit.

## What's included
- `mcp_servers/publication_validator_server.py` — front-matter + image-path validation
- `mcp_servers/web_researcher_server.py` — Serper/Google, Scholar, arXiv, page fetch
- `mcp_servers/image_generator_server.py` — DALL-E 3 image generation
- `mcp_servers/published_topics_server.py` — topic similarity + duplicate detection
- `.mcp.json` — all 8 servers registered (unified)

Closes #217
Closes #218
Closes #219
Closes #220