### PR TITLE
fix: deploy_to_blog copies featured image PNG+WebP to blog assets

### DIFF
--- a/scripts/deploy_to_blog.py
+++ b/scripts/deploy_to_blog.py
@@ -117,8 +117,10 @@ def main():
     # Setup blog directories
     posts_dir = blog_dir / "_posts"
     assets_dir = blog_dir / "assets" / "charts"
+    images_dir = blog_dir / "assets" / "images"
     posts_dir.mkdir(parents=True, exist_ok=True)
     assets_dir.mkdir(parents=True, exist_ok=True)
+    images_dir.mkdir(parents=True, exist_ok=True)
 
     # Determine the deploy date and rename article file accordingly
     deploy_date = datetime.now().strftime("%Y-%m-%d")
@@ -148,6 +150,28 @@ def main():
         target_chart = assets_dir / f"{slug}.png"
         print(f"📊 Copying chart: {chart_file} → {target_chart}")
         run_command(f"cp {chart_file} {target_chart}")
+
+    # Copy featured image (PNG + WebP) — required by responsive-image.html include
+    # The blog's _includes/responsive-image.html always emits a <picture><source srcset="...webp">
+    # for every .png, so htmlproofer will fail if the .webp is absent.
+    featured_image_dir = Path("output") / "posts" / "images"
+    featured_png = featured_image_dir / f"{slug}.png"
+    if featured_png.exists():
+        target_png = images_dir / f"{slug}.png"
+        shutil.copy2(featured_png, target_png)
+        print(f"🖼️  Copied featured image: {featured_png} → {target_png}")
+
+        # Generate WebP alongside PNG
+        target_webp = images_dir / f"{slug}.webp"
+        try:
+            from PIL import Image  # type: ignore
+            img = Image.open(target_png)
+            img.save(str(target_webp), "WEBP", quality=85)
+            print(f"🖼️  Generated webp: {target_webp}")
+        except ImportError:
+            print("⚠️  Pillow not available — skipping webp generation (htmlproofer may fail)")
+    else:
+        print(f"   ℹ No featured image at {featured_png} — skipping image copy")
 
     # -----------------------------------------------------------------------
     # Pre-deploy validation gate


### PR DESCRIPTION
Root cause of htmlproofer CI failure on oviney/blog (PR #782 was a band-aid).

**Problem:** `_includes/responsive-image.html` always emits `<picture><source srcset="...webp">` for every `.png` featured image. `deploy_to_blog.py` copied charts (`output/charts/`) to `assets/charts/` but never touched featured images at all. So every deployed article was missing its `assets/images/{slug}.png` and `assets/images/{slug}.webp`, causing htmlproofer to fail on every page showing the article card.

**Fix:**
1. Create `assets/images/` directory in the cloned blog repo
2. Copy `output/posts/images/{slug}.png` → `assets/images/{slug}.png`
3. Auto-generate `assets/images/{slug}.webp` via Pillow (quality 85)

Now every deployed article ships with both image variants so htmlproofer passes.