### PR TITLE
fix: re-run Research Agent during revision for unsourced claims (#299)

### DIFF
--- a/src/economist_agents/flow.py
+++ b/src/economist_agents/flow.py
@@ -56,6 +56,91 @@ class EconomistContentFlow(Flow):
         self.stage4_crew = Stage4Crew()
         self._deduplicator = TopicDeduplicator()
 
+    def _research_unsourced_claims(
+        self, topic: str, feedback: str
+    ) -> str:
+        """Run a targeted Research Agent pass to find sources for unsourced claims.
+
+        Extracts sentences containing placeholder tags from the previous draft,
+        sends them to the Research Agent as specific claims to verify, and returns
+        any verified sources found.
+
+        Args:
+            topic: The article topic.
+            feedback: Revision feedback describing the sourcing issues.
+
+        Returns:
+            Supplementary research text with verified sources, or empty string.
+        """
+        import re as _re
+
+        print("   🔬 Re-running Research Agent for unsourced claims...")
+
+        # Extract the previous article draft
+        quality_result = self.state.get("quality_result", {})
+        article = quality_result.get("article", "")
+        if not article:
+            return ""
+
+        # Find sentences with placeholder tags
+        unsourced = _re.findall(
+            r"[^.]*\[NEEDS SOURCE\][^.]*\.", article
+        )
+        if not unsourced:
+            # Also check for generic "studies show" patterns
+            unsourced = _re.findall(
+                r"[^.]*(?:studies show|experts say|research indicates)[^.]*\.",
+                article,
+                _re.IGNORECASE,
+            )
+
+        if not unsourced:
+            print("   ℹ️  No specific unsourced claims extracted")
+            return ""
+
+        claims_text = "\n".join(f"- {c.strip()}" for c in unsourced[:5])
+        print(f"   Found {len(unsourced)} unsourced claim(s)")
+
+        # Run a lightweight research pass targeting these specific claims
+        try:
+            from crewai import Agent, Crew, Task
+
+            researcher = Agent(
+                role="Source Verification Researcher",
+                goal=(
+                    "Find authoritative, verifiable sources for specific claims. "
+                    "Return ONLY sources you can attribute to a named organisation, "
+                    "year, and methodology. If a claim cannot be sourced, say so."
+                ),
+                backstory=(
+                    "You are a fact-checking researcher. Your job is to find real, "
+                    "citable sources for specific statistical claims. Prefer 2025-2026 "
+                    "publications. Include the source name, year, and key finding."
+                ),
+            )
+            task = Task(
+                description=(
+                    f"Find authoritative sources for the following claims about "
+                    f"'{topic}'. For each claim, provide a named source with year "
+                    f"and specific finding, or state 'UNSOURCEABLE — drop this claim'."
+                    f"\n\nClaims:\n{claims_text}"
+                ),
+                agent=researcher,
+                expected_output=(
+                    "For each claim: the source name, year, finding with numbers, "
+                    "and URL if available. Or 'UNSOURCEABLE' if no credible source exists."
+                ),
+            )
+            crew = Crew(agents=[researcher], tasks=[task])
+            result = crew.kickoff()
+            supplement = str(result.raw) if hasattr(result, "raw") else str(result)
+            print(f"   ✅ Research supplement: {len(supplement)} chars")
+            return supplement
+
+        except Exception as e:
+            print(f"   ⚠️  Research re-run failed: {e}")
+            return ""
+
     @start()
     def discover_topics(self) -> dict[str, Any]:
         """Stage 1: Discover topic candidates via Topic Scout.
@@ -385,9 +470,10 @@ class EconomistContentFlow(Flow):
     def request_revision(self) -> dict[str, Any]:
         """Revision path: retry content generation once with feedback.
 
-        Re-runs Stage3Crew with revision instructions, then re-runs
-        Stage4Crew + PublicationValidator. Returns final result regardless
-        of pass/fail (max 1 retry to avoid runaway LLM costs).
+        When the failure involves unsourced claims (placeholder tags), re-runs
+        the Research Agent first to find real sources for those specific claims,
+        then feeds the new sources into Stage3Crew. For non-sourcing failures,
+        re-runs Stage3Crew directly with revision instructions.
 
         Returns:
             dict with status, article (if published), scores, retry_count.
@@ -415,13 +501,31 @@ class EconomistContentFlow(Flow):
         print(f"🔄 Revision attempt {retry_count + 1}/{MAX_REVISIONS}")
         print(f"   Feedback: {feedback_text[:200]}")
 
-        # Re-run Stage3Crew with revision instructions appended to topic
         topic = self.state.get("selected_topic", {}).get("topic", "")
+
+        # Detect sourcing failures — re-run Research Agent for those claims
+        sourcing_supplement = ""
+        is_sourcing_failure = any(
+            kw in feedback_text.lower()
+            for kw in ("placeholder", "needs source", "unverified", "unsourced")
+        )
+        if is_sourcing_failure:
+            sourcing_supplement = self._research_unsourced_claims(
+                topic, feedback_text
+            )
+
         enhanced_topic = (
             f"{topic}\n\n"
             f"REVISION INSTRUCTIONS — the previous draft failed review. "
             f"Fix these issues:\n{feedback_text}"
         )
+        if sourcing_supplement:
+            enhanced_topic += (
+                f"\n\nADDITIONAL VERIFIED SOURCES from a fresh research pass "
+                f"(use these to replace any unsourced claims, or drop the claim "
+                f"entirely and rewrite the surrounding text for coherence):\n"
+                f"{sourcing_supplement}"
+            )
 
         stage3_crew = Stage3Crew(topic=enhanced_topic)
         new_draft = stage3_crew.kickoff()

--- a/tests/test_economist_flow.py
+++ b/tests/test_economist_flow.py
@@ -344,6 +344,138 @@ class TestEconomistFlow:
     not os.environ.get("OPENAI_API_KEY"),
     reason="OPENAI_API_KEY required for CrewAI agent initialization",
 )
