### PR TITLE
fix(#266): fix 5 failing integration tests + add agent contract tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Agent state
+.claude/
+.gemini/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,7 +13,7 @@ warn_no_return = True
 check_untyped_defs = False
 
 # Exclude directories
-exclude = (\.venv|\.git|__pycache__|output|tests)
+exclude = (\.venv|\.git|__pycache__|output|tests|\.gemini|\.claude)
 
 # P1 TODO: Re-enable strict checks file-by-file as annotations are added
 # See Issue #XX: Comprehensive type annotation project (611 errors)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -7,6 +7,8 @@
     "**/.pytest_cache",
     "**/.mypy_cache",
     "**/node_modules",
-    "docs"
+    "docs",
+    ".gemini",
+    ".claude"
   ]
 }

--- a/ruff.toml
+++ b/ruff.toml
@@ -18,6 +18,8 @@ exclude = [
     ".pytest_cache",
     ".mypy_cache",
     ".ruff_cache",
+    ".gemini",
+    ".claude",
 ]
 
 [lint]

--- a/tests/test_agent_contracts.py
+++ b/tests/test_agent_contracts.py
@@ -1,0 +1,96 @@
+"""
+Agent Contract Tests
+
+Validates the contracts between pipeline agents:
+- Research → Writer schema contract
+- Citation integrity (no fabricated stats / embedded secrets)
+- FrontmatterSchema validate_article structured result
+"""
+
+
+def test_research_writer_schema_contract():
+    """Writer output must include all required front matter fields."""
+    from scripts.frontmatter_schema import REQUIRED_FIELDS, FrontmatterSchema
+
+    schema = FrontmatterSchema()
+
+    valid_output = (
+        '---\nlayout: post\ntitle: "Test Article"\ndate: 2026-04-14\n'
+        'author: "Ouray Viney"\ncategories: ["quality-engineering"]\n'
+        "image: /assets/images/test-article.png\n"
+        'description: "A test article about quality engineering."\n'
+        "---\n\nContent here."
+    )
+    result = schema.validate_article(valid_output)
+    assert result.is_valid, f"Valid writer output failed schema: {result.errors}"
+
+    for field in REQUIRED_FIELDS:
+        incomplete = valid_output.replace(f"\n{field}:", "\nMISSING_FIELD:")
+        result = schema.validate_article(incomplete)
+        assert not result.is_valid, f"Missing {field} should fail validation"
+        assert any(field in e for e in result.errors), f"Error should mention {field}"
+
+
+def test_citation_integrity_no_fabricated_stats():
+    """Article body should not contain suspicious unattributed statistics."""
+    from scripts.frontmatter_schema import FrontmatterSchema
+
+    schema = FrontmatterSchema()
+
+    with_citation = (
+        '---\nlayout: post\ntitle: "AI Study"\ndate: 2026-04-14\n'
+        'author: "Ouray Viney"\ncategories: ["software-engineering"]\n'
+        "image: /assets/images/ai-study.png\n"
+        'description: "Analysis of AI adoption."\n'
+        "---\n\n"
+        "According to McKinsey's 2024 report, 72% of companies have adopted AI. "
+        "The data shows strong growth."
+    )
+    result = schema.validate_article(with_citation)
+    assert result.is_valid
+
+    with_secret = (
+        '---\nlayout: post\ntitle: "Test"\ndate: 2026-04-14\n'
+        'author: "Ouray Viney"\ncategories: ["test-automation"]\n'
+        "image: /assets/images/test.png\n"
+        'description: "Test post."\n'
+        "---\n\nContent here."
+    )
+    result = schema.validate_article(with_secret)
+    assert result.is_valid
+
+    # The schema surfaces embedded API keys as a warning (not a hard error),
+    # keeping is_valid=True so the pipeline can still route the article — but
+    # the warning must be present so the publisher can review before deploying.
+    with_api_key = (
+        '---\nlayout: post\ntitle: "Test"\ndate: 2026-04-14\n'
+        'author: "Ouray Viney"\ncategories: ["test-automation"]\n'
+        "image: /assets/images/test.png\n"
+        'description: "API key: sk-abcdefghijklmnopqrstuvwxyz123456"\n'
+        "---\n\nContent"
+    )
+    result = schema.validate_article(with_api_key)
+    assert any(
+        "sensitive" in w.lower() or "secret" in w.lower() or "api" in w.lower()
+        for w in result.warnings
+    ), f"Expected sensitive-data warning, got: {result.warnings}"
+
+
+def test_validate_file_returns_structured_result():
+    """validate_article() should return ValidationResult with is_valid, errors, warnings."""
+    from scripts.frontmatter_schema import FrontmatterSchema, ValidationResult
+
+    schema = FrontmatterSchema()
+
+    valid_content = (
+        '---\nlayout: post\ntitle: "Contract Test"\ndate: 2026-04-14\n'
+        'author: "Ouray Viney"\ncategories: ["quality-engineering"]\n'
+        "image: /assets/images/contract-test.png\n"
+        'description: "A contract test article."\n'
+        "---\n\nSome content here."
+    )
+
+    result = schema.validate_article(valid_content)
+    assert isinstance(result, ValidationResult)
+    assert result.is_valid
+    assert result.errors == []

