### PR TITLE
fix: generate WebP images during blog deploy step (#276)

### DIFF
--- a/.github/workflows/content-pipeline.yml
+++ b/.github/workflows/content-pipeline.yml
@@ -177,6 +177,27 @@ jobs:
           cp "../output/charts/${ARTICLE_BASENAME}.png" assets/charts/ 2>/dev/null || true
           cp "../output/images/${ARTICLE_BASENAME}.png" assets/images/ 2>/dev/null || true
 
+          # Generate WebP versions so blog's responsive-image include doesn't break HTML-Proofer
+          BASENAME="$ARTICLE_BASENAME" python3 -c "
+import os, pathlib
+try:
+    from PIL import Image
+    basename = os.environ['BASENAME']
+    for src_path in [
+        pathlib.Path(f'assets/images/{basename}.png'),
+        pathlib.Path(f'assets/charts/{basename}.png'),
+    ]:
+        if src_path.exists():
+            dst = src_path.with_suffix('.webp')
+            with Image.open(src_path) as im:
+                im.save(dst, 'WebP', quality=85)
+            print(f'Generated {dst}')
+        else:
+            print(f'Skipped (not found): {src_path}')
+except Exception as e:
+    print(f'Warning: WebP generation failed: {e} -- continuing without WebP')
+"
+
           # Commit and push directly to main
           git add "_posts/$(basename "$ARTICLE_PATH")" assets/charts/ assets/images/
           ARTICLE_TITLE=$(cat ../article_title.txt 2>/dev/null || echo "Generated Article")


### PR DESCRIPTION
## Summary

Every future article deploy was guaranteed to fail HTML-Proofer unless WebP images were generated manually. This fix automates WebP generation as part of the pipeline.

## Problem

The blog's `_includes/responsive-image.html` emits `<source srcset="…webp">` tags for every image. HTML-Proofer validates those paths. Before this fix, the pipeline only copied `.png` files — causing **N failures per missing WebP** (one per page referencing the image via related-posts or blog listing). This caused 76 failures on 2026-04-12.

## Fix

Added a Pillow-based WebP conversion step in `content-pipeline.yml` immediately after the PNG copy:

```bash
BASENAME="$ARTICLE_BASENAME" python3 -c "
import os, pathlib
try:
    from PIL import Image
    basename = os.environ['BASENAME']
    for src_path in [
        pathlib.Path(f'assets/images/{basename}.png'),
        pathlib.Path(f'assets/charts/{basename}.png'),
    ]:
        if src_path.exists():
            dst = src_path.with_suffix('.webp')
            with Image.open(src_path) as im:
                im.save(dst, 'WebP', quality=85)
...
"
```

- Converts both image and chart PNGs to WebP
- Skips gracefully if source PNG is absent (chart or image may not exist)
- Non-fatal on Pillow error (logs warning, does not abort deploy)

## Testing

- Logic verified locally with Pillow 12.0.0
- Graceful skip tested with non-existent source file

Closes #276