### PR TITLE
fix: integration test fixtures for frontmatter schema gate

### DIFF
--- a/tests/test_economist_flow.py
+++ b/tests/test_economist_flow.py
@@ -30,7 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from src.economist_agents.flow import EconomistContentFlow
 
 # Valid article stub for tests that need to pass schema validation
-_VALID_ARTICLE = '---\nlayout: post\ntitle: "Test"\ndate: 2026-04-04\ncategories: ["QE"]\nimage: /assets/images/test.png\n---\n\nBody'
+_VALID_ARTICLE = '---\nlayout: post\ntitle: "Test"\ndate: 2026-04-04\nauthor: "The Economist"\ndescription: "Test article for quality gate validation"\ncategories: ["quality-engineering"]\nimage: /assets/images/test.png\n---\n\nBody'
 
 
 @pytest.mark.skipif(

--- a/tests/test_production_integration.py
+++ b/tests/test_production_integration.py
@@ -95,7 +95,7 @@ class TestFlowOrchestration:
         flow = EconomistContentFlow()
         # quality_gate expects dict with valid frontmatter (schema gate fires first)
         article_draft = {
-            "article": '---\nlayout: post\ntitle: "AI Testing"\ndate: 2026-04-04\ncategories: ["QE"]\nimage: /assets/images/test.png\ndescription: "AI testing overview"\n---\n\nHigh quality content...',
+            "article": '---\nlayout: post\ntitle: "AI Testing"\ndate: 2026-04-04\nauthor: "The Economist"\ncategories: ["quality-engineering"]\nimage: /assets/images/test.png\ndescription: "AI testing overview"\n---\n\nHigh quality content...',
             "chart_path": None,
             "word_count": 100,
         }


### PR DESCRIPTION
## Summary
4 integration tests were failing because the quality gate now validates frontmatter schema (author, description, kebab-case categories) before running Stage4Crew. Test article fixtures lacked these fields.

Fix: added `author`, `description`, and kebab-case `categories` to fixtures.

Closes #266

## Test plan
- [x] 31/31 integration tests pass (test_economist_flow.py + test_production_integration.py)
- [x] Full suite: 1677 tests, 0 failures expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)