### PR TITLE
feat: wire article evaluator into pipeline for quality trend tracking (#301)

### DIFF
--- a/scripts/article_evaluator.py
+++ b/scripts/article_evaluator.py
@@ -73,6 +73,10 @@ _HEDGING_PHRASES: list[str] = [
     "further complicating matters",
     "invites closer scrutiny",
     "in practical terms",
+    "one suspects",
+    "if you find yourself",
+    "it is clear that",
+    "it remains to be seen",
 ]
 
 _BANNED_CLOSINGS = [
@@ -81,10 +85,12 @@ _BANNED_CLOSINGS = [
     "in summary",
     "remains to be seen",
     "only time will tell",
+    "the journey ahead",
     "will rest on",
     "depends on",
     "the key is",
     "to summarise",
+    "one suspects",
 ]
 
 _VAGUE_ATTRIBUTION = [

--- a/src/economist_agents/flow.py
+++ b/src/economist_agents/flow.py
@@ -56,6 +56,32 @@ class EconomistContentFlow(Flow):
         self.stage4_crew = Stage4Crew()
         self._deduplicator = TopicDeduplicator()
 
+    def _run_article_eval(self, article: str, status: str) -> None:
+        """Run the 5-dimension article evaluator and persist scores.
+
+        Called after both publish and quarantine paths so every article
+        gets scored for trend tracking regardless of outcome.
+
+        Args:
+            article: Full article text with YAML frontmatter.
+            status: Pipeline outcome ("published" or "quarantined").
+        """
+        try:
+            from scripts.article_evaluator import ArticleEvaluator
+
+            evaluator = ArticleEvaluator()
+            result = evaluator.evaluate(article, filename=status)
+            result.persist("logs/article_evals.json")
+            print(
+                f"   📊 Article eval: {result.total_score}/{result.max_score} "
+                f"({result.percentage}%)"
+            )
+            for dim, score in result.scores.items():
+                detail = result.details.get(dim, "")
+                print(f"      {dim}: {score}/10 — {detail}")
+        except Exception as e:
+            print(f"   ⚠️  Article evaluation failed: {e}")
+
     def _research_unsourced_claims(
         self, topic: str, feedback: str
     ) -> str:
@@ -450,6 +476,9 @@ class EconomistContentFlow(Flow):
         print("✅ Flow Complete: PUBLISHED")
         print(f"   Editorial Score: {quality_result.get('editorial_score', 0)}/100")
 
+        # ── Article evaluation for trend tracking ─────────────────────
+        self._run_article_eval(article_text, "published")
+
         # ── Post-publication indexing ───────────────────────────────────
         # Index the article in the published_articles archive so future
         # deduplication runs can detect coverage of this topic.
@@ -605,6 +634,9 @@ class EconomistContentFlow(Flow):
         )
         quarantine_path.write_text(edited_article)
         print(f"   📄 Quarantined article saved: {quarantine_path}")
+
+        # ── Article evaluation for trend tracking (even quarantined) ──
+        self._run_article_eval(edited_article, "quarantined")
 
         return {
             "status": "needs_revision",


### PR DESCRIPTION
## Summary
- Syncs `article_evaluator.py` hedging/closing lists with expanded lists from stories 1-3
- Wires `_run_article_eval()` into both publish and quarantine paths in `flow.py`
- Every pipeline run now persists a 5-dimension quality score to `logs/article_evals.json`
- Scores: opening_quality, evidence_sourcing, voice_consistency, structure, visual_engagement (1-10 each, 50 total)

## Why
One pipeline run proving nothing is the problem. This creates the trend data needed to measure whether articles are improving or degrading over time — the observability foundation from the `observability` skill.

## Test plan
- [x] 39 tests pass (16 flow + 23 evaluator)
- [ ] CI green
- [ ] Next pipeline run produces `logs/article_evals.json` entry with 5 dimension scores

Completes stories 5-6 of #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)