### PR TITLE
docs: add agent-skills lifecycle discipline + worker brief contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Exempt: simple Q&A, status checks, command output, one-line edits.
 
 ### Dispatching worker agents
 
-When dispatching agents via the `Agent` tool (orchestrating the fleet), the brief MUST include the worker discipline contract from `.claude/worker-brief-contract.md`. Workers that produce output without evidence of `Skill` invocations are rejected and re-dispatched.
+When dispatching agents via the `Agent` tool (orchestrating the fleet), the brief MUST include the worker discipline contract from `docs/worker-brief-contract.md`. Workers that produce output without evidence of `Skill` invocations are rejected and re-dispatched.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,23 @@ Task arrives
 **No implementation starts without a spec. No sprint planning starts without a dependency-ordered task list.**
 Both require human review (a "LGTM") before proceeding.
 
+### Lifecycle discipline (non-negotiable)
+
+For any **non-trivial** response (anything beyond Q&A, status checks, or one-line edits):
+
+1. The **first two tool calls** MUST be:
+   1. `Skill agent-skills:using-agent-skills` — triages the task and points to the right phase skill
+   2. `Skill agent-skills:context-engineering` — sets up focused context for the task
+2. After triage, invoke the phase skill the meta-skill points you at (e.g. `agent-skills:spec-driven-development`, `agent-skills:incremental-implementation`, `agent-skills:test-driven-development`, etc.).
+3. **Improvising the lifecycle as plain workflow labels is a blocker, not a warning.** If you find yourself running DEFINE/PLAN/BUILD by hand without an active `Skill` invocation, stop and invoke the meta-skill first.
+4. Per `agent-skills:using-agent-skills` Core Behavior #1: surface assumptions explicitly before implementing anything non-trivial.
+
+Exempt: simple Q&A, status checks, command output, one-line edits.
+
+### Dispatching worker agents
+
+When dispatching agents via the `Agent` tool (orchestrating the fleet), the brief MUST include the worker discipline contract from `.claude/worker-brief-contract.md`. Workers that produce output without evidence of `Skill` invocations are rejected and re-dispatched.
+
 ## Architecture
 
 - **LLM**: Claude (Anthropic) is the primary LLM. OPENAI_API_KEY only needed for DALL-E images.

