### PR TITLE
feat: enforce economist-writing rules 4, 7, 8 in pipeline (#301)

### DIFF
--- a/scripts/publication_validator.py
+++ b/scripts/publication_validator.py
@@ -141,6 +141,9 @@ class PublicationValidator:
         # Check 12: Category validation
         self._check_category(article_content)
 
+        # Check 13: Ending quality (banned closings from stage4_crew)
+        self._check_ending(article_content)
+
         # Determine if valid (no CRITICAL issues)
         critical_issues = [i for i in self.issues if i["severity"] == "CRITICAL"]
         is_valid = len(critical_issues) == 0
@@ -472,6 +475,89 @@ class PublicationValidator:
                             )
         except Exception:
             pass  # YAML parse errors are caught by _check_yaml_format
+
+    # Banned closing phrases aligned with stage4_crew._BANNED_CLOSINGS + extras.
+    _BANNED_CLOSINGS: list[str] = [
+        "In conclusion",
+        "To conclude",
+        "In summary",
+        "remains to be seen",
+        "only time will tell",
+        "The journey ahead",
+        "will rest on",
+        "depends on",
+        "the key is",
+        "to summarise",
+        "One suspects",
+    ]
+
+    # Summary-opening phrases that signal a restatement ending.
+    _SUMMARY_STARTERS: list[str] = [
+        "In short",
+        "Ultimately",
+        "Overall",
+    ]
+
+    def _check_ending(self, content: str) -> None:
+        """Check the last paragraph for banned closing patterns.
+
+        Extracts the article body (after YAML frontmatter, before
+        ``## References`` if present) and inspects the final paragraph for
+        weak/hedging closings drawn from ``stage4_crew._BANNED_CLOSINGS``
+        plus additional patterns (e.g. summary-opener restatements).
+
+        Issues are reported at **HIGH** severity so they flag without
+        blocking publication on the first run.
+        """
+        # --- extract body after frontmatter ---
+        if content.startswith("---"):
+            parts = content.split("---", 2)
+            body = parts[2] if len(parts) >= 3 else ""
+        else:
+            body = content
+
+        # --- strip References / Sources / Bibliography section ---
+        for pattern in (
+            r"\n## References\b",
+            r"\n## Sources\b",
+            r"\n## Bibliography\b",
+        ):
+            match = re.search(pattern, body, re.IGNORECASE)
+            if match:
+                body = body[: match.start()]
+                break
+
+        # --- isolate last paragraph ---
+        paragraphs = [p.strip() for p in body.strip().split("\n\n") if p.strip()]
+        if not paragraphs:
+            return
+        last_paragraph = paragraphs[-1]
+
+        violations: list[str] = []
+
+        # 1. Check banned closing phrases (case-insensitive)
+        for phrase in self._BANNED_CLOSINGS:
+            if re.search(re.escape(phrase), last_paragraph, re.IGNORECASE):
+                violations.append(f'Banned closing phrase: "{phrase}"')
+
+        # 2. Check summary-opener restatement endings
+        for starter in self._SUMMARY_STARTERS:
+            if re.match(re.escape(starter) + r"\b", last_paragraph, re.IGNORECASE):
+                violations.append(
+                    f'Summary restatement opening: "{starter}"'
+                )
+
+        if violations:
+            details = "\n".join(f"  - {v}" for v in violations)
+            self.issues.append(
+                {
+                    "check": "ending_quality",
+                    "severity": "HIGH",
+                    "message": f"Weak/hedging ending detected ({len(violations)} violations)",
+                    "details": details,
+                    "fix": "Rewrite ending with a vivid prediction, metaphor, or concrete forward-looking statement",
+                }
+            )
 
     def _check_chart_references(self, content: str):
         """Check that articles include at least one chart in /assets/charts/ and flag orphaned charts that lack text references."""

