### PR TITLE
fix(ci): install anthropic SDK in Test Suite workflow (#345)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 # Dev-only tools (pytest, streamlit, linters) are in requirements-dev.txt.
 # Pin new deps to a tested minor range; update deliberately, not silently.
 
+anthropic>=0.40.0,<1.0.0          # Anthropic Python SDK — used by src/agent_sdk/_shared.py for vision refinement (#345)
 claude-agent-sdk>=0.1.68,<1.0.0   # Anthropic Agent SDK — primary agent runtime (ADR-0006 Phase 2)
 chromadb>=0.4.0,<1.0.0            # Vector DB for Style Memory RAG; API breaks across major versions
 matplotlib>=3.7.0,<4.0.0          # Chart generation for graphics agent


### PR DESCRIPTION
## Summary

Adds the `anthropic` Python SDK to `requirements.txt` so the CI Test Suite job installs it. Previously, `src/agent_sdk/_shared.py` imported `anthropic` at runtime (for vision refinement), but the package was not declared in either `requirements.txt` or `requirements-dev.txt`. Five tests that exercise that path failed with `ModuleNotFoundError: No module named 'anthropic'` on every CI run since 2026-05-08.

The fix is the minimal, conventional one for this repo: add the dependency to `requirements.txt` rather than adding a new `pip install` step to `.github/workflows/ci.yml`. We place it in `requirements.txt` (not `-dev.txt`) because `src/` runtime code imports it, not test-only code.

Failing CI run that motivated this fix: `gh run view 25834056774 --log-failed` (referenced in issue #345).

Closes #345

## Test plan

- [x] Run the 5 affected tests locally: `pytest tests/test_flow_agent_sdk.py tests/test_stage3_writer_skill.py -q` -> 81 passed
- [ ] Test Suite (Python 3.11) on this PR reports 0 `ModuleNotFoundError: No module named 'anthropic'` failures
- [ ] Test Suite (Python 3.12) on this PR reports 0 such failures
- [ ] No new test failures introduced

## Acceptance criteria

- **AC1** — The 5 `ModuleNotFoundError` failures stop appearing in Test Suite CI
- **AC2** — Both Python 3.11 and 3.12 Test Suite jobs report 0 such failures on this PR
- **AC3** — No new test failures introduced

Scope is anthropic SDK only; chromadb v0.6 (#346) is being addressed in a separate PR.

Generated with [Claude Code](https://claude.com/claude-code)