### PR TITLE
fix: persist quarantined articles when pipeline fails quality gate

### DIFF
--- a/src/economist_agents/flow.py
+++ b/src/economist_agents/flow.py
@@ -447,12 +447,25 @@ class EconomistContentFlow(Flow):
         print(
             f"   ⚠️  Revision still failing (score: {editorial_score}, issues: {len(critical)})"
         )
+
+        # Persist quarantined article so it can be reviewed/fixed manually.
+        import pathlib
+        import re as _re_q
+
+        slug = _re_q.sub(r"[^a-z0-9]+", "-", edited_article[:80].lower()).strip("-")[:60]
+        quarantine_dir = pathlib.Path("output") / "quarantine"
+        quarantine_dir.mkdir(parents=True, exist_ok=True)
+        quarantine_path = quarantine_dir / f"{datetime.now().strftime('%Y-%m-%d')}-{slug}.md"
+        quarantine_path.write_text(edited_article)
+        print(f"   📄 Quarantined article saved: {quarantine_path}")
+
         return {
             "status": "needs_revision",
             "editorial_score": editorial_score,
             "gates_passed": gates_passed,
             "validation_issues": [i["message"] for i in critical],
             "retry_count": self.state["retry_count"],
+            "quarantine_path": str(quarantine_path),
         }
 
 


### PR DESCRIPTION
## Summary
Failed articles were lost when the pipeline exited with `needs_revision` — only existed in-memory. Now saves to `output/quarantine/<date>-<slug>.md` so they can be reviewed and fixed manually.

## Test plan
- [x] Verified: pipeline run scored 98/100, article saved to `output/quarantine/`, manually fixed 2 issues, deployed to blog (oviney/blog#790)

🤖 Generated with [Claude Code](https://claude.com/claude-code)