### PR TITLE
fix: resolve 23 pre-existing test failures blocking pre-push hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,7 +85,7 @@ repos:
           ADR-002 (direct LLM imports), unprotected json.loads, hardcoded
           secrets, and print() used for error reporting.
           Fails commit if error-level violations are found.
-        entry: python scripts/pre_commit_arch_check.py
+        entry: .venv/bin/python scripts/pre_commit_arch_check.py
         language: system
         types: [python]
         pass_filenames: true

--- a/tests/test_article_archive.py
+++ b/tests/test_article_archive.py
@@ -77,6 +77,7 @@ except ImportError:
 # Helper: create an EphemeralClient for isolated in-memory testing
 # ---------------------------------------------------------------------------
 
+
 def _ephemeral_archive() -> ArticleArchive:
     """Return an ArticleArchive backed by an in-memory EphemeralClient."""
     try:
@@ -94,6 +95,7 @@ def _ephemeral_archive() -> ArticleArchive:
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture()
 def archive() -> ArticleArchive:
@@ -220,17 +222,17 @@ class TestIndexArticle:
     """Tests for the index_article method."""
 
     def test_index_returns_doc_id(self, archive: ArticleArchive) -> None:
-        """index_article returns a non-empty document ID."""
-        doc_id = archive.index_article(
+        """index_article returns a result dict with a non-empty document ID."""
+        result = archive.index_article(
             title="Test Article",
             thesis="This is the thesis.",
-            summary="Short summary.",
             categories="testing",
             date="2026-01-01",
             file_path="_posts/2026-01-01-test.md",
         )
-        assert doc_id
-        assert isinstance(doc_id, str)
+        assert result["success"] is True
+        assert result["id"]
+        assert isinstance(result["id"], str)
 
     def test_index_increments_count(self, archive: ArticleArchive) -> None:
         """Indexing an article increases the collection count."""
@@ -238,7 +240,6 @@ class TestIndexArticle:
         archive.index_article(
             title="Article A",
             thesis="Thesis A.",
-            summary="Summary A.",
             categories="a",
             date="2026-01-01",
             file_path="_posts/a.md",
@@ -251,7 +252,6 @@ class TestIndexArticle:
             archive.index_article(
                 title=f"Article {i}",
                 thesis=f"Thesis {i}.",
-                summary=f"Summary {i}.",
                 categories="testing",
                 date=f"2026-01-0{i + 1}",
                 file_path=f"_posts/article-{i}.md",
@@ -263,7 +263,6 @@ class TestIndexArticle:
         kwargs = {
             "title": "Same Article",
             "thesis": "Same thesis.",
-            "summary": "Same summary.",
             "categories": "testing",
             "date": "2026-01-01",
             "file_path": "_posts/same.md",
@@ -272,19 +271,19 @@ class TestIndexArticle:
         archive.index_article(**kwargs)
         assert archive.count() == 1
 
-    def test_index_raises_when_unavailable(self) -> None:
-        """index_article raises RuntimeError when ChromaDB is not available."""
+    def test_index_returns_failure_when_unavailable(self) -> None:
+        """index_article returns a failure dict when ChromaDB is not available."""
         with patch("scripts.article_archive.CHROMADB_AVAILABLE", False):
             arc = ArticleArchive()
-        with pytest.raises(RuntimeError):
-            arc.index_article(
-                title="X",
-                thesis="T",
-                summary="S",
-                categories="c",
-                date="2026-01-01",
-                file_path="x.md",
-            )
+        result = arc.index_article(
+            title="X",
+            thesis="T",
+            categories="c",
+            date="2026-01-01",
+            file_path="x.md",
+        )
+        assert result["success"] is False
+        assert "error" in result
 
 
 # ---------------------------------------------------------------------------
@@ -301,7 +300,6 @@ class TestFindSimilarTopics:
         archive.index_article(
             title="AI Testing Quality Illusion",
             thesis="AI test generation creates coverage without catching defects.",
-            summary="500-team survey shows divergence between coverage and bug detection.",
             categories="testing,ai",
             date="2026-01-01",
             file_path="_posts/2026-01-01-ai-testing.md",
@@ -309,7 +307,6 @@ class TestFindSimilarTopics:
         archive.index_article(
             title="Platform Engineering Cognitive Load",
             thesis="Internal developer platforms reduce cognitive overhead by 40 %.",
-            summary="Research across 200 organisations demonstrates productivity gains.",
             categories="platform-engineering",
             date="2026-02-10",
             file_path="_posts/2026-02-10-platform.md",
@@ -322,9 +319,18 @@ class TestFindSimilarTopics:
 
     def test_result_has_required_keys(self, populated_archive: ArticleArchive) -> None:
         """Each result dict contains the required schema keys."""
-        results = populated_archive.find_similar_topics("AI test quality", threshold=0.0)
+        results = populated_archive.find_similar_topics(
+            "AI test quality", threshold=0.0
+        )
         assert results  # at least one result
-        required_keys = {"title", "thesis", "date", "categories", "file_path", "similarity"}
+        required_keys = {
+            "title",
+            "thesis",
+            "date",
+            "categories",
+            "file_path",
+            "similarity",
+        }
         for result in results:
             assert required_keys.issubset(result.keys())
 
@@ -342,7 +348,9 @@ class TestFindSimilarTopics:
         self, populated_archive: ArticleArchive
     ) -> None:
         """threshold=0 returns all documents (up to n_results)."""
-        results = populated_archive.find_similar_topics("x", threshold=0.0, n_results=10)
+        results = populated_archive.find_similar_topics(
+            "x", threshold=0.0, n_results=10
+        )
         assert len(results) == 2
 
     def test_n_results_limits_output(self, populated_archive: ArticleArchive) -> None:
@@ -360,9 +368,7 @@ class TestFindSimilarTopics:
         similarities = [r["similarity"] for r in results]
         assert similarities == sorted(similarities, reverse=True)
 
-    def test_empty_query_returns_empty(
-        self, populated_archive: ArticleArchive
-    ) -> None:
+    def test_empty_query_returns_empty(self, populated_archive: ArticleArchive) -> None:
         results = populated_archive.find_similar_topics("   ")
         assert results == []
 
@@ -479,7 +485,7 @@ class TestCount:
         assert archive.count() == 0
 
     def test_count_after_indexing(self, archive: ArticleArchive) -> None:
-        archive.index_article("T", "Th", "S", "c", "2026-01-01", "f.md")
+        archive.index_article("T", "Th", "2026-01-01", "c", "f.md")
         assert archive.count() == 1
 
     def test_count_returns_zero_when_unavailable(self) -> None:

--- a/tests/test_economist_agent.py
+++ b/tests/test_economist_agent.py
@@ -217,6 +217,10 @@ class TestRunResearchAgent:
                 "agents.research_agent.ResearchAgent._gather_arxiv_research",
                 return_value=None,
             ),
+            patch(
+                "agents.research_agent.ResearchAgent._gather_web_research",
+                return_value=None,
+            ),
         ):
             # Return the properly structured mock response
             mock_call_llm.return_value = json.dumps(sample_research_output)
@@ -308,6 +312,10 @@ class TestRunResearchAgent:
             patch("agents.research_agent.review_agent_output") as mock_review,
             patch(
                 "agents.research_agent.ResearchAgent._gather_arxiv_research",
+                return_value=None,
+            ),
+            patch(
+                "agents.research_agent.ResearchAgent._gather_web_research",
                 return_value=None,
             ),
         ):

--- a/tests/test_mcp_servers/test_style_memory_server.py
+++ b/tests/test_mcp_servers/test_style_memory_server.py
@@ -42,6 +42,7 @@ def _get_shared_client() -> tuple[object, object]:
             import hashlib
 
             import chromadb
+            import chromadb.api.shared_system_client
             from chromadb.api.types import Documents, Embeddings
             from chromadb.utils.embedding_functions import EmbeddingFunction
 
@@ -62,6 +63,7 @@ def _get_shared_client() -> tuple[object, object]:
                         result.append(vec)
                     return result
 
+            chromadb.api.shared_system_client.SharedSystemClient.clear_system_cache()
             _chroma_client = chromadb.EphemeralClient()
             _fake_ef = _FakeEmbedding()
         except ImportError:


### PR DESCRIPTION
## Summary
- **test_article_archive** (13 failures): removed stale `summary=` kwarg from all `index_article()` calls, fixed return-type assertion (dict not string), fixed unavailability assertion (returns failure dict, doesn't raise).
- **test_economist_agent** (2 failures): mocked `_gather_web_research` alongside `_gather_arxiv_research` so live Serper API calls don't inject unexpected `web_research` key.
- **test_style_memory_server** (15 failures in full suite): cleared ChromaDB `SharedSystemClient` cache before creating `EphemeralClient` to avoid singleton collision with `PersistentClient` from earlier tests.
- Also includes arch-review hook fix (`python` -> `.venv/bin/python`), same as PR #242.

Full suite: **1593 passed, 0 failed**, 1 skipped (4m33s).

Closes #241

## Test plan
- [x] `tests/test_article_archive.py` — 37/37 passed
- [x] `tests/test_economist_agent.py` — 34/34 passed
- [x] `tests/test_mcp_servers/test_style_memory_server.py` — 19/19 passed
- [x] Full suite (`pytest tests/`) — 1593/1593 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)