### PR TITLE
fix: consolidate duplicate env in regenerate-image workflow

### DIFF
--- a/.github/workflows/regenerate-image.yml
+++ b/.github/workflows/regenerate-image.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Push image to blog repository
         env:
           BLOG_DEPLOY_TOKEN: ${{ secrets.BLOG_DEPLOY_TOKEN }}
+          GH_TOKEN: ${{ secrets.BLOG_DEPLOY_TOKEN }}
         run: |
           git clone --depth=1 https://x-access-token:${BLOG_DEPLOY_TOKEN}@github.com/oviney/blog.git blog-repo
           cp output/images/${{ inputs.slug }}.png blog-repo/assets/images/${{ inputs.slug }}.png
@@ -105,5 +106,3 @@ jobs:
             --body "Regenerated via \`regenerate-image\` workflow using DALL-E 3 HD.
 
           Closes #802" || true
-        env:
-          GH_TOKEN: ${{ secrets.BLOG_DEPLOY_TOKEN }}

--- a/src/economist_agents/flow.py
+++ b/src/economist_agents/flow.py
@@ -431,6 +431,10 @@ class EconomistContentFlow(Flow):
         gates_passed = result.get("gates_passed", 0)
         edited_article = result.get("article", new_draft.get("article", ""))
 
+        # Apply summary→description fixup (same as quality_gate first pass).
+        if "summary:" in edited_article and "description:" not in edited_article:
+            edited_article = edited_article.replace("summary:", "description:", 1)
+
         self.state["quality_result"] = result
 
         # Run publication validator


### PR DESCRIPTION
Fixes HTTP 422 on workflow dispatch — duplicate env key in Push step.