### PR TITLE
fix: chromadb v0.6 list_collections API (#346)

### DIFF
--- a/tests/test_index_published_articles.py
+++ b/tests/test_index_published_articles.py
@@ -500,7 +500,14 @@ class TestRun:
                 _embedding_function=_HASH_EF,
             )
 
-        collection_names = [c.name for c in client.list_collections()]
+        # ChromaDB v0.6 changed list_collections() to return collection-name
+        # strings rather than Collection objects.  Support both shapes so the
+        # test passes regardless of which chromadb version the resolver picks
+        # (the requirements pin allows >=0.4.0,<1.0.0).
+        # See: https://docs.trychroma.com/docs/overview/migration
+        collection_names = [
+            c if isinstance(c, str) else c.name for c in client.list_collections()
+        ]
         assert COLLECTION_NAME in collection_names
 
 


### PR DESCRIPTION
## Summary

`tests/test_index_published_articles.py::TestRun::test_run_uses_correct_collection_name` has been failing on Test Suite CI since 2026-05-08 because ChromaDB v0.6.0 changed the return type of `Client.list_collections()` from a list of `Collection` objects to a list of collection-name strings. The test did `[c.name for c in client.list_collections()]`, which raised `NotImplementedError` on v0.6.

## Fix option chosen: B (migrate to v0.6 API)

The issue offered two options:

- **A.** Pin `chromadb<0.6` in `requirements.txt` — fastest, but defers the migration and accrues debt.
- **B.** Migrate the call site to the v0.6 API — small, permanent fix.

Going with **B** per the issue author's recommendation. Only one call site exists in the entire repo (the failing test itself); no production code in `scripts/` or `src/` uses `list_collections()`. The change is two extra lines, no new dependencies, no requirements churn.

To keep the test resilient across the version range allowed by the existing pin (`chromadb>=0.4.0,<1.0.0` — v0.5 returns Collection objects, v0.6 returns strings), the comprehension accepts both shapes:

```python
collection_names = [
    c if isinstance(c, str) else c.name for c in client.list_collections()
]
```

Reference: https://docs.trychroma.com/docs/overview/migration

## Verification

- `pytest tests/test_index_published_articles.py::TestRun::test_run_uses_correct_collection_name` — passes against chromadb 0.6.3
- `pytest tests/test_index_published_articles.py` — all 34 tests pass
- `ruff check --no-fix tests/test_index_published_articles.py` — clean
- `ruff format --check tests/test_index_published_articles.py` — clean

## Acceptance criteria

- AC1 (failing test passes on CI) — verified locally; CI pending
- AC2 (call sites updated) — yes (1 call site, the test)
- AC3 (no new failures) — verified; full file passes

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)