+class TestResearchBackedRevision:
+    """Tests for research-backed revision when sourcing issues detected."""
+
+    @pytest.fixture
+    def flow(self) -> EconomistContentFlow:
+        return EconomistContentFlow()
+
+    @patch("src.economist_agents.flow.PublicationValidator")
+    @patch("src.economist_agents.flow.Stage3Crew")
+    def test_sourcing_failure_triggers_research_rerun(
+        self,
+        mock_stage3_class: Mock,
+        mock_validator_class: Mock,
+        flow: EconomistContentFlow,
+    ) -> None:
+        """Revision with placeholder feedback re-runs Research Agent."""
+        flow.state["selected_topic"] = {"topic": "AI Testing"}
+        flow.state["revision_reason"] = "Publication validation failed"
+        flow.state["revision_feedback"] = ["Found 2 placeholder(s)"]
+        flow.state["quality_result"] = {
+            "editorial_score": 98,
+            "gates_passed": 5,
+            "article": (
+                "Half of teams report improved outcomes [NEEDS SOURCE]. "
+                "The market grew by 40% last year [NEEDS SOURCE]."
+            ),
+        }
+        flow.state["retry_count"] = 0
+
+        mock_s3 = Mock()
+        mock_s3.kickoff.return_value = {
+            "article": "Fixed article with real sources",
+            "chart_data": {},
+        }
+        mock_stage3_class.return_value = mock_s3
+
+        flow.stage4_crew = Mock()
+        flow.stage4_crew.kickoff.return_value = {
+            "article": "Polished article",
+            "editorial_score": 95,
+            "gates_passed": 5,
+        }
+
+        mock_validator = Mock()
+        mock_validator.validate.return_value = (True, [])
+        mock_validator_class.return_value = mock_validator
+
+        with patch("crewai.Crew") as mock_crew_cls:
+            mock_crew = Mock()
+            mock_result = Mock()
+            mock_result.raw = "McKinsey 2025 found 48% of teams improved."
+            mock_crew.kickoff.return_value = mock_result
+            mock_crew_cls.return_value = mock_crew
+
+            result = flow.request_revision()
+
+        assert result["status"] == "published"
+        # Verify Stage3Crew received research supplement
+        topic_arg = mock_stage3_class.call_args[1]["topic"]
+        assert "ADDITIONAL VERIFIED SOURCES" in topic_arg
+
+    @patch("src.economist_agents.flow.PublicationValidator")
+    @patch("src.economist_agents.flow.Stage3Crew")
+    def test_non_sourcing_failure_skips_research_rerun(
+        self,
+        mock_stage3_class: Mock,
+        mock_validator_class: Mock,
+        flow: EconomistContentFlow,
+    ) -> None:
+        """Revision for non-sourcing issues does NOT re-run Research Agent."""
+        flow.state["selected_topic"] = {"topic": "AI Testing"}
+        flow.state["revision_reason"] = "Editorial score 65/100"
+        flow.state["revision_feedback"] = ["Fix weak opening paragraph"]
+        flow.state["quality_result"] = {
+            "editorial_score": 65,
+            "gates_passed": 3,
+            "article": "In today's world, AI is changing everything.",
+        }
+        flow.state["retry_count"] = 0
+
+        mock_s3 = Mock()
+        mock_s3.kickoff.return_value = {"article": "Better opening", "chart_data": {}}
+        mock_stage3_class.return_value = mock_s3
+
+        flow.stage4_crew = Mock()
+        flow.stage4_crew.kickoff.return_value = {
+            "article": "Polished article",
+            "editorial_score": 88,
+            "gates_passed": 5,
+        }
+
+        mock_validator = Mock()
+        mock_validator.validate.return_value = (True, [])
+        mock_validator_class.return_value = mock_validator
+
+        result = flow.request_revision()
+
+        assert result["status"] == "published"
+        # Verify no research supplement injected
+        topic_arg = mock_stage3_class.call_args[1]["topic"]
+        assert "ADDITIONAL VERIFIED SOURCES" not in topic_arg
+
+    def test_research_unsourced_claims_extracts_placeholders(
+        self,
+        flow: EconomistContentFlow,
+    ) -> None:
+        """_research_unsourced_claims extracts [NEEDS SOURCE] sentences."""
+        flow.state["quality_result"] = {
+            "article": (
+                "Teams report 50% gains [NEEDS SOURCE]. "
+                "This is well known. "
+                "Market grew 40% [NEEDS SOURCE]."
+            ),
+        }
+
+        with patch("crewai.Crew") as mock_crew_cls:
+            mock_crew = Mock()
+            mock_result = Mock()
+            mock_result.raw = "Gartner 2025: 48% of teams improved."
+            mock_crew.kickoff.return_value = mock_result
+            mock_crew_cls.return_value = mock_crew
+
+            result = flow._research_unsourced_claims("AI Testing", "placeholder issues")
+
+        assert "Gartner 2025" in result
+        mock_crew_cls.assert_called_once()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY required for CrewAI agent initialization",
+)
 def test_flow_decorators_registered() -> None:
     """All Flow decorated methods are registered and callable."""
     flow = EconomistContentFlow()


### PR DESCRIPTION
## Summary
- When revision feedback mentions sourcing issues (placeholders, NEEDS SOURCE, unverified), the revision loop now re-runs a targeted Research Agent before re-running Stage3Crew
- Extracts `[NEEDS SOURCE]` sentences from the previous draft, sends them to a fact-checking researcher crew
- Feeds verified sources (or UNSOURCEABLE markers) back to the Writer as supplementary context
- Non-sourcing failures (weak opening, structure issues) skip the research re-run — no wasted LLM calls

## Why
The previous revision loop asked the Writer to "fix sourcing" but the Writer has no access to new sources. It either re-invents the same fabricated claim or strips context the article needs. This is fundamentally an information retrieval problem, not a generation problem.

## Test plan
- [x] 16/16 flow tests pass (3 new: sourcing triggers research, non-sourcing skips it, placeholder extraction)
- [ ] CI green
- [ ] E2E pipeline run produces article without placeholder failures

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)