### PR TITLE
fix: auto-correct Writer category casing and chart embedding (#297)

### DIFF
--- a/src/crews/stage4_crew.py
+++ b/src/crews/stage4_crew.py
@@ -117,6 +117,66 @@ _BANNED_CLOSINGS: list[str] = [
 ]
 
 
+_CATEGORY_NORMALIZATION: dict[str, str] = {
+    "quality engineering": "quality-engineering",
+    "software engineering": "software-engineering",
+    "test automation": "test-automation",
+}
+
+
+def _normalize_category_casing(frontmatter: str) -> str:
+    """Normalize category values to kebab-case.
+
+    Only modifies the categories: line, not other frontmatter fields.
+
+    Args:
+        frontmatter: YAML frontmatter string (between --- delimiters).
+
+    Returns:
+        Frontmatter with categories normalized to kebab-case.
+    """
+    lines = frontmatter.split("\n")
+    for i, line in enumerate(lines):
+        if line.strip().startswith("categories:"):
+            for title_case, kebab in _CATEGORY_NORMALIZATION.items():
+                lines[i] = re.sub(
+                    re.escape(title_case), kebab, lines[i], flags=re.IGNORECASE
+                )
+            break
+    return "\n".join(lines)
+
+
+def _auto_embed_chart(article: str) -> str:
+    """Insert chart embed if chart_data referenced but no image embed found.
+
+    Looks for a chart file reference in frontmatter or text without a
+    corresponding ``![...](...chart...)`` markdown image. Inserts the embed
+    just before the References section (or at end of body).
+
+    Args:
+        article: Full article text with YAML frontmatter.
+
+    Returns:
+        Article with chart embed inserted if needed.
+    """
+    if "![" in article and "/assets/charts/" in article:
+        return article
+
+    slug_match = re.search(r"image:\s*/assets/images/([^.\s]+)", article)
+    if not slug_match:
+        return article
+
+    slug = slug_match.group(1)
+    chart_embed = f"\n![Chart](/assets/charts/{slug}.png)\n"
+
+    ref_match = re.search(r"\n## References", article)
+    if ref_match:
+        pos = ref_match.start()
+        return article[:pos] + chart_embed + article[pos:]
+
+    return article.rstrip() + "\n" + chart_embed
+
+
 def _apply_editorial_fixes(article: str, current_date: str | None = None) -> str:
     """Apply deterministic editorial fixes to an article.
 
@@ -183,7 +243,12 @@ def _apply_editorial_fixes(article: str, current_date: str | None = None) -> str
                 fm = "\nlayout: post" + fm
             if "categories:" not in fm:
                 fm = fm.rstrip() + '\ncategories: ["quality-engineering"]\n'
+            # 8b. Normalize category casing to kebab-case
+            fm = _normalize_category_casing(fm)
             text = "---" + fm + "---" + parts[2]
+
+    # 8c. Auto-embed chart if chart_data exists but embed missing
+    text = _auto_embed_chart(text)
 
     # 9. Clean up double spaces from phrase/placeholder removal
     text = re.sub(r"  +", " ", text)

--- a/tests/test_frontmatter_schema.py
+++ b/tests/test_frontmatter_schema.py
@@ -18,7 +18,7 @@ VALID_FRONTMATTER = {
     "title": "The Economics of Test Automation",
     "date": "2026-04-04",
     "author": "Ouray Viney",
-    "categories": ["Quality Engineering"],
+    "categories": ["quality-engineering"],
     "image": "/assets/images/test-automation.png",
     "description": "How test automation reshapes engineering economics",
 }

--- a/tests/test_stage4_editorial_fixes.py
+++ b/tests/test_stage4_editorial_fixes.py
@@ -150,5 +150,64 @@ class TestVerbosePadding:
         assert "the framework works well" in result
 
 
+class TestCategoryNormalization:
+    """Category casing normalization to kebab-case."""
+
+    def test_title_case_to_kebab(self) -> None:
+        article = '---\ncategories: ["Quality Engineering"]\n---\nBody'
+        result = _apply_editorial_fixes(article)
+        assert "quality-engineering" in result
+        assert "Quality Engineering" not in result
+
+    def test_mixed_case_to_kebab(self) -> None:
+        article = '---\ncategories: ["software engineering"]\n---\nBody'
+        result = _apply_editorial_fixes(article)
+        assert "software-engineering" in result
+
+    def test_already_kebab_unchanged(self) -> None:
+        article = '---\ncategories: ["quality-engineering"]\n---\nBody'
+        result = _apply_editorial_fixes(article)
+        assert "quality-engineering" in result
+
+    def test_test_automation_normalized(self) -> None:
+        article = '---\ncategories: ["Test Automation"]\n---\nBody'
+        result = _apply_editorial_fixes(article)
+        assert "test-automation" in result
+
+
+class TestChartAutoEmbed:
+    """Auto-insert chart embed when missing."""
+
+    def test_chart_inserted_before_references(self) -> None:
+        article = (
+            "---\nimage: /assets/images/my-slug.png\n---\n"
+            "Article body.\n\n## References\n\n1. Source"
+        )
+        result = _apply_editorial_fixes(article)
+        assert "![Chart](/assets/charts/my-slug.png)" in result
+        assert result.index("![Chart]") < result.index("## References")
+
+    def test_chart_not_doubled_if_present(self) -> None:
+        article = (
+            "---\nimage: /assets/images/my-slug.png\n---\n"
+            "Body.\n\n![Chart](/assets/charts/my-slug.png)\n\n## References\n"
+        )
+        result = _apply_editorial_fixes(article)
+        assert result.count("![Chart]") == 1
+
+    def test_no_chart_if_no_image_field(self) -> None:
+        article = "---\ntitle: Test\n---\nBody.\n\n## References\n"
+        result = _apply_editorial_fixes(article)
+        assert "![Chart]" not in result
+
+    def test_chart_appended_if_no_references_section(self) -> None:
+        article = (
+            "---\nimage: /assets/images/my-slug.png\n---\n"
+            "Article body with no references."
+        )
+        result = _apply_editorial_fixes(article)
+        assert "![Chart](/assets/charts/my-slug.png)" in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
## Summary
- Adds category casing normalization to `_apply_editorial_fixes()` — converts Title Case (e.g., "Quality Engineering") to required kebab-case ("quality-engineering"), scoped to the `categories:` line only
- Adds chart auto-embed — if frontmatter has an `image:` field but no `![...](/assets/charts/...)` embed in the body, inserts one before the References section
- Fixes `test_frontmatter_schema.py` fixture to use correct kebab-case categories

## Test plan
- [x] 55 tests pass (8 new tests for category normalization + chart auto-embed)
- [x] Existing editorial fixes tests unaffected
- [x] Frontmatter schema tests pass with corrected fixture
- [ ] CI green

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)