--- a/src/crews/stage4_crew.py
+++ b/src/crews/stage4_crew.py
@@ -68,6 +68,10 @@ _HEDGING_PHRASES: list[str] = [
     "further complicating matters",
     "invites closer scrutiny",
     "in practical terms",
+    "One suspects",
+    "if you find yourself",
+    "it is clear that",
+    "it remains to be seen",
 ]
 
 # Verbose padding — throat-clearing and redundant attribution (SKILL.md Rule 6)
@@ -114,6 +118,7 @@ _BANNED_CLOSINGS: list[str] = [
     "depends on",
     "the key is",
     "to summarise",
+    "One suspects",
 ]
 
 
@@ -175,6 +180,82 @@ def _auto_embed_chart(article: str) -> str:
         return article[:pos] + chart_embed + article[pos:]
 
     return article.rstrip() + "\n" + chart_embed
+
+
+def _enforce_heading_limit(article: str, max_headings: int = 4) -> str:
+    """Merge the shortest section when body heading count exceeds the limit.
+
+    Counts ``## `` headings in the article body (after YAML frontmatter),
+    excluding ``## References``.  When the count exceeds *max_headings*,
+    the shortest section (fewest lines between consecutive headings) is
+    merged into the previous section by removing its heading line.  The
+    process repeats until the count is at or below the limit.
+
+    Args:
+        article: Full article text, optionally with YAML frontmatter.
+        max_headings: Maximum allowed ``## `` headings (default 4).
+
+    Returns:
+        Article with headings merged down to the limit.
+    """
+    # Split frontmatter from body
+    if article.startswith("---"):
+        parts = article.split("---", 2)
+        if len(parts) >= 3:
+            frontmatter = "---" + parts[1] + "---"
+            body = parts[2]
+        else:
+            frontmatter = ""
+            body = article
+    else:
+        frontmatter = ""
+        body = article
+
+    while True:
+        lines = body.split("\n")
+        # Collect indices of body headings (## ) excluding ## References
+        heading_indices: list[int] = [
+            i
+            for i, line in enumerate(lines)
+            if line.startswith("## ") and line.strip() != "## References"
+        ]
+
+        if len(heading_indices) <= max_headings:
+            break
+
+        # Find shortest section (by line count between headings)
+        # Build section lengths: from heading to next heading (or end)
+        section_lengths: list[tuple[int, int]] = []  # (length, heading_index)
+        for idx, h_idx in enumerate(heading_indices):
+            if idx + 1 < len(heading_indices):
+                next_h = heading_indices[idx + 1]
+            else:
+                next_h = len(lines)
+            section_len = next_h - h_idx
+            section_lengths.append((section_len, h_idx))
+
+        # Don't merge the very first heading (nothing to merge into)
+        mergeable = section_lengths[1:]
+        if not mergeable:
+            break
+
+        # Pick the shortest mergeable section
+        shortest = min(mergeable, key=lambda x: x[0])
+        remove_idx = shortest[1]
+
+        logger.info(
+            "Heading limit exceeded (%d > %d); removing heading at line %d: %s",
+            len(heading_indices),
+            max_headings,
+            remove_idx + 1,
+            lines[remove_idx].strip(),
+        )
+
+        # Remove the heading line
+        del lines[remove_idx]
+        body = "\n".join(lines)
+
+    return frontmatter + body
 
 
 def _apply_editorial_fixes(article: str, current_date: str | None = None) -> str:
@@ -249,6 +330,9 @@ def _apply_editorial_fixes(article: str, current_date: str | None = None) -> str
 
     # 8c. Auto-embed chart if chart_data exists but embed missing
     text = _auto_embed_chart(text)
+
+    # 8d. Enforce heading limit (max 4 body headings)
+    text = _enforce_heading_limit(text)
 
     # 9. Clean up double spaces from phrase/placeholder removal
     text = re.sub(r"  +", " ", text)

--- a/tests/test_publication_validator.py
+++ b/tests/test_publication_validator.py
@@ -346,6 +346,70 @@ class TestPublicationValidatorChart:
         assert len(orphan_issues) == 0
 
 
