### PR TITLE
fix: update ROITracker pricing for Claude 4 + wire into pipeline (#333)

### DIFF
--- a/src/agent_sdk/pipeline.py
+++ b/src/agent_sdk/pipeline.py
@@ -23,10 +23,14 @@ from src.agent_sdk.stage3_runner import (
     run_stage3_spike,
 )
 from src.agent_sdk.stage4_runner import run_stage4
+from src.telemetry.roi_tracker import ROITracker, get_tracker
 
 logger = logging.getLogger(__name__)
 
 COST_LOG_PATH = Path("logs/agent_sdk_costs.jsonl")
+
+# Logical agent name used when recording pipeline runs in the ROI tracker.
+ROI_PIPELINE_AGENT = "pipeline"
 
 
 @dataclass
@@ -91,7 +95,42 @@ async def run_pipeline(
         await asyncio.to_thread(_append_cost_log, result, wall_seconds)
     except Exception as exc:
         logger.warning("Cost log write failed (non-fatal): %s", exc)
+    try:
+        await asyncio.to_thread(_record_roi, result)
+    except Exception as exc:
+        logger.warning("ROI telemetry write failed (non-fatal): %s", exc)
     return result
+
+
+def _record_roi(result: PipelineResult) -> None:
+    """Record this pipeline run in the ROI telemetry log.
+
+    Uses the SDK-reported ``total_cost_usd`` rather than the local pricing
+    table so the recorded cost matches the actual API charge. The writer
+    and graphics calls are logged as separate ``log_llm_call`` entries so
+    per-model attribution is preserved in ``logs/execution_roi.json``.
+    """
+    tracker: ROITracker = get_tracker()
+    execution_id = tracker.start_execution(ROI_PIPELINE_AGENT)
+    tracker.log_llm_call(
+        execution_id=execution_id,
+        agent=ROI_PIPELINE_AGENT,
+        model=result.writer_model,
+        input_tokens=0,
+        output_tokens=0,
+        cost_usd=result.writer_cost_usd,
+        metadata={"stage": "writer", "topic": result.topic},
+    )
+    tracker.log_llm_call(
+        execution_id=execution_id,
+        agent=ROI_PIPELINE_AGENT,
+        model=result.graphics_model,
+        input_tokens=0,
+        output_tokens=0,
+        cost_usd=result.graphics_cost_usd,
+        metadata={"stage": "graphics", "topic": result.topic},
+    )
+    tracker.end_execution(execution_id)
 
 
 def _append_cost_log(result: PipelineResult, total_wall_seconds: float) -> None:

--- a/src/telemetry/roi_tracker.py
+++ b/src/telemetry/roi_tracker.py
@@ -19,14 +19,36 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
-# Model pricing (as of Jan 2026) - USD per 1M tokens
+# Model pricing - USD per 1M tokens (base input / output rates).
+#
+# Source: Anthropic API pricing page,
+# https://platform.claude.com/docs/en/docs/about-claude/pricing
+# (fetched 2026-05-15). OpenAI rates retained for legacy log compatibility.
+#
+# NOTE: Cache-write, cache-read, batch, and fast-mode multipliers are NOT
+# modelled here. The pipeline records the SDK-reported total_cost_usd
+# directly via the ``cost_usd`` override on ``log_llm_call``; this table
+# is the fallback when only token counts are known.
 MODEL_PRICING = {
-    "gpt-4o": {"input": 2.50, "output": 10.00},
-    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
-    "gpt-3.5-turbo": {"input": 0.50, "output": 1.50},
+    # Claude 4 family (current, per claude.com/pricing)
+    "claude-opus-4-7": {"input": 5.00, "output": 25.00},
+    "claude-opus-4-6": {"input": 5.00, "output": 25.00},
+    "claude-opus-4-5": {"input": 5.00, "output": 25.00},
+    "claude-opus-4-1": {"input": 15.00, "output": 75.00},
+    "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
+    "claude-sonnet-4-5": {"input": 3.00, "output": 15.00},
+    "claude-haiku-4-5": {"input": 1.00, "output": 5.00},
+    # Deprecated Claude 4 model IDs (retained for legacy log compatibility)
+    "claude-opus-4": {"input": 15.00, "output": 75.00},
+    "claude-sonnet-4": {"input": 3.00, "output": 15.00},
+    # Legacy Claude 3.x model IDs (retained for back-compat with older logs)
     "claude-3-5-sonnet-20241022": {"input": 3.00, "output": 15.00},
     "claude-3-5-haiku-20241022": {"input": 0.80, "output": 4.00},
     "claude-3-opus-20240229": {"input": 15.00, "output": 75.00},
+    # OpenAI (legacy; pipeline does not use OpenAI for text generation)
+    "gpt-4o": {"input": 2.50, "output": 10.00},
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+    "gpt-3.5-turbo": {"input": 0.50, "output": 1.50},
 }
 
 # Human-hour benchmarks (hours to complete task manually)
@@ -163,16 +185,23 @@ class ROITracker:
         input_tokens: int,
         output_tokens: int,
         metadata: dict[str, Any] | None = None,
+        cost_usd: float | None = None,
     ) -> None:
         """Log an LLM call with token usage.
 
         Args:
             execution_id: Execution identifier
             agent: Agent name
-            model: Model name (e.g., "gpt-4o")
+            model: Model name (e.g., "claude-sonnet-4-6")
             input_tokens: Input token count
             output_tokens: Output token count
             metadata: Optional metadata (task, stage, etc.)
+            cost_usd: Optional pre-computed cost in USD. When provided, the
+                ``MODEL_PRICING`` table is bypassed and this value is recorded
+                directly. Use this when the caller already has an authoritative
+                cost (e.g., ``ResultMessage.total_cost_usd`` from the Anthropic
+                SDK), which avoids drift between the SDK's price model and the
+                local pricing table.
 
         """
         start_time = time.perf_counter()
@@ -180,11 +209,14 @@ class ROITracker:
         if execution_id not in self.active_executions:
             raise ValueError(f"Execution {execution_id} not started")
 
-        # Calculate cost
-        pricing = MODEL_PRICING.get(model, {"input": 0, "output": 0})
-        input_cost = (input_tokens / 1_000_000) * pricing["input"]
-        output_cost = (output_tokens / 1_000_000) * pricing["output"]
-        total_cost = input_cost + output_cost
+        # Calculate cost (or use authoritative pre-computed value)
+        if cost_usd is not None:
+            total_cost = float(cost_usd)
+        else:
+            pricing = MODEL_PRICING.get(model, {"input": 0, "output": 0})
+            input_cost = (input_tokens / 1_000_000) * pricing["input"]
+            output_cost = (output_tokens / 1_000_000) * pricing["output"]
+            total_cost = input_cost + output_cost
 
         # Log call
         call_record = {

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -139,3 +139,72 @@ class TestRunPipeline:
 
         assert isinstance(result, PipelineResult)
         assert result.total_cost_usd == pytest.approx(0.05)
+
+
+class TestRoiTelemetryWiring:
+    """Issue #333 AC2: run_pipeline records cost via ROITracker."""
+
+    def test_pipeline_records_writer_and_graphics_cost_in_roi_log(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Writer + graphics costs from PipelineResult land in execution_roi.json."""
+        from src.telemetry.roi_tracker import ROITracker
+
+        # Isolate the cost log and the ROI tracker singleton.
+        monkeypatch.setattr(
+            "src.agent_sdk.pipeline.COST_LOG_PATH", tmp_path / "costs.jsonl"
+        )
+        roi_log = tmp_path / "execution_roi.json"
+        isolated_tracker = ROITracker(log_file=str(roi_log))
+        monkeypatch.setattr(
+            "src.agent_sdk.pipeline.get_tracker", lambda: isolated_tracker
+        )
+
+        stage3 = _fake_stage3()
+        with (
+            patch("src.agent_sdk.pipeline.run_stage3_spike", return_value=stage3),
+            patch(
+                "src.agent_sdk.pipeline.run_stage4",
+                return_value=_fake_stage4(stage3.article),
+            ),
+        ):
+            asyncio.run(run_pipeline("AI Testing"))
+
+        executions = isolated_tracker.log["executions"]
+        assert len(executions) == 1, "Expected one pipeline execution in ROI log"
+        execution = executions[0]
+        assert execution["agent"] == "pipeline"
+        # Total recorded cost equals writer + graphics from the SDK, not a
+        # token-times-pricing recomputation.
+        assert execution["total_cost_usd"] == pytest.approx(
+            stage3.writer_cost_usd + stage3.graphics_cost_usd
+        )
+        # Both calls are individually recorded so per-model attribution holds.
+        models = [call["model"] for call in execution["llm_calls"]]
+        assert stage3.writer_model in models
+        assert stage3.graphics_model in models
+
+    def test_pipeline_returns_result_when_roi_logging_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """ROI telemetry failure is non-fatal — pipeline still returns a result."""
+        monkeypatch.setattr(
+            "src.agent_sdk.pipeline.COST_LOG_PATH", tmp_path / "costs.jsonl"
+        )
+        monkeypatch.setattr(
+            "src.agent_sdk.pipeline._record_roi",
+            MagicMock(side_effect=RuntimeError("disk full")),
+        )
+
+        stage3 = _fake_stage3()
+        with (
+            patch("src.agent_sdk.pipeline.run_stage3_spike", return_value=stage3),
+            patch(
+                "src.agent_sdk.pipeline.run_stage4",
+                return_value=_fake_stage4(stage3.article),
+            ),
+        ):
+            result = asyncio.run(run_pipeline("AI Testing"))
+
+        assert isinstance(result, PipelineResult)
+        assert result.total_cost_usd == pytest.approx(0.05)

--- a/tests/test_roi_telemetry.py
+++ b/tests/test_roi_telemetry.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from src.telemetry.roi_tracker import ROITracker, get_tracker
+from src.telemetry.roi_tracker import MODEL_PRICING, ROITracker, get_tracker
 
 
 class TestROITrackerBasics:
@@ -388,6 +388,51 @@ class TestLogRotation:
             # Verify old execution was removed
             assert len(tracker.log["executions"]) == 1
             assert tracker.log["executions"][0]["execution_id"] != "old_exec"
+
+
+class TestClaude4Pricing:
+    """Issue #333 AC1: Claude 4 model IDs are present with current Anthropic rates.
+
+    Source: https://platform.claude.com/docs/en/docs/about-claude/pricing
+    (fetched 2026-05-15).
+    """
+
+    @pytest.mark.parametrize(
+        "model_id,expected_input,expected_output",
+        [
+            ("claude-sonnet-4-6", 3.00, 15.00),
+            ("claude-sonnet-4-5", 3.00, 15.00),
+            ("claude-opus-4-7", 5.00, 25.00),
+            ("claude-haiku-4-5", 1.00, 5.00),
+        ],
+    )
+    def test_claude_4_model_priced_per_anthropic_rate_card(
+        self, model_id: str, expected_input: float, expected_output: float
+    ):
+        """Each active Claude 4 model ID has the published Anthropic rate."""
+        assert model_id in MODEL_PRICING, (
+            f"{model_id} missing from MODEL_PRICING — production runs would "
+            f"be priced at $0.00 per the .get() fallback."
+        )
+        assert MODEL_PRICING[model_id]["input"] == pytest.approx(expected_input)
+        assert MODEL_PRICING[model_id]["output"] == pytest.approx(expected_output)
+
+    def test_cost_override_bypasses_pricing_table(self):
+        """When ``cost_usd`` is supplied, the pricing table is ignored."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tracker = ROITracker(log_file=str(Path(tmpdir) / "test_roi.json"))
+            execution_id = tracker.start_execution("pipeline")
+            tracker.log_llm_call(
+                execution_id=execution_id,
+                agent="pipeline",
+                model="some-unknown-model",
+                input_tokens=0,
+                output_tokens=0,
+                cost_usd=0.1234,
+            )
+            execution = tracker.active_executions[execution_id]
+            assert execution["total_cost_usd"] == pytest.approx(0.1234)
+            assert execution["llm_calls"][0]["cost_usd"] == pytest.approx(0.1234)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #333

## Summary

`src/telemetry/roi_tracker.py` shipped only pre-2026 model IDs, so every Claude 4 production run was priced at \$0.00 via the `MODEL_PRICING.get(model, {"input": 0, "output": 0})` fallback. The tracker was also never invoked from `run_pipeline`, making the telemetry investment idle.

This change:

1. **AC1** — Adds the active Claude 4 model IDs to `MODEL_PRICING` with rates from Anthropic's official rate card:

   | Model ID | Input USD/MTok | Output USD/MTok |
   |---|---|---|
   | `claude-opus-4-7` | \$5.00 | \$25.00 |
   | `claude-opus-4-6` | \$5.00 | \$25.00 |
   | `claude-opus-4-5` | \$5.00 | \$25.00 |
   | `claude-opus-4-1` | \$15.00 | \$75.00 |
   | `claude-sonnet-4-6` | \$3.00 | \$15.00 |
   | `claude-sonnet-4-5` | \$3.00 | \$15.00 |
   | `claude-haiku-4-5` | \$1.00 | \$5.00 |

   Source: https://platform.claude.com/docs/en/docs/about-claude/pricing (fetched 2026-05-15). Deprecated IDs (`claude-opus-4`, `claude-sonnet-4`) are kept for back-compat with historical logs.

2. **AC2** — Wires `ROITracker` into `run_pipeline()`. Each run now produces a `"pipeline"` execution in `logs/execution_roi.json` with two `log_llm_call` entries (writer + graphics) carrying the SDK-reported `total_cost_usd` directly via a new optional `cost_usd` parameter. This avoids drift between the SDK's authoritative price model and the local table. ROI write failures are caught and logged — the pipeline still returns its result.

### Sample `logs/execution_roi.json` entry

```json
{
  "execution_id": "pipeline_20260515_054508",
  "agent": "pipeline",
  "llm_calls": [
    {
      "model": "claude-sonnet-4-6",
      "cost_usd": 0.085,
      "metadata": {"stage": "writer", "topic": "..."}
    },
    {
      "model": "claude-sonnet-4-6",
      "cost_usd": 0.025,
      "metadata": {"stage": "graphics", "topic": "..."}
    }
  ],
  "total_cost_usd": 0.11,
  "roi_multiplier": 681.82
}
```

## Verification

- `pytest tests/ -q` — 1741 passed, 84 skipped, 0 failures
- `ruff check --no-fix` and `ruff format --check` on the four changed files — clean
- New tests:
  - `tests/test_roi_telemetry.py::TestClaude4Pricing::test_claude_4_model_priced_per_anthropic_rate_card` (parametrised over sonnet-4-6, sonnet-4-5, opus-4-7, haiku-4-5)
  - `tests/test_roi_telemetry.py::TestClaude4Pricing::test_cost_override_bypasses_pricing_table`
  - `tests/test_pipeline.py::TestRoiTelemetryWiring::test_pipeline_records_writer_and_graphics_cost_in_roi_log`
  - `tests/test_pipeline.py::TestRoiTelemetryWiring::test_pipeline_returns_result_when_roi_logging_fails`

## Test plan

- [x] Unit tests cover both ACs
- [x] Full test suite passes
- [x] Ruff lint + format clean on changed files
- [x] Verified end-to-end by running `run_pipeline` against mocked stage runners and inspecting `execution_roi.json`