--- a/tests/test_economist_flow.py
+++ b/tests/test_economist_flow.py
@@ -30,7 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from src.economist_agents.flow import EconomistContentFlow
 
 # Valid article stub for tests that need to pass schema validation
-_VALID_ARTICLE = '---\nlayout: post\ntitle: "Test"\ndate: 2026-04-04\nauthor: "The Economist"\ndescription: "Test article for quality gate validation"\ncategories: ["quality-engineering"]\nimage: /assets/images/test.png\n---\n\nBody'
+_VALID_ARTICLE = '---\nlayout: post\ntitle: "Test"\ndate: 2026-04-04\nauthor: "Ouray Viney"\ndescription: "Test article for quality gate validation"\ncategories: ["quality-engineering"]\nimage: /assets/images/test.png\n---\n\nBody'
 
 
 @pytest.mark.skipif(

--- a/tests/test_production_integration.py
+++ b/tests/test_production_integration.py
@@ -34,23 +34,42 @@ class TestFlowOrchestration:
         assert hasattr(flow, "generate_content")
         assert hasattr(flow, "quality_gate")
 
-    @pytest.mark.skipif(
-        not os.environ.get("OPENAI_API_KEY"),
-        reason="OPENAI_API_KEY required for CrewAI agent initialization",
-    )
-    def test_flow_topic_discovery(self):
+    @patch("src.economist_agents.flow.create_llm_client")
+    @patch("src.economist_agents.flow.scout_topics")
+    def test_flow_topic_discovery(self, mock_scout_topics, mock_create_llm_client):
         """Test Flow can discover topics via Stage 1"""
-        # Stage1Crew not yet integrated - test stub implementation
+        mock_create_llm_client.return_value = MagicMock()
+        mock_scout_topics.return_value = [
+            {
+                "topic": "AI in Quality Engineering",
+                "total_score": 90,
+                "hook": "AI transforms QE",
+                "thesis": "AI enables better testing",
+                "data_sources": ["McKinsey 2024"],
+                "contrarian_angle": "Not all teams benefit",
+                "talking_points": ["automation", "coverage"],
+            },
+            {
+                "topic": "Test Automation ROI",
+                "total_score": 85,
+                "hook": "Automation pays off",
+                "thesis": "ROI is measurable",
+                "data_sources": ["Gartner 2024"],
+                "contrarian_angle": "Upfront costs are real",
+                "talking_points": ["cost", "speed"],
+            },
+        ]
+
         flow = EconomistContentFlow()
         result = flow.discover_topics()
 
         assert result is not None
         assert "topics" in result
         assert len(result["topics"]) >= 2
-        # Verify mock data structure
         for topic in result["topics"]:
             assert "topic" in topic
             assert "score" in topic
+        mock_scout_topics.assert_called_once()
 
     @pytest.mark.skip(reason="Stage2Crew not yet implemented in flow.py")
     def test_flow_editorial_review_skip(self):
@@ -95,7 +114,7 @@ class TestFlowOrchestration:
         flow = EconomistContentFlow()
         # quality_gate expects dict with valid frontmatter (schema gate fires first)
         article_draft = {
-            "article": '---\nlayout: post\ntitle: "AI Testing"\ndate: 2026-04-04\nauthor: "The Economist"\ncategories: ["quality-engineering"]\nimage: /assets/images/test.png\ndescription: "AI testing overview"\n---\n\nHigh quality content...',
+            "article": '---\nlayout: post\ntitle: "AI Testing"\ndate: 2026-04-04\nauthor: "Ouray Viney"\ncategories: ["quality-engineering"]\nimage: /assets/images/test.png\ndescription: "AI testing overview"\n---\n\nHigh quality content...',
             "chart_path": None,
             "word_count": 100,
         }


### PR DESCRIPTION
Closes #266

## Changes

- Updated `_VALID_ARTICLE` fixture in test_economist_flow.py: `author: "Ouray Viney"`
- Fixed inline article fixture in test_production_integration.py: `author: "Ouray Viney"`
- Replaced OPENAI_API_KEY-gated `test_flow_topic_discovery` with a properly mocked version using `@patch` for `scout_topics` and `create_llm_client`
- Added `tests/test_agent_contracts.py` with 3 new contract/integrity tests:
  - `test_research_writer_schema_contract`
  - `test_citation_integrity_no_fabricated_stats`
  - `test_validate_file_returns_structured_result`
- Excluded agent IDE directories (.gemini, .claude) from linting tools in `.gitignore`, `mypy.ini`, `pyrightconfig.json`, `ruff.toml`

## Tests verified locally
- tests/test_agent_contracts.py: all 3 pass
- tests/test_frontmatter_schema.py: all 23 pass

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>