+class TestPublicationValidatorEnding:
+    """Ending quality validation checks (banned closings from stage4_crew)."""
+
+    def test_ending_with_banned_phrase_flagged(self) -> None:
+        """Article ending with 'In conclusion, the key is...' triggers HIGH issue."""
+        validator = PublicationValidator(expected_date="2026-04-03")
+        # Place the banned ending after the chart embed so it is the last paragraph
+        chart_with_ending = (
+            VALID_CHART_EMBED
+            + "\n\nIn conclusion, the key is to keep testing."
+        )
+        article = _make_article(chart_embed=chart_with_ending)
+        _, issues = validator.validate(article)
+        ending_issues = [i for i in issues if i["check"] == "ending_quality"]
+        assert len(ending_issues) == 1
+        assert ending_issues[0]["severity"] == "HIGH"
+        assert "2 violations" in ending_issues[0]["message"]
+
+    def test_ending_with_vivid_prediction_passes(self) -> None:
+        """Article ending with a metaphor should produce no ending issues."""
+        validator = PublicationValidator(expected_date="2026-04-03")
+        chart_with_ending = (
+            VALID_CHART_EMBED
+            + "\n\nThe iceberg, it turns out, hides nine-tenths of itself "
+            "beneath the waterline — and so does technical debt."
+        )
+        article = _make_article(chart_embed=chart_with_ending)
+        _, issues = validator.validate(article)
+        ending_issues = [i for i in issues if i["check"] == "ending_quality"]
+        assert len(ending_issues) == 0
+
+    def test_ending_with_one_suspects_flagged(self) -> None:
+        """Article ending with 'One suspects...' triggers HIGH issue."""
+        validator = PublicationValidator(expected_date="2026-04-03")
+        chart_with_ending = (
+            VALID_CHART_EMBED
+            + "\n\nOne suspects the industry will eventually catch up."
+        )
+        article = _make_article(chart_embed=chart_with_ending)
+        _, issues = validator.validate(article)
+        ending_issues = [i for i in issues if i["check"] == "ending_quality"]
+        assert len(ending_issues) == 1
+        assert ending_issues[0]["severity"] == "HIGH"
+
+    def test_ending_check_ignores_references(self) -> None:
+        """Only text before ## References is checked for ending quality."""
+        validator = PublicationValidator(expected_date="2026-04-03")
+        # Body ends cleanly; the banned phrase only appears inside References
+        chart_with_ending = (
+            VALID_CHART_EMBED
+            + "\n\nThe market will fracture along entirely new lines."
+        )
+        refs = (
+            "## References\n\n"
+            "1. In conclusion paper, [link](https://a.com), 2024\n"
+            "2. Source B, [Report](https://b.com), 2024\n"
+            "3. Source C, [Study](https://c.com), 2024\n"
+        )
+        article = _make_article(chart_embed=chart_with_ending, references=refs)
+        _, issues = validator.validate(article)
+        ending_issues = [i for i in issues if i["check"] == "ending_quality"]
+        assert len(ending_issues) == 0
+
+
 class TestPublicationValidatorReport:
     """format_report() output checks."""
 

--- a/tests/test_stage4_editorial_fixes.py
+++ b/tests/test_stage4_editorial_fixes.py
@@ -3,7 +3,11 @@
 
 import pytest
 
-from src.crews.stage4_crew import _apply_editorial_fixes
+from src.crews.stage4_crew import (
+    _apply_editorial_fixes,
+    _BANNED_CLOSINGS,
+    _enforce_heading_limit,
+)
 
 
 class TestBritishSpelling:
@@ -207,6 +211,74 @@ class TestChartAutoEmbed:
         )
         result = _apply_editorial_fixes(article)
         assert "![Chart](/assets/charts/my-slug.png)" in result
