### PR TITLE
fix: surface budget-exceeded as typed error in flow.py (#340)

### DIFF
--- a/src/agent_sdk/_shared.py
+++ b/src/agent_sdk/_shared.py
@@ -19,6 +19,22 @@ class EmptyResearchBriefError(RuntimeError):
     """Raised when all web searches return no results, preventing an unsourced LLM call."""
 
 
+class BudgetExceededError(RuntimeError):
+    """Raised when an Agent SDK call hits its ``max_budget_usd`` cap.
+
+    The SDK signals budget exhaustion by emitting a ``ResultMessage`` with
+    ``subtype="error_max_budget_usd"`` and ``is_error=True`` (see
+    ``claude_agent_sdk.types.ClaudeAgentOptions.max_budget_usd`` docstring).
+    The Stage 3 runner inspects that signal and re-raises this typed error so
+    callers (notably ``flow.py:generate_content``) can route a clean abort
+    instead of crashing with an unhandled exception.
+    """
+
+    def __init__(self, message: str, *, budget_usd: float | None = None) -> None:
+        self.budget_usd = budget_usd
+        super().__init__(message)
+
+
 _DEFAULT_VISION_MODEL = "claude-sonnet-4-6"
 _ALLOWED_MODELS: frozenset[str] = frozenset(
     {

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -41,6 +41,7 @@ from src.agent_sdk._shared import (
 )
 from src.agent_sdk._shared import (
     GRAPHICS_AGENT_PROMPT,
+    BudgetExceededError,
     build_research_brief,
 )
 from src.agent_sdk._shared import (
@@ -199,6 +200,27 @@ async def _collect_text(
                     text_chunks.append(block.text)
         elif isinstance(msg, ResultMessage):
             cost = float(msg.total_cost_usd or 0.0)
+            # The Agent SDK signals budget exhaustion by returning a
+            # ResultMessage with subtype="error_max_budget_usd" rather than
+            # raising. Surface it as a typed BudgetExceededError so callers
+            # can route a clean abort. See claude_agent_sdk.types
+            # ClaudeAgentOptions.max_budget_usd docstring.
+            if msg.subtype == "error_max_budget_usd":
+                cap_str = (
+                    f"${max_budget_usd:.4f}"
+                    if max_budget_usd is not None
+                    else "<unset>"
+                )
+                logger.warning(
+                    "Agent SDK budget exceeded: cap=%s, cost_at_abort=$%.4f",
+                    cap_str,
+                    cost,
+                )
+                raise BudgetExceededError(
+                    f"Agent SDK budget exceeded: cap={cap_str}, "
+                    f"cost_at_abort=${cost:.4f}",
+                    budget_usd=max_budget_usd,
+                )
 
     pieces: list[str] = []
     for chunk in text_chunks:

--- a/src/economist_agents/flow.py
+++ b/src/economist_agents/flow.py
@@ -39,7 +39,11 @@ import yaml as _yaml
 
 from scripts.article_evaluator import ArticleEvaluator
 from scripts.frontmatter_schema import FrontmatterSchema
-from src.agent_sdk._shared import EmptyResearchBriefError, refine_image_metadata
+from src.agent_sdk._shared import (
+    BudgetExceededError,
+    EmptyResearchBriefError,
+    refine_image_metadata,
+)
 from src.agent_sdk.pipeline import run_pipeline
 from src.agent_sdk.stage3_runner import MalformedArticleError
 from src.economist_agents.adapters import (
@@ -93,22 +97,43 @@ class EconomistContentFlow:
         topics = self.discover_topics()
         selected = self.editorial_review(topics)
         draft = self.generate_content(selected)
-        decision = self.quality_gate(draft)
-        if decision == "publish":
-            result = self.publish_article()
+        # Budget-exceeded is a hard abort — revising won't lower per-call
+        # cost, so skip the quality_gate/revision dance entirely.
+        if self.state.get("abort_reason") == "budget_exceeded":
+            result = self._budget_exceeded_result()
         else:
-            result = self.request_revision()
+            decision = self.quality_gate(draft)
+            if decision == "publish":
+                result = self.publish_article()
+            else:
+                result = self.request_revision()
         self._write_pipeline_result(result)
         return result
+
+    def _budget_exceeded_result(self) -> dict[str, Any]:
+        """Terminal pipeline result when an Agent SDK call hit max_budget_usd."""
+        print("⛔ Flow aborted: budget exceeded")
+        return {
+            "status": "budget_exceeded",
+            "editorial_score": 0,
+            "gates_passed": 0,
+            "revision_reason": self.state.get(
+                "revision_reason", "Agent SDK budget exceeded"
+            ),
+            "budget_usd": self.state.get("budget_usd"),
+        }
 
     def _write_pipeline_result(self, result: dict[str, Any]) -> None:
         """Write output/pipeline_result.json for the CI metrics step in content-pipeline.yml."""
         PIPELINE_RESULT_PATH.parent.mkdir(parents=True, exist_ok=True)
-        payload = {
+        payload: dict[str, Any] = {
             "status": result.get("status", "unknown"),
             "editorial_score": result.get("editorial_score", 0),
             "gates_passed": result.get("gates_passed", 0),
         }
+        if result.get("status") == "budget_exceeded":
+            payload["revision_reason"] = result.get("revision_reason", "")
+            payload["budget_usd"] = result.get("budget_usd")
         try:
             PIPELINE_RESULT_PATH.write_bytes(orjson.dumps(payload))
         except Exception as exc:
@@ -240,6 +265,18 @@ class EconomistContentFlow:
             return self._null_article_draft(
                 "empty_research_brief",
                 "No web search results — check SERPER_API_KEY and retry.",
+            )
+        except BudgetExceededError as exc:
+            # Hard abort. Revising won't lower per-call cost — it just burns
+            # more budget — so we mark the run terminal and let kickoff()
+            # short-circuit to a `status: budget_exceeded` pipeline result.
+            logger.error("Agent SDK budget exceeded — aborting pipeline: %s", exc)
+            self.state["abort_reason"] = "budget_exceeded"
+            self.state["revision_reason"] = str(exc)
+            self.state["budget_usd"] = exc.budget_usd
+            return self._null_article_draft(
+                "budget_exceeded",
+                f"Agent SDK budget exceeded — pipeline aborted: {exc}",
             )
         article = result.article
         print(f"   ✅ Article generated: {len(article.split())} words")
@@ -441,6 +478,17 @@ class EconomistContentFlow:
 
         try:
             result = asyncio.run(run_pipeline(enhanced_topic))
+        except BudgetExceededError as exc:
+            # Budget caps don't get fixed by retrying — abort cleanly.
+            logger.error("Agent SDK budget exceeded on revision — aborting: %s", exc)
+            return {
+                "status": "budget_exceeded",
+                "editorial_score": 0,
+                "gates_passed": 0,
+                "revision_reason": str(exc),
+                "budget_usd": exc.budget_usd,
+                "retry_count": retry_count + 1,
+            }
         except (MalformedArticleError, EmptyResearchBriefError) as exc:
             logger.warning("Pipeline error on revision — quarantining: %s", exc)
             return {

--- a/tests/test_budget_exceeded.py
+++ b/tests/test_budget_exceeded.py
@@ -1,0 +1,224 @@
+"""Prove-it tests for #340: surface Agent SDK budget exhaustion as a typed error.
+
+Verifies that:
+1. ``BudgetExceededError`` is a ``RuntimeError`` subclass living alongside
+   ``EmptyResearchBriefError`` in ``src/agent_sdk/_shared.py``.
+2. ``_collect_text`` in ``stage3_runner.py`` raises ``BudgetExceededError``
+   when the Agent SDK emits a ``ResultMessage`` with
+   ``subtype="error_max_budget_usd"`` (and does NOT raise for normal
+   ``subtype="success"`` results).
+3. ``flow.generate_content`` catches ``BudgetExceededError`` and produces a
+   terminal pipeline result with ``status: "budget_exceeded"`` — it does NOT
+   route to revision (the budget is a hard cap, not a content problem).
+4. ``flow.request_revision`` also short-circuits to ``status: "budget_exceeded"``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
+# ── Unit: BudgetExceededError class ─────────────────────────────────────────
+
+
+class TestBudgetExceededErrorClass:
+    def test_is_runtime_error_subclass(self) -> None:
+        from src.agent_sdk._shared import BudgetExceededError
+
+        assert issubclass(BudgetExceededError, RuntimeError)
+
+    def test_carries_budget_usd(self) -> None:
+        from src.agent_sdk._shared import BudgetExceededError
+
+        err = BudgetExceededError("cap hit", budget_usd=0.30)
+        assert err.budget_usd == 0.30
+        assert "cap hit" in str(err)
+
+    def test_lives_next_to_empty_research_brief_error(self) -> None:
+        """Both error types must export from the same module for symmetry."""
+        from src.agent_sdk import _shared
+
+        assert hasattr(_shared, "BudgetExceededError")
+        assert hasattr(_shared, "EmptyResearchBriefError")
+
+
+# ── Unit: _collect_text detects subtype="error_max_budget_usd" ──────────────
+
+
+def _make_assistant_msg(text: str) -> AssistantMessage:
+    return AssistantMessage(content=[TextBlock(text=text)], model="claude-sonnet-4-6")
+
+
+def _make_result_msg(
+    subtype: str = "success",
+    is_error: bool = False,
+    total_cost_usd: float | None = 0.05,
+) -> ResultMessage:
+    return ResultMessage(
+        subtype=subtype,
+        duration_ms=1000,
+        duration_api_ms=900,
+        is_error=is_error,
+        num_turns=1,
+        session_id="test-session",
+        total_cost_usd=total_cost_usd,
+    )
+
+
+async def _async_iter(items: list) -> AsyncIterator:
+    for item in items:
+        yield item
+
+
+class TestCollectTextBudgetDetection:
+    def test_raises_budget_exceeded_when_subtype_signals_budget(self) -> None:
+        """The Agent SDK signals budget exhaustion via ResultMessage subtype,
+        not by raising. _collect_text must inspect and re-raise as a typed error.
+        """
+        from src.agent_sdk._shared import BudgetExceededError
+        from src.agent_sdk.stage3_runner import _collect_text
+
+        messages = [
+            _make_assistant_msg("partial output"),
+            _make_result_msg(
+                subtype="error_max_budget_usd",
+                is_error=True,
+                total_cost_usd=0.31,
+            ),
+        ]
+
+        def _fake_query(prompt: str, options):  # noqa: ANN001 — mock signature
+            return _async_iter(messages)
+
+        with (
+            patch("src.agent_sdk.stage3_runner.query", side_effect=_fake_query),
+            pytest.raises(BudgetExceededError) as excinfo,
+        ):
+            asyncio.run(
+                _collect_text(
+                    prompt="hi",
+                    system_prompt="sys",
+                    max_budget_usd=0.30,
+                )
+            )
+
+        # Message must include the cap and the cost we hit it at.
+        assert excinfo.value.budget_usd == 0.30
+        assert "0.30" in str(excinfo.value)
+        assert "0.31" in str(excinfo.value)
+
+    def test_does_not_raise_on_normal_success_subtype(self) -> None:
+        """Belt-and-braces: a vanilla success ResultMessage must NOT trip the
+        budget guard (the previous implementation didn't inspect subtype at all).
+        """
+        from src.agent_sdk.stage3_runner import _collect_text
+
+        messages = [
+            _make_assistant_msg("article body"),
+            _make_result_msg(subtype="success", is_error=False, total_cost_usd=0.05),
+        ]
+
+        def _fake_query(prompt: str, options):  # noqa: ANN001 — mock signature
+            return _async_iter(messages)
+
+        with patch("src.agent_sdk.stage3_runner.query", side_effect=_fake_query):
+            text, cost = asyncio.run(
+                _collect_text(
+                    prompt="hi",
+                    system_prompt="sys",
+                    max_budget_usd=0.30,
+                )
+            )
+
+        assert "article body" in text
+        assert cost == 0.05
+
+
+# ── Integration: flow.py routes BudgetExceededError to clean abort ──────────
+
+
+class TestFlowBudgetExceededRouting:
+    def test_generate_content_returns_budget_exceeded_draft(self) -> None:
+        from src.agent_sdk._shared import BudgetExceededError
+        from src.economist_agents.flow import EconomistContentFlow
+
+        flow = EconomistContentFlow()
+
+        with patch(
+            "src.economist_agents.flow.asyncio.run",
+            side_effect=BudgetExceededError("cap $0.30 hit", budget_usd=0.30),
+        ):
+            draft = flow.generate_content({"topic": "AI Testing"})
+
+        # Routes through the null-draft path (so quality_gate can see the failure).
+        assert draft["publication_validator_passed"] is False
+        assert draft["editorial_score"] == 0
+        # Critically, flow.state records the abort so kickoff() short-circuits.
+        assert flow.state.get("abort_reason") == "budget_exceeded"
+        assert flow.state.get("budget_usd") == 0.30
+        # The null-draft surfaces the typed reason in its issues.
+        issues = draft["publication_validator_issues"]
+        assert any(i.get("check") == "budget_exceeded" for i in issues)
+
+    def test_kickoff_short_circuits_on_budget_exceeded(self) -> None:
+        """When generate_content sets abort_reason, kickoff() must skip the
+        quality_gate/revision dance and emit a budget_exceeded terminal result.
+        """
+        from src.agent_sdk._shared import BudgetExceededError
+        from src.economist_agents.flow import EconomistContentFlow
+
+        flow = EconomistContentFlow()
+
+        # Stub the stages that run before generate_content.
+        flow.discover_topics = MagicMock(  # type: ignore[method-assign]
+            return_value={"topics": [{"topic": "AI Testing", "raw": {}}]}
+        )
+        flow.editorial_review = MagicMock(  # type: ignore[method-assign]
+            return_value={"topic": "AI Testing"}
+        )
+        # Sentinels — they MUST NOT be called when budget exceeded.
+        flow.quality_gate = MagicMock()  # type: ignore[method-assign]
+        flow.request_revision = MagicMock()  # type: ignore[method-assign]
+        flow.publish_article = MagicMock()  # type: ignore[method-assign]
+        flow._write_pipeline_result = MagicMock()  # type: ignore[method-assign]
+
+        with patch(
+            "src.economist_agents.flow.asyncio.run",
+            side_effect=BudgetExceededError("cap hit", budget_usd=0.30),
+        ):
+            result = flow.kickoff()
+
+        assert result["status"] == "budget_exceeded"
+        assert result["budget_usd"] == 0.30
+        assert result["editorial_score"] == 0
+        assert result["gates_passed"] == 0
+        # Revision/publish/quality_gate must NOT run — budget is a hard abort.
+        flow.quality_gate.assert_not_called()
+        flow.request_revision.assert_not_called()
+        flow.publish_article.assert_not_called()
+
+    def test_request_revision_returns_budget_exceeded_status(self) -> None:
+        """Defense in depth: direct callers of request_revision get the same
+        clean abort behaviour rather than thrashing through retries.
+        """
+        from src.agent_sdk._shared import BudgetExceededError
+        from src.economist_agents.flow import EconomistContentFlow
+
+        flow = EconomistContentFlow()
+        flow.state["selected_topic"] = {"topic": "AI Testing"}
+        flow.state["revision_feedback"] = ["fix something"]
+        flow.state["article_draft"] = {"featured_image": ""}
+
+        with patch(
+            "src.economist_agents.flow.asyncio.run",
+            side_effect=BudgetExceededError("cap hit", budget_usd=0.30),
+        ):
+            result = flow.request_revision()
+
+        assert result["status"] == "budget_exceeded"
+        assert result["budget_usd"] == 0.30
+        assert result["editorial_score"] == 0


### PR DESCRIPTION
## Summary

Surfaces Agent SDK `max_budget_usd` exhaustion as a typed `BudgetExceededError` so `flow.py` can route a clean abort instead of crashing on missing writer output.

- New error class `BudgetExceededError` in `src/agent_sdk/_shared.py`, mirroring the existing `EmptyResearchBriefError` pattern (both `RuntimeError` subclasses).
- `_collect_text` in `stage3_runner.py` inspects the terminal `ResultMessage` for `subtype="error_max_budget_usd"` and re-raises with the cap + observed cost.
- `flow.py:generate_content` catches `BudgetExceededError`, marks `state["abort_reason"] = "budget_exceeded"`, and `kickoff()` short-circuits past `quality_gate`/`request_revision` straight to a `status: "budget_exceeded"` pipeline result.
- `request_revision` also catches the same exception (defense in depth for direct callers).
- `output/pipeline_result.json` now carries `revision_reason` and `budget_usd` when status is `budget_exceeded`.

## Routing decision

**Clean abort, not revision.** The Agent SDK budget is an infrastructure cap, not an output-quality issue — re-running the writer with feedback can't lower per-call cost, it just burns more budget. The new `kickoff()` branch makes that explicit.

## Source

- Agent SDK signals budget exhaustion via `ResultMessage` rather than an exception. Confirmed in `claude_agent_sdk.types.ClaudeAgentOptions.max_budget_usd` docstring ("returning an `error_max_budget_usd` result") and `claude_agent_sdk._errors` (no budget-specific exception class exists).

## Test plan

- [x] `tests/test_budget_exceeded.py` — 8 prove-it tests covering the error class, `_collect_text` subtype detection (positive + negative), `generate_content` routing, `kickoff()` short-circuit, and `request_revision` clean abort.
- [x] `pytest tests/test_flow_agent_sdk.py tests/test_pipeline.py tests/test_empty_research_guard.py tests/test_budget_exceeded.py` — 59 passed.
- [x] `ruff check --no-fix` clean, `ruff format --check` clean across all touched files.

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)