--- a/docs/worker-brief-contract.md
+++ b/docs/worker-brief-contract.md
@@ -1,0 +1,100 @@
+# Worker Brief Contract
+
+**Include this contract verbatim in every `Agent` tool dispatch brief.** Workers must follow it or have their output rejected and re-dispatched.
+
+---
+
+## Discipline contract (mandatory)
+
+You are a worker agent in a fleet orchestrated by a parent Claude Code session. The parent will review your output. Failure to follow this contract results in rejection and re-dispatch.
+
+### 1. First two tool calls — non-negotiable
+
+Your **first two tool calls** MUST be, in order:
+
+1. `Skill agent-skills:using-agent-skills`
+2. `Skill agent-skills:context-engineering`
+
+Do this **before** any `Read`, `Bash`, `Edit`, `Write`, `Grep`, or other tool. Do not skip even if the task seems obvious. The meta-skills exist to triage and orient you — running the lifecycle "by hand" is the failure mode this contract prevents.
+
+### 2. After triage — invoke the phase skill
+
+The `using-agent-skills` flowchart will point you at a phase skill (e.g. `agent-skills:spec-driven-development`, `agent-skills:planning-and-task-breakdown`, `agent-skills:incremental-implementation`, `agent-skills:test-driven-development`, `agent-skills:code-review-and-quality`, `agent-skills:shipping-and-launch`). Invoke it via the `Skill` tool. Do not paraphrase its workflow inline.
+
+For a feature implementation from a GitHub issue, the typical chain is:
+
+```
+using-agent-skills → context-engineering → spec-driven-development (if issue body too thin)
+  → planning-and-task-breakdown → incremental-implementation
+  → test-driven-development → code-review-and-quality
+  → git-workflow-and-versioning → shipping-and-launch
+```
+
+### 3. Surface assumptions (Core Operating Behavior #1)
+
+Before implementing anything non-trivial, emit an `ASSUMPTIONS:` block listing what you're taking as given. Wait for the parent to redirect, or proceed with explicit acknowledgement that you're going on those assumptions.
+
+### 4. Output format
+
+Your final summary MUST include:
+
+```
+SKILL INVOCATIONS:
+- <timestamp> Skill agent-skills:using-agent-skills
+- <timestamp> Skill agent-skills:context-engineering
+- <timestamp> Skill <phase-skill-1>
+- <timestamp> Skill <phase-skill-2>
+...
+
+ASSUMPTIONS:
+- <assumption 1>
+- <assumption 2>
+...
+
+WORK PRODUCT:
+- PR URL: <url>
+- Branch: <branch-name>
+- Files changed: <count>
+- Tests added/modified: <count>
+- CI status: <pass|fail|pending>
+- Acceptance criteria met: <yes|partial|no with explanation>
+```
+
+If the SKILL INVOCATIONS list does not start with `using-agent-skills` followed by `context-engineering`, your work will be rejected.
+
+### 5. Isolation
+
+You are running with `isolation: "worktree"` — a fresh git worktree at a path the parent provides. Do all your work there. Do not `cd` outside it. Do not assume any state from prior conversations.
+
+### 6. Scope discipline (Core Operating Behavior #5)
+
+Touch only what your assigned issue requires. Do NOT:
+
+- Apply drive-by formatter/linter passes to files unrelated to the issue
+- Refactor adjacent code "while you're in there"
+- Delete code that seems unused without explicit approval
+- Add features not in the issue body
+
+If you notice something out of scope, surface it as a follow-up issue suggestion in your final summary. Do not act on it.
+
+### 7. Verification (Core Operating Behavior #6)
+
+A task is not complete until verification passes. "Seems right" is not sufficient.
+
+Required evidence:
+
+- `pytest` (or equivalent) output showing tests pass
+- `ruff check --no-fix` and `ruff format --check` clean
+- CI passing on your PR before you report completion
+
+### 8. Acknowledgement
+
+In your first response after receiving this brief, include the line:
+
+> Contract acknowledged. First two tool calls will be `Skill agent-skills:using-agent-skills` then `Skill agent-skills:context-engineering`.
+
+If that line is absent from your first response, the parent will abort the dispatch.
+
+---
+
+**Why this contract exists:** the 2026-05-13/14 session on issue #327 demonstrated that an agent will improvise the lifecycle as plain workflow labels even when the skills are loaded and available. The user had to call out the failure mode three times before it was corrected. This contract makes the discipline a hard precondition rather than a hope.


### PR DESCRIPTION
## Summary

Two-layer enforcement infrastructure for the agent-skills lifecycle, in response to the 2026-05-13/14 session on #327 where the agent improvised the lifecycle as plain workflow labels rather than invoking the `Skill` tool.

- **Layer 2:** new "Lifecycle discipline (non-negotiable)" section in `CLAUDE.md` — mandates the first two tool calls of any non-trivial response are `Skill agent-skills:using-agent-skills` then `Skill agent-skills:context-engineering`. Exempt: Q&A / status / one-line edits.
- **Layer 3:** new `docs/worker-brief-contract.md` — mandatory contract for every `Agent` tool dispatch. Workers must acknowledge it, follow the first-two-tool-calls rule, emit a `SKILL INVOCATIONS:` manifest in their final summary, and stay in scope per Core Operating Behavior #5.

A fourth layer (PreToolUse hook on Edit/Write/Bash that blocks until a `Skill` invocation has occurred this session) was proposed but deferred — needs user-named authorization per the Claude Code auto-mode classifier. Tracking as a separate follow-up.

## Why this is its own PR

Originally created during the Wave 1 dispatch on 2026-05-15 (workers fixing #345 + #346) but uncommitted at the time. Lost when local `main` was reset to `origin/main` after Wave 1 merged. Restoring on a feature branch ensures persistence.

## Test plan

- [ ] CI passes (docs-only change; Code Quality / Security / Sprint Discipline should all pass)
- [ ] After merge, the next worker dispatch reads `docs/worker-brief-contract.md` and the new CLAUDE.md section before invoking skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)