### PR TITLE
fix: add requests to regenerate-image workflow deps

### DIFF
--- a/.github/workflows/regenerate-image.yml
+++ b/.github/workflows/regenerate-image.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install openai pillow
+          pip install openai pillow requests
 
       - name: Generate featured image via DALL-E 3
         env:


### PR DESCRIPTION
Workflow failed with 'No module named requests'. featured_image_agent.py lazily imports requests to fetch the DALL-E image URL response. Adding it to the install step.