### PR TITLE
fix: Topic Scout dedup bypass — fail-closed on empty archive

### DIFF
--- a/scripts/topic_scout.py
+++ b/scripts/topic_scout.py
@@ -17,11 +17,22 @@ Output: Ranked list of topics with data availability scores
 """
 
 import json
+import logging
 import os
 import re
+import sys
 from datetime import datetime
+from pathlib import Path
 
-from agent_loader import load_scout_prompts as _load_scout_prompts
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from agent_loader import load_scout_prompts as _load_scout_prompts  # noqa: E402
+
+from src.tools.topic_deduplicator import TopicDeduplicator  # noqa: E402
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Theme keyword map for diversity classification.
@@ -29,48 +40,111 @@ from agent_loader import load_scout_prompts as _load_scout_prompts
 # ---------------------------------------------------------------------------
 THEME_KEYWORDS: dict[str, list[str]] = {
     "ai_testing": [
-        "ai", "ml", "machine learning", "test generation", "copilot",
-        "llm", "generative", "ai-powered", "ai testing",
+        "ai",
+        "ml",
+        "machine learning",
+        "test generation",
+        "copilot",
+        "llm",
+        "generative",
+        "ai-powered",
+        "ai testing",
     ],
     "security": [
-        "security", "vulnerability", "devsecops", "sast", "dast", "owasp",
-        "penetration", "supply-chain", "exploit", "cve",
+        "security",
+        "vulnerability",
+        "devsecops",
+        "sast",
+        "dast",
+        "owasp",
+        "penetration",
+        "supply-chain",
+        "exploit",
+        "cve",
     ],
     "devops": [
-        "devops", "ci/cd", "cicd", "deployment", "pipeline", "gitops",
-        "docker", "kubernetes", "release engineering", "continuous delivery",
+        "devops",
+        "ci/cd",
+        "cicd",
+        "deployment",
+        "pipeline",
+        "gitops",
+        "docker",
+        "kubernetes",
+        "release engineering",
+        "continuous delivery",
     ],
     "platform_engineering": [
-        "platform engineering", "internal developer platform", "idp",
-        "backstage", "paved path", "golden path", "developer portal",
+        "platform engineering",
+        "internal developer platform",
+        "idp",
+        "backstage",
+        "paved path",
+        "golden path",
+        "developer portal",
     ],
     "observability": [
-        "observability", "opentelemetry", "distributed tracing", "tracing",
-        "logging", "metrics", "slo", "sla", "alerting", "monitoring",
+        "observability",
+        "opentelemetry",
+        "distributed tracing",
+        "tracing",
+        "logging",
+        "metrics",
+        "slo",
+        "sla",
+        "alerting",
+        "monitoring",
     ],
     "developer_experience": [
-        "developer experience", "dx", "developer productivity", "onboarding",
-        "cognitive load", "inner loop", "developer satisfaction", "devex",
+        "developer experience",
+        "dx",
+        "developer productivity",
+        "onboarding",
+        "cognitive load",
+        "inner loop",
+        "developer satisfaction",
+        "devex",
     ],
     "software_architecture": [
-        "architecture", "microservices", "monolith", "design pattern",
-        "technical debt", "refactoring", "modular", "domain-driven",
+        "architecture",
+        "microservices",
+        "monolith",
+        "design pattern",
+        "technical debt",
+        "refactoring",
+        "modular",
+        "domain-driven",
     ],
     "quality_economics": [
-        "roi", "cost", "economics", "budget", "maintenance cost",
-        "investment", "total cost", "productivity", "velocity",
+        "roi",
+        "cost",
+        "economics",
+        "budget",
+        "maintenance cost",
+        "investment",
+        "total cost",
+        "productivity",
+        "velocity",
     ],
     "test_automation": [
-        "test automation", "flaky test", "test suite", "playwright", "cypress",
-        "selenium", "shift-left", "shift-right", "e2e", "unit test",
+        "test automation",
+        "flaky test",
+        "test suite",
+        "playwright",
+        "cypress",
+        "selenium",
+        "shift-left",
+        "shift-right",
+        "e2e",
+        "unit test",
     ],
 }
 
 # Content Intelligence: real blog performance data from GA4 ETL (ADR-0007)
-from content_intelligence import get_performance_context
+from content_intelligence import get_performance_context  # noqa: E402
 
 # Import unified LLM client
-from llm_client import call_llm, create_llm_client
+from llm_client import call_llm, create_llm_client  # noqa: E402
 
 _scout_prompts = _load_scout_prompts()
 SCOUT_AGENT_PROMPT = _scout_prompts["scout"]
@@ -109,9 +183,7 @@ def classify_topic_theme(topic: dict) -> str:
     theme_scores: dict[str, int] = {}
     for theme, keywords in THEME_KEYWORDS.items():
         score = sum(
-            1
-            for kw in keywords
-            if re.search(r"\b" + re.escape(kw) + r"\b", text)
+            1 for kw in keywords if re.search(r"\b" + re.escape(kw) + r"\b", text)
         )
         if score > 0:
             theme_scores[theme] = score
@@ -180,15 +252,29 @@ def create_client():
     return create_llm_client()
 
 
-def scout_topics(client, focus_area: str = None) -> list:
+def scout_topics(
+    client,
+    focus_area: str = None,
+    *,
+    allow_empty_archive: bool = False,
+) -> list:
     """
     Scout for high-value topics.
 
     Args:
         focus_area: Optional filter (e.g., "test automation", "AI", "performance")
