### PR TITLE
fix: mock citation_verifier in research agent tests

### DIFF
--- a/tests/test_economist_agent.py
+++ b/tests/test_economist_agent.py
@@ -221,6 +221,7 @@ class TestRunResearchAgent:
                 "agents.research_agent.ResearchAgent._gather_web_research",
                 return_value=None,
             ),
+            patch("citation_verifier.verify_citations", side_effect=lambda x: x),
         ):
             # Return the properly structured mock response
             mock_call_llm.return_value = json.dumps(sample_research_output)
@@ -275,6 +276,7 @@ class TestRunResearchAgent:
         with (
             patch("agents.research_agent.call_llm") as mock_call_llm,
             patch("agents.research_agent.review_agent_output") as mock_review,
+            patch("citation_verifier.verify_citations", side_effect=lambda x: x),
         ):
             mock_call_llm.return_value = json.dumps(sample_research_output)
             mock_review.return_value = (True, [])
@@ -318,6 +320,7 @@ class TestRunResearchAgent:
                 "agents.research_agent.ResearchAgent._gather_web_research",
                 return_value=None,
             ),
+            patch("citation_verifier.verify_citations", side_effect=lambda x: x),
         ):
             mock_call_llm.return_value = json.dumps(sample_research_output)
             mock_review.return_value = (

--- a/tests/test_research_agent.py
+++ b/tests/test_research_agent.py
@@ -398,8 +398,9 @@ class TestIntegrationScenarios:
 
     @patch("agents.research_agent.call_llm")
     @patch("agents.research_agent.review_agent_output")
+    @patch("citation_verifier.verify_citations", side_effect=lambda x: x)
     def test_full_research_pipeline(
-        self, mock_review, mock_call_llm, mock_client, sample_research_response, capsys
+        self, mock_verify, mock_review, mock_call_llm, mock_client, sample_research_response, capsys
     ):
         """Test complete research pipeline from input to output."""
         # Setup


### PR DESCRIPTION
4 tests making real HTTP calls to citation_verifier → SSL/404 failures causing verified:True→False assertion failures.

Patches `citation_verifier.verify_citations` with a passthrough mock (`side_effect=lambda x: x`) in all 4 affected tests.

52/52 passing, 0 network calls in test suite.

Closes #241