+
+
+class TestNewHedgingPhrases:
+    """New hedging phrases added in Story 1."""
+
+    def test_one_suspects_removed(self) -> None:
+        """Article containing 'One suspects' has the phrase stripped."""
+        result = _apply_editorial_fixes("One suspects the future is bleak.")
+        assert "One suspects" not in result
+        assert "the future is bleak" in result
+
+    def test_it_is_clear_that_removed(self) -> None:
+        """Article containing 'it is clear that' has the phrase stripped."""
+        result = _apply_editorial_fixes("It is clear that progress has stalled.")
+        assert "it is clear that" not in result.lower()
+        assert "progress has stalled" in result
+
+    def test_one_suspects_in_closing_banned(self) -> None:
+        """'One suspects' appears in _BANNED_CLOSINGS."""
+        assert "One suspects" in _BANNED_CLOSINGS
+
+
+class TestHeadingLimitEnforcement:
+    """Heading count enforcement (Story 3)."""
+
+    def test_headings_under_limit_unchanged(self) -> None:
+        """Article with 3 headings passes through unchanged."""
+        article = (
+            "---\ntitle: Test\n---\n\n"
+            "## Introduction\n\nParagraph one.\n\n"
+            "## Analysis\n\nParagraph two.\n\n"
+            "## Conclusion\n\nParagraph three.\n"
+        )
+        result = _enforce_heading_limit(article)
+        assert result.count("\n## ") == 3
+
+    def test_headings_over_limit_merged(self) -> None:
+        """Article with 6 headings is reduced to 4."""
+        sections = []
+        for i in range(6):
+            sections.append(f"## Section {i + 1}\n\n{'Line.\n' * (i + 1)}")
+        article = "---\ntitle: Test\n---\n\n" + "\n".join(sections)
+        result = _enforce_heading_limit(article)
+        heading_count = sum(
+            1
+            for line in result.split("\n")
+            if line.startswith("## ") and line.strip() != "## References"
+        )
+        assert heading_count == 4
+
+    def test_references_heading_not_counted(self) -> None:
+        """Article with 4 body headings + ## References stays unchanged."""
+        article = (
+            "---\ntitle: Test\n---\n\n"
+            "## Introduction\n\nText.\n\n"
+            "## Analysis\n\nText.\n\n"
+            "## Results\n\nText.\n\n"
+            "## Outlook\n\nText.\n\n"
+            "## References\n\n1. Source A\n"
+        )
+        result = _enforce_heading_limit(article)
+        # All 4 body headings + References should remain
+        all_headings = [
+            line for line in result.split("\n") if line.startswith("## ")
+        ]
+        assert len(all_headings) == 5
+        body_headings = [h for h in all_headings if h.strip() != "## References"]
+        assert len(body_headings) == 4
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Story 1**: Adds 4 hedging phrases to `_HEDGING_PHRASES` ("One suspects", "if you find yourself", "it is clear that", "it remains to be seen") + "One suspects" to `_BANNED_CLOSINGS`. Rule 4 enforcement.
- **Story 2**: Adds `_check_ending()` to PublicationValidator — flags banned closing patterns and summary openers at HIGH severity. Rule 7 enforcement.
- **Story 3**: Adds `_enforce_heading_limit()` — merges shortest section when heading count exceeds 4. Rule 8 enforcement.
- **Story 4**: Backfilled kebab-case categories on 20 blog posts (pushed directly to oviney/blog main).

## Audit context
24 production articles audited against economist-writing 10 rules. Average score 6.5/10. Systemic failures:
- 18/24 summary endings (Rule 7) — now flagged by `_check_ending()`
- 8/24 excess headings (Rule 8) — now auto-merged by `_enforce_heading_limit()`
- Worst articles all contain "One suspects" hedging (Rule 4) — now stripped

## Test plan
- [x] 71 tests pass (10 new: 3 hedging, 3 headings, 4 endings)
- [x] Blog category backfill pushed (20 posts, categories line only)
- [ ] CI green

Stories 5-6 (article evaluator scoring + pipeline wiring) to follow in next commit.

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)