### PR TITLE
fix: DALL-E prompt truncation in pipeline + writer regen includes draft (#269 #270)

### DIFF
--- a/agents/writer_agent.py
+++ b/agents/writer_agent.py
@@ -278,11 +278,11 @@ image: {featured_image}
                     ]
                 )
 
-                # Regenerate with fix instructions
+                # Regenerate with fix instructions, passing original draft for context
                 draft = call_llm(
                     self.client,
                     system_prompt + "\n\n" + fix_instructions,
-                    f"Fix the issues and regenerate: {topic}",
+                    f"Fix the issues in this draft and return the complete corrected article:\n\n{draft}",
                     max_tokens=3000,
                 )
                 # Deterministic fix for BUG-028 on regenerated output

--- a/scripts/featured_image_agent.py
+++ b/scripts/featured_image_agent.py
@@ -33,6 +33,9 @@ from typing import Literal
 
 ImageMood = Literal["satirical", "contemplative", "urgent", "ironic", "wry"]
 
+# DALL-E 3 rejects prompts over 4000 characters; use 3900 as a safety margin.
+DALLE_MAX_PROMPT_LENGTH = 3900
+
 # ═══════════════════════════════════════════════════════════════════════════
 # ECONOMIST VISUAL STYLE SPECIFICATION
 # ═══════════════════════════════════════════════════════════════════════════
@@ -158,6 +161,9 @@ not just its topic.
 
 CRITICAL: ZERO text, words, letters, numbers, or symbols in the image.
 """
+
+    if len(prompt) > DALLE_MAX_PROMPT_LENGTH:
+        prompt = prompt[:DALLE_MAX_PROMPT_LENGTH]
 
     return prompt
 

--- a/tests/test_featured_image_agent.py
+++ b/tests/test_featured_image_agent.py
@@ -146,6 +146,17 @@ class TestCreateImagePrompt:
         assert isinstance(result, str)
         assert len(result) > 100  # should be a substantial prompt
 
+    def test_prompt_truncated_to_dalle_max_length(self) -> None:
+        """Prompt must never exceed DALLE_MAX_PROMPT_LENGTH (3900 chars)."""
+        from featured_image_agent import DALLE_MAX_PROMPT_LENGTH
+
+        # Use an extremely long summary to trigger truncation
+        long_summary = "A" * 5000
+        prompt = create_image_prompt(self.TOPIC, long_summary)
+        assert len(prompt) <= DALLE_MAX_PROMPT_LENGTH, (
+            f"Prompt length {len(prompt)} exceeds DALLE_MAX_PROMPT_LENGTH {DALLE_MAX_PROMPT_LENGTH}"
+        )
+
 
 # ===========================================================================
 # generate_featured_image()

--- a/tests/test_writer_agent.py
+++ b/tests/test_writer_agent.py
@@ -266,6 +266,35 @@ class TestWriterAgent:
 
     @patch("agents.writer_agent.call_llm")
     @patch("agents.writer_agent.review_agent_output")
+    def test_regeneration_user_message_includes_draft(
+        self, mock_review, mock_call_llm, mock_client, sample_research_brief
+    ):
+        """Regeneration call must include original draft in user message (fix for #270)."""
+        bad_article = "---\ntitle: Bad\n---\nIn conclusion, game-changer!"
+        good_article = "---\nlayout: post\ntitle: Good\ndate: 2026-01-02\n---\nContent"
+
+        mock_call_llm.side_effect = [bad_article, good_article]
+        mock_review.side_effect = [
+            (False, ["CRITICAL: Article too short", "BANNED: in conclusion"]),
+            (True, []),
+        ]
+
+        agent = WriterAgent(mock_client)
+        agent.write(
+            topic="Security Debt",
+            research_brief=sample_research_brief,
+            current_date="2026-01-02",
+        )
+
+        # Second call is the regeneration; its user message must contain the original draft
+        assert mock_call_llm.call_count == 2
+        regen_user_msg = mock_call_llm.call_args_list[1][0][2]
+        assert bad_article in regen_user_msg, (
+            "Regeneration user message must include original draft so the LLM has content to fix"
+        )
+
+    @patch("agents.writer_agent.call_llm")
+    @patch("agents.writer_agent.review_agent_output")
     def test_write_with_governance_logging(
         self,
         mock_review,


### PR DESCRIPTION
## Summary

Two pipeline crash bugs discovered during a Security pipeline run.

## Bug 1 — DALL-E prompt too long (#269)

**Root cause**: PR #257 truncated DALL-E prompts in `mcp_servers/image_generator_server.py` but left `scripts/featured_image_agent.py` (the actual pipeline code path) unfixed.

**Fix**: Added `DALLE_MAX_PROMPT_LENGTH = 3900` constant and truncation in `create_image_prompt()`.

**Evidence**: Prompt of 4117 chars sent → 400 error; now capped at 3900.

## Bug 2 — Writer regeneration returns empty draft (#270)

**Root cause**: Regeneration user message was `f'Fix the issues and regenerate: {topic}'` — no draft included. LLM returned 9 tokens, `_ensure_frontmatter` got near-empty string, Editor agent crashed with `ValueError: Draft too short`.

**Fix**: User message now includes the original draft: `f'Fix the issues in this draft and return the complete corrected article:\n\n{draft}'`

## Tests

- `test_prompt_truncated_to_dalle_max_length` — verifies 5000-char summary is truncated to ≤3900
- `test_regeneration_user_message_includes_draft` — verifies original draft is in regeneration call

## Closes

Closes #269
Closes #270