### PR TITLE
feat: citation verifier — fetch URLs and confirm stats appear in sources

### DIFF
--- a/agents/research_agent.py
+++ b/agents/research_agent.py
@@ -153,6 +153,19 @@ class ResearchAgent:
         if web_research:
             research_data["web_research"] = web_research
 
+        # Verify citations: fetch URLs and confirm stats appear in source text
+        try:
+            from citation_verifier import verify_citations
+
+            research_data = verify_citations(research_data)
+            cv = research_data.get("citation_verification", {})
+            print(
+                f"   🔍 Citation verification: {cv.get('verified', 0)} verified, "
+                f"{cv.get('failed', 0)} failed"
+            )
+        except ImportError:
+            logger.warning("citation_verifier not available — skipping verification")
+
         # Log metrics
         self._log_metrics(research_data, topic, arxiv_insights, web_research)
 

--- a/scripts/citation_verifier.py
+++ b/scripts/citation_verifier.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Citation Verifier — confirm statistics appear in their cited sources.
+
+Fetches URLs from the Research Agent's ``data_points`` and checks whether
+the claimed statistic actually appears in the source text.  Marks
+unverifiable claims as ``verified: false`` so the Writer can tag them
+``[UNVERIFIED]`` and the publication validator can reject the article.
+
+Usage::
+
+    from scripts.citation_verifier import verify_citations
+
+    research_data = research_agent.research(topic)
+    research_data = verify_citations(research_data)
+    # data_points now have accurate ``verified`` flags
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_FETCH_TIMEOUT = 10
+_MAX_CONTENT_LENGTH = 50_000  # chars — don't read entire books
+
+
+def _fetch_page_text(url: str) -> str | None:
+    """Fetch a URL and return plain text content.
+
+    Returns None on any failure (network, timeout, non-text response).
+    """
+    try:
+        resp = requests.get(
+            url,
+            timeout=_FETCH_TIMEOUT,
+            headers={"User-Agent": "EconomistAgents/1.0 citation-verifier"},
+        )
+        resp.raise_for_status()
+        content_type = resp.headers.get("content-type", "")
+        if "text" not in content_type and "json" not in content_type:
+            logger.info("Skipping non-text URL: %s (%s)", url, content_type)
+            return None
+        return resp.text[:_MAX_CONTENT_LENGTH]
+    except Exception as exc:
+        logger.warning("Failed to fetch %s: %s", url, exc)
+        return None
+
+
+def _normalize(text: str) -> str:
+    """Lowercase, collapse whitespace, strip punctuation for fuzzy matching."""
+    text = text.lower()
+    text = re.sub(r"[^\w\s%.$]", " ", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def _stat_appears_in_text(stat: str, page_text: str) -> bool:
+    """Check whether a statistic appears in the page text.
+
+    Uses fuzzy matching: extracts key numbers/percentages from the stat
+    and checks if they appear near relevant words in the page text.
+    """
+    if not stat or not stat.strip():
+        return False
+
+    norm_page = _normalize(page_text)
+    norm_stat = _normalize(stat)
+
+    # Extract numbers and percentages from the stat — required for verification.
+    # Stats without numbers can't be meaningfully verified against source text.
+    numbers = re.findall(r"\d+(?:\.\d+)?%?", stat)
+    if not numbers:
+        # No numbers in the stat — can't verify numerically
+        return False
+
+    # Check if ALL key numbers appear somewhere in the page
+    for num in numbers:
+        if num not in norm_page:
+            return False
+
+    # Numbers are present — check if at least one contextual word from
+    # the stat also appears near a number (within 200 chars)
+    context_words = [
+        w for w in re.findall(r"[a-z]{4,}", norm_stat) if w not in {"that", "than", "with", "from", "this", "have", "been"}
+    ]
+    if not context_words:
+        return True  # numbers match, no context words to check
+
+    for num in numbers:
+        idx = norm_page.find(num)
+        if idx == -1:
+            continue
+        window = norm_page[max(0, idx - 200) : idx + 200]
+        if any(w in window for w in context_words):
+            return True
+
+    return False
+
+
+def verify_citations(
+    research_data: dict[str, Any],
+    *,
+    fetch_fn: Any = None,
+) -> dict[str, Any]:
+    """Verify that cited statistics appear in their source URLs.
+
+    For each ``data_point`` with a ``url`` field, fetches the page and
+    checks whether the ``stat`` text appears.  Updates ``verified`` to
+    ``False`` for unverifiable claims and adds them to
+    ``unverified_claims``.
+
+    Args:
+        research_data: Output from ``ResearchAgent.research()``.
+        fetch_fn: Optional override for ``_fetch_page_text`` (for testing).
+
+    Returns:
+        The same dict with updated ``verified`` flags and
+        ``unverified_claims`` list.
+    """
+    fetch = fetch_fn or _fetch_page_text
+    data_points = research_data.get("data_points", [])
+    unverified: list[str] = list(research_data.get("unverified_claims", []))
+    verified_count = 0
+    failed_count = 0
+
+    for dp in data_points:
+        url = dp.get("url", "")
+        stat = dp.get("stat", "")
+
+        if not url or not stat:
+            # No URL to verify against — mark unverified
+            if stat and dp.get("verified", True):
+                dp["verified"] = False
+                unverified.append(f"{stat} (no URL to verify)")
+                failed_count += 1
+            continue
+
+        page_text = fetch(url)
+        if page_text is None:
+            # Couldn't fetch — mark unverified but don't penalise
+            # (network issues shouldn't block the pipeline)
+            logger.info("Could not fetch %s — leaving verified=%s", url, dp.get("verified"))
+            continue
+
+        if _stat_appears_in_text(stat, page_text):
+            dp["verified"] = True
+            verified_count += 1
+            logger.info("✅ Verified: '%s' found in %s", stat[:60], url)
+        else:
+            dp["verified"] = False
+            failed_count += 1
+            claim_desc = f"{stat} (not found in {url})"
+            unverified.append(claim_desc)
+            logger.warning("❌ Unverified: '%s' NOT found in %s", stat[:60], url)
+
+    # Also verify headline_stat if it has a URL
+    headline = research_data.get("headline_stat", {})
+    headline_url = headline.get("url", "")
+    headline_stat = headline.get("value", "")
+    if headline_url and headline_stat:
+        page_text = fetch(headline_url)
+        if page_text and not _stat_appears_in_text(headline_stat, page_text):
+            headline["verified"] = False
+            unverified.append(f"HEADLINE: {headline_stat} (not found in {headline_url})")
+            failed_count += 1
+            logger.warning("❌ Headline unverified: '%s'", headline_stat[:60])
+
+    research_data["unverified_claims"] = unverified
+    research_data["citation_verification"] = {
+        "verified": verified_count,
+        "failed": failed_count,
+        "total_checked": verified_count + failed_count,
+    }
+
+    logger.info(
+        "Citation verification: %d verified, %d failed, %d total",
+        verified_count, failed_count, verified_count + failed_count,
+    )
+
+    return research_data

--- a/tests/test_citation_verifier.py
+++ b/tests/test_citation_verifier.py
@@ -1,0 +1,219 @@
+"""Tests for scripts/citation_verifier.py — citation verification against source URLs."""
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from citation_verifier import (
+    _normalize,
+    _stat_appears_in_text,
+    verify_citations,
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests: _normalize()
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestNormalize:
+    """Tests for text normalization helper."""
+
+    def test_lowercases(self) -> None:
+        assert _normalize("ABC") == "abc"
+
+    def test_collapses_whitespace(self) -> None:
+        assert _normalize("a   b  c") == "a b c"
+
+    def test_strips_punctuation(self) -> None:
+        assert "50%" in _normalize("50% of companies")
+
+    def test_empty_string(self) -> None:
+        assert _normalize("") == ""
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests: _stat_appears_in_text()
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestStatAppearsInText:
+    """Tests for fuzzy stat-matching logic."""
+
+    def test_exact_match(self) -> None:
+        page = "A study found a 50% reduction in maintenance costs."
+        assert _stat_appears_in_text("50% reduction in maintenance costs", page)
+
+    def test_number_with_context_match(self) -> None:
+        page = "The survey showed that 72% of teams reported reduced cognitive load."
+        assert _stat_appears_in_text("72% of teams reported reduced cognitive load", page)
+
+    def test_number_present_but_wrong_context(self) -> None:
+        page = "The year 2025 saw 72% growth in cloud spending."
+        assert not _stat_appears_in_text("72% of teams reported reduced cognitive load", page)
+
+    def test_number_absent(self) -> None:
+        page = "The survey found significant improvements."
+        assert not _stat_appears_in_text("50% improvement", page)
+
+    def test_no_numbers_in_stat(self) -> None:
+        page = "Teams experienced improved velocity."
+        assert not _stat_appears_in_text("improved velocity", page)
+
+    def test_case_insensitive(self) -> None:
+        page = "Gartner reports a 30% RISE in TCO."
+        assert _stat_appears_in_text("30% rise in TCO", page)
+
+    def test_empty_page(self) -> None:
+        assert not _stat_appears_in_text("50% reduction", "")
+
+    def test_empty_stat(self) -> None:
+        assert not _stat_appears_in_text("", "some page content")
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Tests: verify_citations()
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _mock_fetch(url_to_content: dict[str, str | None]):
+    """Build a mock fetch function that returns content by URL."""
+
+    def fetch(url: str) -> str | None:
+        return url_to_content.get(url)
+
+    return fetch
+
+
+class TestVerifyCitations:
+    """Tests for the main verify_citations() function."""
+
+    def test_verified_stat_stays_verified(self) -> None:
+        """A stat that appears in its source URL stays verified=True."""
+        research: dict[str, Any] = {
+            "data_points": [
+                {
+                    "stat": "50% reduction in maintenance",
+                    "source": "TestGuild 2024",
+                    "url": "https://example.com/report",
+                    "verified": True,
+                }
+            ],
+            "unverified_claims": [],
+        }
+        fetch = _mock_fetch({
+            "https://example.com/report": "The report found a 50% reduction in maintenance costs across 200 teams."
+        })
+        result = verify_citations(research, fetch_fn=fetch)
+        assert result["data_points"][0]["verified"] is True
+        assert result["citation_verification"]["verified"] == 1
+        assert result["citation_verification"]["failed"] == 0
+
+    def test_fabricated_stat_marked_unverified(self) -> None:
+        """A stat NOT found in its source URL is marked verified=False."""
+        research: dict[str, Any] = {
+            "data_points": [
+                {
+                    "stat": "80% of companies adopted platform engineering",
+                    "source": "Gartner 2026",
+                    "url": "https://example.com/gartner",
+                    "verified": True,
+                }
+            ],
+            "unverified_claims": [],
+        }
+        fetch = _mock_fetch({
+            "https://example.com/gartner": "This paper discusses cloud infrastructure trends and cost optimization."
+        })
+        result = verify_citations(research, fetch_fn=fetch)
+        assert result["data_points"][0]["verified"] is False
+        assert result["citation_verification"]["failed"] == 1
+        assert any("80%" in c for c in result["unverified_claims"])
+
+    def test_no_url_marks_unverified(self) -> None:
+        """Data points without a URL are marked unverified."""
+        research: dict[str, Any] = {
+            "data_points": [
+                {"stat": "60% of teams struggle", "source": "Unknown", "url": "", "verified": True}
+            ],
+            "unverified_claims": [],
+        }
+        result = verify_citations(research, fetch_fn=_mock_fetch({}))
+        assert result["data_points"][0]["verified"] is False
+        assert len(result["unverified_claims"]) == 1
+
+    def test_fetch_failure_preserves_verified_flag(self) -> None:
+        """Network failures don't change the verified flag (benefit of doubt)."""
+        research: dict[str, Any] = {
+            "data_points": [
+                {"stat": "50% reduction", "source": "Report", "url": "https://down.example.com", "verified": True}
+            ],
+            "unverified_claims": [],
+        }
+        fetch = _mock_fetch({"https://down.example.com": None})
+        result = verify_citations(research, fetch_fn=fetch)
+        # Verified flag unchanged (couldn't fetch, not a definitive failure)
+        assert result["data_points"][0]["verified"] is True
+
+    def test_headline_stat_verified(self) -> None:
+        """Headline stat with URL is also checked."""
+        research: dict[str, Any] = {
+            "headline_stat": {
+                "value": "62% of enterprises report painful headaches",
+                "source": "Gartner",
+                "url": "https://example.com/headline",
+                "verified": True,
+            },
+            "data_points": [],
+            "unverified_claims": [],
+        }
+        fetch = _mock_fetch({
+            "https://example.com/headline": "This page discusses vendor management strategies."
+        })
+        result = verify_citations(research, fetch_fn=fetch)
+        assert result["headline_stat"]["verified"] is False
+        assert any("HEADLINE" in c for c in result["unverified_claims"])
+
+    def test_empty_data_points(self) -> None:
+        """No data points → no verification needed."""
+        research: dict[str, Any] = {"data_points": [], "unverified_claims": []}
+        result = verify_citations(research, fetch_fn=_mock_fetch({}))
+        assert result["citation_verification"]["total_checked"] == 0
+
+    def test_mixed_batch(self) -> None:
+        """Mix of verified, fabricated, and URL-less data points."""
+        research: dict[str, Any] = {
+            "data_points": [
+                {"stat": "50% reduction", "url": "https://example.com/real", "verified": True},
+                {"stat": "99% adoption", "url": "https://example.com/fake", "verified": True},
+                {"stat": "Unknown stat", "url": "", "verified": True},
+            ],
+            "unverified_claims": [],
+        }
+        fetch = _mock_fetch({
+            "https://example.com/real": "The study found a 50% reduction in costs.",
+            "https://example.com/fake": "This page is about gardening tips.",
+        })
+        result = verify_citations(research, fetch_fn=fetch)
+        assert result["data_points"][0]["verified"] is True
+        assert result["data_points"][1]["verified"] is False
+        assert result["data_points"][2]["verified"] is False
+        assert result["citation_verification"]["verified"] == 1
+        assert result["citation_verification"]["failed"] == 2
+
+    def test_preserves_existing_unverified_claims(self) -> None:
+        """Existing unverified_claims are preserved, not overwritten."""
+        research: dict[str, Any] = {
+            "data_points": [
+                {"stat": "fake stat", "url": "https://example.com/x", "verified": True}
+            ],
+            "unverified_claims": ["Pre-existing claim"],
+        }
+        fetch = _mock_fetch({"https://example.com/x": "Unrelated content."})
+        result = verify_citations(research, fetch_fn=fetch)
+        assert "Pre-existing claim" in result["unverified_claims"]
+        assert len(result["unverified_claims"]) == 2


### PR DESCRIPTION
## Summary
New `scripts/citation_verifier.py` fetches each Research Agent data_point URL and confirms the claimed statistic actually appears in the source text. Marks fabricated claims as `verified: false` and adds them to `unverified_claims`. Wired into `ResearchAgent.research()` automatically.

This is the systemic fix for #259 — the Writer prompt hardening was the first line of defence, this is the verification layer that catches what leaks through.

## How it works
1. For each `data_point` with a URL, fetch the page
2. Extract numbers/percentages from the stat
3. Check if they appear in the page text near contextually relevant words
4. Mark `verified: false` if not found → Writer tags `[UNVERIFIED]` → publication validator rejects

## Test plan
- [x] 20/20 tests pass — exact match, fuzzy match, wrong context, no URL, fetch failure, headline stat, mixed batch
- [ ] Run full pipeline and confirm fabricated stats are caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)