+        allow_empty_archive: If False (default), raise RuntimeError when the
+            `published_articles` ChromaDB collection is missing or empty. This
+            fail-closed behavior prevents publishing dedup-blind (issue #237).
+            Set to True only for bootstrap runs before any articles exist.
 
     Returns:
-        List of scored topic recommendations
+        List of scored topic recommendations, filtered against the
+        published_articles archive (near-duplicates removed).
+
+    Raises:
+        RuntimeError: If the ChromaDB archive is unavailable or empty and
+            `allow_empty_archive` is False.
     """
     print("🔭 Topic Scout Agent: Scanning the landscape...\n")
 
@@ -263,6 +349,33 @@ def scout_topics(client, focus_area: str = None) -> list:
     # Sort by score
     topics.sort(key=lambda x: x.get("total_score", 0), reverse=True)
 
+    # Deduplicate against the published-articles archive (issue #237).
+    # Fail-closed: if the archive is unavailable or empty, abort rather
+    # than publish dedup-blind. Callers can opt out via allow_empty_archive.
+    print("\n   Running dedup check against published_articles archive...")
+    deduplicator = TopicDeduplicator()
+    archive_ok = (
+        deduplicator.collection is not None and deduplicator.collection.count() > 0
+    )
+    if not archive_ok:
+        msg = (
+            "TopicDeduplicator archive unavailable or empty — refusing to "
+            "publish dedup-blind. Run scripts/index_published_articles.py "
+            "to backfill the published_articles collection, or re-run with "
+            "TOPIC_SCOUT_ALLOW_EMPTY_ARCHIVE=1 for a bootstrap run."
+        )
+        if not allow_empty_archive:
+            raise RuntimeError(msg)
+        logger.warning("%s (allow_empty_archive=True, proceeding)", msg)
+
+    kept, rejected = deduplicator.filter_topics(topics)
+    if rejected:
+        print(
+            f"   🚫 Dropped {len(rejected)} near-duplicate topic(s) "
+            f"against the published archive."
+        )
+    topics = kept
+
     print(f"\n✅ Found {len(topics)} high-value topics:\n")
     for i, t in enumerate(topics, 1):
         score = t.get("total_score", 0)
@@ -301,7 +414,15 @@ def main():
     # Optional focus area from environment
     focus = os.environ.get("FOCUS_AREA", "").strip()
 
-    topics = scout_topics(client, focus if focus else None)
+    # Bootstrap escape hatch for dedup fail-closed (issue #237). Only set
+    # this for the very first run, before any articles exist in the archive.
+    allow_empty = bool(os.environ.get("TOPIC_SCOUT_ALLOW_EMPTY_ARCHIVE", "").strip())
+
+    topics = scout_topics(
+        client,
+        focus if focus else None,
+        allow_empty_archive=allow_empty,
+    )
 
     if topics:
         # Save to queue

--- a/tests/test_topic_scout.py
+++ b/tests/test_topic_scout.py
@@ -110,6 +110,23 @@ def mock_llm_response_topics(sample_topics) -> str:
 
 
 @pytest.fixture
+def mock_dedup_passthrough():
+    """Mock TopicDeduplicator that passes all topics through.
+
+    Simulates a non-empty published_articles archive (count=19) and
+    returns the input topics unchanged from filter_topics(). Use this
+    in tests that don't care about dedup logic — it satisfies the
+    fail-closed check added for issue #237 without rejecting anything.
+    """
+    with patch("topic_scout.TopicDeduplicator") as MockDedup:
+        instance = MockDedup.return_value
+        instance.collection = Mock()
+        instance.collection.count = Mock(return_value=19)
+        instance.filter_topics = Mock(side_effect=lambda topics: (topics, []))
+        yield instance
+
+
+@pytest.fixture
 def mock_llm_client(mock_llm_response_trends, mock_llm_response_topics):
     """Create mock LLM client with realistic responses.
 
@@ -144,7 +161,9 @@ def mock_llm_client(mock_llm_response_trends, mock_llm_response_topics):
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-def test_scout_topics_success(mock_llm_client, sample_topics, capsys):
+def test_scout_topics_success(
+    mock_llm_client, mock_dedup_passthrough, sample_topics, capsys
+):
     """Test scout_topics() with successful API responses.
 
     Validates:
@@ -177,7 +196,9 @@ def test_scout_topics_success(mock_llm_client, sample_topics, capsys):
     assert "[23/25]" in captured.out
 
 
-def test_scout_topics_with_focus_area(mock_llm_client, sample_topics):
+def test_scout_topics_with_focus_area(
+    mock_llm_client, mock_dedup_passthrough, sample_topics
+):
     """Test scout_topics() with focus_area parameter.
 
     Validates:
@@ -199,7 +220,7 @@ def test_scout_topics_with_focus_area(mock_llm_client, sample_topics):
     assert len(topics) == 2
 
 
-def test_scout_topics_empty_results(mock_llm_client):
+def test_scout_topics_empty_results(mock_llm_client, mock_dedup_passthrough):
     """Test scout_topics() when LLM returns no valid topics.
 
     Validates:
@@ -220,7 +241,7 @@ def test_scout_topics_empty_results(mock_llm_client):
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-def test_scout_topics_json_parse_error(mock_llm_client, capsys):
+def test_scout_topics_json_parse_error(mock_llm_client, mock_dedup_passthrough, capsys):
     """Test scout_topics() with malformed JSON response.
 
     Validates:
@@ -241,7 +262,7 @@ def test_scout_topics_json_parse_error(mock_llm_client, capsys):
     assert "parse error" in captured.out or "Could not parse" in captured.out
 
 
-def test_scout_topics_no_json_array(mock_llm_client, capsys):
+def test_scout_topics_no_json_array(mock_llm_client, mock_dedup_passthrough, capsys):
     """Test scout_topics() when response has no JSON array.
 
     Validates:
@@ -275,7 +296,7 @@ def test_scout_topics_api_exception(mock_llm_client):
         scout_topics(mock_client)
 
 
-def test_scout_topics_partial_json(mock_llm_client):
+def test_scout_topics_partial_json(mock_llm_client, mock_dedup_passthrough):
     """Test scout_topics() with incomplete topic objects.
 
     Validates:
@@ -293,6 +314,101 @@ def test_scout_topics_partial_json(mock_llm_client):
     assert len(topics) == 1
     assert topics[0]["topic"] == "Test"
     assert topics[0]["total_score"] == 15
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# TESTS: Issue #237 — Dedup bypass regression guard
+#
+# These tests pin the behavior added to scout_topics() to fix the dedup
+# bypass bug: topic_scout must run TopicDeduplicator.filter_topics() against
+# the published_articles archive AND fail-closed when that archive is
+# unavailable or empty (with an explicit allow_empty_archive opt-out for
+# bootstrap runs). See issue #237.
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def test_scout_topics_runs_filter_topics(mock_llm_client, mock_dedup_passthrough):
+    """scout_topics() must call TopicDeduplicator.filter_topics() on every run."""
+    mock_client, call_llm_side_effect = mock_llm_client
+
+    with patch("topic_scout.call_llm", side_effect=call_llm_side_effect):
+        scout_topics(mock_client)
+
+    assert mock_dedup_passthrough.filter_topics.called, (
+        "scout_topics() must invoke TopicDeduplicator.filter_topics() — "
+        "skipping dedup lets near-duplicate topics reach the pipeline."
+    )
+
+
+def test_scout_topics_drops_rejected_duplicates(mock_llm_client, sample_topics):
+    """Topics rejected by filter_topics() must not appear in the returned list."""
+    mock_client, call_llm_side_effect = mock_llm_client
+
+    # Mock dedup to reject the first topic and keep the second.
+    with (
+        patch("topic_scout.TopicDeduplicator") as MockDedup,
+        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+    ):
+        instance = MockDedup.return_value
+        instance.collection = Mock()
+        instance.collection.count = Mock(return_value=19)
+        instance.filter_topics = Mock(
+            side_effect=lambda topics: (
+                [t for t in topics if t["topic"] != "The AI Testing Paradox"],
+                [t for t in topics if t["topic"] == "The AI Testing Paradox"],
+            )
+        )
+        topics = scout_topics(mock_client)
+
+    returned_titles = {t["topic"] for t in topics}
+    assert "The AI Testing Paradox" not in returned_titles
+    assert "Flaky Tests: The Hidden Tax" in returned_titles
+
+
+def test_scout_topics_fail_closed_when_collection_missing(mock_llm_client):
+    """Missing ChromaDB collection must raise RuntimeError by default."""
+    mock_client, call_llm_side_effect = mock_llm_client
+
+    with (
+        patch("topic_scout.TopicDeduplicator") as MockDedup,
+        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+    ):
+        instance = MockDedup.return_value
+        instance.collection = None  # ChromaDB unavailable
+        with pytest.raises(RuntimeError, match="archive unavailable or empty"):
+            scout_topics(mock_client)
+
+
+def test_scout_topics_fail_closed_when_collection_empty(mock_llm_client):
+    """Empty published_articles collection must raise RuntimeError by default."""
+    mock_client, call_llm_side_effect = mock_llm_client
+
+    with (
+        patch("topic_scout.TopicDeduplicator") as MockDedup,
+        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+    ):
+        instance = MockDedup.return_value
+        instance.collection = Mock()
+        instance.collection.count = Mock(return_value=0)
+        with pytest.raises(RuntimeError, match="archive unavailable or empty"):
+            scout_topics(mock_client)
+
+
+def test_scout_topics_allow_empty_archive_override(mock_llm_client, sample_topics):
+    """allow_empty_archive=True must downgrade empty archive to a warning and proceed."""
+    mock_client, call_llm_side_effect = mock_llm_client
+
+    with (
+        patch("topic_scout.TopicDeduplicator") as MockDedup,
+        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+    ):
+        instance = MockDedup.return_value
+        instance.collection = Mock()
+        instance.collection.count = Mock(return_value=0)
+        instance.filter_topics = Mock(side_effect=lambda topics: (topics, []))
+        topics = scout_topics(mock_client, allow_empty_archive=True)
+
+    assert len(topics) == 2  # sample_topics pass through untouched
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -533,7 +649,12 @@ def test_create_client_propagates_exceptions():
 
 
 def test_main_success_flow(
-    mock_llm_client, sample_topics, tmp_path, monkeypatch, capsys
+    mock_llm_client,
+    mock_dedup_passthrough,
+    sample_topics,
+    tmp_path,
+    monkeypatch,
+    capsys,
 ):
     """Test main() executes full scout workflow.
 
@@ -565,7 +686,9 @@ def test_main_success_flow(
     assert "The AI Testing Paradox" in captured.out
 
 
-def test_main_with_focus_area(mock_llm_client, sample_topics, tmp_path, monkeypatch):
+def test_main_with_focus_area(
+    mock_llm_client, mock_dedup_passthrough, sample_topics, tmp_path, monkeypatch
+):
     """Test main() respects FOCUS_AREA environment variable.
 
     Validates:
@@ -590,7 +713,7 @@ def test_main_with_focus_area(mock_llm_client, sample_topics, tmp_path, monkeypa
 
 
 def test_main_github_actions_output(
-    mock_llm_client, sample_topics, tmp_path, monkeypatch
+    mock_llm_client, mock_dedup_passthrough, sample_topics, tmp_path, monkeypatch
 ):
     """Test main() writes GitHub Actions output file.
 
@@ -783,7 +906,7 @@ def test_trend_research_prompt_structure():
 # ═══════════════════════════════════════════════════════════════════════════
 
 
-def test_scout_topics_single_topic(mock_llm_client):
+def test_scout_topics_single_topic(mock_llm_client, mock_dedup_passthrough):
     """Test scout_topics() with single topic (edge case).
 
     Validates:
@@ -801,7 +924,9 @@ def test_scout_topics_single_topic(mock_llm_client):
     assert len(topics) == 1
 
 
-def test_scout_topics_unsorted_input(mock_llm_client, sample_topics):
+def test_scout_topics_unsorted_input(
+    mock_llm_client, mock_dedup_passthrough, sample_topics
+):
     """Test scout_topics() sorts topics by total_score.
 
     Validates:
@@ -882,7 +1007,7 @@ def test_scout_topics_network_timeout(mock_llm_client):
 
 
 def test_performance_context_injected_into_scout_prompt(
-    mock_llm_client, monkeypatch
+    mock_llm_client, mock_dedup_passthrough, monkeypatch
 ):
     """Performance context from content_intelligence must appear in the scout prompt.
 
@@ -916,7 +1041,7 @@ def test_performance_context_injected_into_scout_prompt(
 
 
 def test_performance_context_fallback_when_db_missing(
-    mock_llm_client, monkeypatch
+    mock_llm_client, mock_dedup_passthrough, monkeypatch
 ):
     """When content_intelligence reports no data, scout must still run.
 
@@ -941,7 +1066,7 @@ def test_performance_context_fallback_when_db_missing(
 
 
 def test_scout_prompt_explicitly_references_performance_data(
-    mock_llm_client, monkeypatch
+    mock_llm_client, mock_dedup_passthrough, monkeypatch
 ):
     """The scout prompt must tell the LLM to *use* the performance data.
 
@@ -965,7 +1090,7 @@ def test_scout_prompt_explicitly_references_performance_data(
 
 
 def test_get_performance_context_called_once_per_scout_run(
-    mock_llm_client, monkeypatch
+    mock_llm_client, mock_dedup_passthrough, monkeypatch
 ):
     """Verify the feedback loop query happens exactly once per scout invocation."""
     mock_client, call_llm_side_effect = mock_llm_client
@@ -1208,7 +1333,9 @@ def _make_topics_with_theme(theme: str, count: int, start_score: int = 20) -> li
     ]
 
 
-def test_scout_topics_diversity_check_triggers_regeneration(capsys):
+def test_scout_topics_diversity_check_triggers_regeneration(
+    mock_dedup_passthrough, capsys
+):
     """When initial topics fail diversity, a 2nd LLM call is made with a diversity hint."""
     mock_client = Mock()
 
@@ -1235,7 +1362,9 @@ def test_scout_topics_diversity_check_triggers_regeneration(capsys):
         ]
     )
 
-    with patch("topic_scout.call_llm", side_effect=lambda *a, **kw: next(call_responses)) as mock_call:
+    with patch(
+        "topic_scout.call_llm", side_effect=lambda *a, **kw: next(call_responses)
+    ) as mock_call:
         topics = scout_topics(mock_client)
 
     # Three LLM calls: trends + initial topics + regeneration
@@ -1253,7 +1382,7 @@ def test_scout_topics_diversity_check_triggers_regeneration(capsys):
     assert "Diversity check failed" in captured.out
 
 
-def test_scout_topics_diversity_check_skipped_for_two_topics():
+def test_scout_topics_diversity_check_skipped_for_two_topics(mock_dedup_passthrough):
     """Diversity check is not applied when fewer than 3 topics are returned."""
     mock_client = Mock()
     # Both topics share the same theme — normally a violation, but too few to check
@@ -1270,7 +1399,7 @@ def test_scout_topics_diversity_check_skipped_for_two_topics():
     assert len(topics) == 2
 
 
-def test_scout_topics_diversity_passes_no_extra_call():
+def test_scout_topics_diversity_passes_no_extra_call(mock_dedup_passthrough):
     """When topics are diverse from the first try, no regeneration call is made."""
     mock_client = Mock()
     diverse = (
@@ -1341,7 +1470,9 @@ def test_scout_prompt_includes_software_architecture_category():
 
 def test_scout_prompt_includes_diversity_requirement():
     """The scout prompt must instruct the LLM to spread topics across categories."""
-    assert "DIVERSITY" in SCOUT_AGENT_PROMPT or "diversity" in SCOUT_AGENT_PROMPT.lower()
+    assert (
+        "DIVERSITY" in SCOUT_AGENT_PROMPT or "diversity" in SCOUT_AGENT_PROMPT.lower()
+    )
 
 
 def test_theme_keywords_covers_all_required_themes():


### PR DESCRIPTION
## Summary
- `scripts/topic_scout.py` now runs `TopicDeduplicator.filter_topics()` on every `scout_topics()` call, dropping near-duplicate topics before they reach `content_queue.json`.
- **Fail-closed**: if the `published_articles` ChromaDB collection is unavailable or empty, raises `RuntimeError` instead of silently publishing dedup-blind. Override with `TOPIC_SCOUT_ALLOW_EMPTY_ARCHIVE=1` for bootstrap runs.
- Fixes `arch-review` pre-commit hook that used bare `python` (now `.venv/bin/python`), unblocking all commits on machines without `python` on PATH.

Closes #237

## Test plan
- [ ] 70/70 `tests/test_topic_scout.py` pass (verified locally).
- [ ] 5 new regression tests: `filter_topics` invocation, reject propagation, fail-closed (collection None), fail-closed (count==0), `allow_empty_archive` override.
- [ ] 85 related tests in `test_topic_scout_reproducibility.py` + `test_topic_deduplicator.py` pass.
- [ ] Pre-push hook has 23 pre-existing failures on `main` tracked in #241 (unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)