### PR TITLE
chore: rename spike artefacts to production names in stage3_runner (#331)

### DIFF
--- a/src/agent_sdk/pipeline.py
+++ b/src/agent_sdk/pipeline.py
@@ -20,7 +20,7 @@ import orjson
 from src.agent_sdk.stage3_runner import (
     DEFAULT_GRAPHICS_MODEL,
     DEFAULT_WRITER_MODEL,
-    run_stage3_spike,
+    run_stage3,
 )
 from src.agent_sdk.stage4_runner import run_stage4
 from src.telemetry.roi_tracker import ROITracker, get_tracker
@@ -63,7 +63,7 @@ async def run_pipeline(
     graphics_model: str = DEFAULT_GRAPHICS_MODEL,
 ) -> PipelineResult:
     """Generate one article through the Agent SDK pipeline."""
-    stage3 = await run_stage3_spike(
+    stage3 = await run_stage3(
         topic,
         writer_budget_usd=writer_budget_usd,
         graphics_budget_usd=graphics_budget_usd,

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -1,9 +1,9 @@
-"""Stage 3 spike — Writer + Graphics on the Anthropic Agent SDK.
+"""Stage 3 production runtime — Writer + Graphics on the Anthropic Agent SDK.
 
-Replaces ``src/crews/stage3_crew.py`` for the Phase 2 spike (ADR-0006,
-epic #308, story #309). The CrewAI path remains the production code
-path; this module runs side-by-side so the comparison report has data
-from both runtimes on the same topic.
+This is the sole production runtime for Stage 3 (article + chart
+generation). It originated as the Phase 2 spike that replaced
+``src/crews/stage3_crew.py`` (ADR-0006, epic #308, story #309); the
+CrewAI path has since been removed.
 
 Design:
 - Research stays deterministic — calls ``build_research_brief`` from
@@ -116,8 +116,8 @@ FORMATTING:
 
 
 @dataclass
-class SpikeResult:
-    """Captured metrics from a Stage 3 spike run."""
+class Stage3Result:
+    """Captured metrics from a Stage 3 run."""
 
     topic: str
     article: str
@@ -252,13 +252,13 @@ def _parse_chart_json(text: str) -> dict:
         return {"specification": text}
 
 
-async def run_stage3_spike(
+async def run_stage3(
     topic: str,
     writer_budget_usd: float | None = 0.30,
     graphics_budget_usd: float | None = 0.10,
     writer_model: str = DEFAULT_WRITER_MODEL,
     graphics_model: str = DEFAULT_GRAPHICS_MODEL,
-) -> SpikeResult:
+) -> Stage3Result:
     """Generate one article via the Agent SDK and return captured metrics.
 
     Mirrors ``Stage3Crew.kickoff`` so output is comparable.
@@ -278,7 +278,7 @@ async def run_stage3_spike(
             4.6; override with GRAPHICS_MODEL env var.
 
     Returns:
-        SpikeResult with article text, chart dict, cost, and timing.
+        Stage3Result with article text, chart dict, cost, and timing.
 
     """
     start = time.perf_counter()
@@ -352,7 +352,7 @@ async def run_stage3_spike(
 
     elapsed = time.perf_counter() - start
 
-    return SpikeResult(
+    return Stage3Result(
         topic=topic,
         article=article,
         chart_data=chart_data,
@@ -369,7 +369,7 @@ async def run_stage3_spike(
 
 
 def main() -> None:
-    """CLI entrypoint — write spike artefacts to ``logs/spike/``."""
+    """CLI entrypoint — write Stage 3 artefacts to ``logs/spike/``."""
     logging.basicConfig(
         level=logging.INFO,
         format="%(levelname)s %(name)s: %(message)s",
@@ -379,8 +379,8 @@ def main() -> None:
         if len(sys.argv) > 1
         else "developer productivity in the age of AI coding agents"
     )
-    print(f"Running Stage 3 spike on topic: {topic}")
-    result = asyncio.run(run_stage3_spike(topic))
+    print(f"Running Stage 3 on topic: {topic}")
+    result = asyncio.run(run_stage3(topic))
 
     out_dir = Path("logs/spike")
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -396,7 +396,7 @@ def main() -> None:
     )
 
     print(
-        f"Spike complete: ${result.total_cost_usd:.4f} "
+        f"Stage 3 complete: ${result.total_cost_usd:.4f} "
         f"(writer ${result.writer_cost_usd:.4f}, "
         f"graphics ${result.graphics_cost_usd:.4f}), "
         f"{result.wall_seconds:.1f}s, "

--- a/tests/test_empty_research_guard.py
+++ b/tests/test_empty_research_guard.py
@@ -3,7 +3,7 @@
 Verifies that:
 1. build_research_brief raises EmptyResearchBriefError when both web
    searches return nothing, preventing any LLM call on zero sourcing.
-2. run_stage3_spike propagates the error (does not swallow it).
+2. run_stage3 propagates the error (does not swallow it).
 3. EconomistContentFlow.generate_content and request_revision route it
    to revision rather than crashing or publishing fabricated content.
 """
@@ -60,16 +60,16 @@ class TestEmptyResearchBriefError:
 
         assert "Some result" in brief
 
-    def test_run_stage3_spike_propagates_empty_research_error(self) -> None:
-        """EmptyResearchBriefError must not be swallowed by run_stage3_spike."""
+    def test_run_stage3_propagates_empty_research_error(self) -> None:
+        """EmptyResearchBriefError must not be swallowed by run_stage3."""
         from src.agent_sdk._shared import EmptyResearchBriefError
-        from src.agent_sdk.stage3_runner import run_stage3_spike
+        from src.agent_sdk.stage3_runner import run_stage3
 
         with (
             patch("src.agent_sdk._shared._run_web_searches", return_value=""),
             pytest.raises(EmptyResearchBriefError),
         ):
-            asyncio.run(run_stage3_spike("AI Testing"))
+            asyncio.run(run_stage3("AI Testing"))
 
 
 # ── Integration: flow.py routing ─────────────────────────────────────────────

--- a/tests/test_malformed_article_guard.py
+++ b/tests/test_malformed_article_guard.py
@@ -1,7 +1,7 @@
 """Prove-it tests for #323: malformed writer output guard.
 
 Verifies that:
-1. run_stage3_spike raises MalformedArticleError when the LLM returns prose
+1. run_stage3 raises MalformedArticleError when the LLM returns prose
    instead of a well-formed article (unit level).
 2. EconomistContentFlow.generate_content catches MalformedArticleError and
    returns a dict that quality_gate routes to revision (integration level).
@@ -25,9 +25,9 @@ class TestMalformedArticleError:
 
         assert issubclass(MalformedArticleError, ValueError)
 
-    def test_run_stage3_spike_raises_on_prose_output(self) -> None:
+    def test_run_stage3_raises_on_prose_output(self) -> None:
         """When the writer returns plain prose (no ---), raise MalformedArticleError."""
-        from src.agent_sdk.stage3_runner import MalformedArticleError, run_stage3_spike
+        from src.agent_sdk.stage3_runner import MalformedArticleError, run_stage3
 
         prose = "I apologise, but I cannot write that article at this time."
 
@@ -41,11 +41,11 @@ class TestMalformedArticleError:
             ),
             pytest.raises(MalformedArticleError),
         ):
-            asyncio.run(run_stage3_spike("AI Testing"))
+            asyncio.run(run_stage3("AI Testing"))
 
-    def test_run_stage3_spike_raises_on_empty_body(self) -> None:
+    def test_run_stage3_raises_on_empty_body(self) -> None:
         """Frontmatter with no body is also malformed."""
-        from src.agent_sdk.stage3_runner import MalformedArticleError, run_stage3_spike
+        from src.agent_sdk.stage3_runner import MalformedArticleError, run_stage3
 
         no_body = "---\nlayout: post\ntitle: Test\n---\n"
 
@@ -59,11 +59,11 @@ class TestMalformedArticleError:
             ),
             pytest.raises(MalformedArticleError),
         ):
-            asyncio.run(run_stage3_spike("AI Testing"))
+            asyncio.run(run_stage3("AI Testing"))
 
-    def test_run_stage3_spike_does_not_raise_on_valid_article(self) -> None:
+    def test_run_stage3_does_not_raise_on_valid_article(self) -> None:
         """Well-formed frontmatter + body must not raise."""
-        from src.agent_sdk.stage3_runner import run_stage3_spike
+        from src.agent_sdk.stage3_runner import run_stage3
 
         valid = (
             '---\nlayout: post\ntitle: "Test"\ndate: 2026-01-01\n'
@@ -87,7 +87,7 @@ class TestMalformedArticleError:
                 ),
             ),
         ):
-            result = asyncio.run(run_stage3_spike("AI Testing"))
+            result = asyncio.run(run_stage3("AI Testing"))
             assert result.article.startswith("---")
 
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -55,7 +55,7 @@ class TestRunPipeline:
         stage3 = _fake_stage3()
 
         with (
-            patch("src.agent_sdk.pipeline.run_stage3_spike", return_value=stage3),
+            patch("src.agent_sdk.pipeline.run_stage3", return_value=stage3),
             patch(
                 "src.agent_sdk.pipeline.run_stage4",
                 return_value=_fake_stage4(stage3.article),
@@ -77,7 +77,7 @@ class TestRunPipeline:
         stage3 = _fake_stage3()
 
         with (
-            patch("src.agent_sdk.pipeline.run_stage3_spike", return_value=stage3),
+            patch("src.agent_sdk.pipeline.run_stage3", return_value=stage3),
             patch(
                 "src.agent_sdk.pipeline.run_stage4",
                 return_value=_fake_stage4(stage3.article),
@@ -102,7 +102,7 @@ class TestRunPipeline:
         stage3 = _fake_stage3()
 
         with (
-            patch("src.agent_sdk.pipeline.run_stage3_spike", return_value=stage3),
+            patch("src.agent_sdk.pipeline.run_stage3", return_value=stage3),
             patch(
                 "src.agent_sdk.pipeline.run_stage4",
                 return_value=_fake_stage4(stage3.article),
@@ -125,7 +125,7 @@ class TestRunPipeline:
         stage3 = _fake_stage3()
 
         with (
-            patch("src.agent_sdk.pipeline.run_stage3_spike", return_value=stage3),
+            patch("src.agent_sdk.pipeline.run_stage3", return_value=stage3),
             patch(
                 "src.agent_sdk.pipeline.run_stage4",
                 return_value=_fake_stage4(stage3.article),
@@ -162,7 +162,7 @@ class TestRoiTelemetryWiring:
 
         stage3 = _fake_stage3()
         with (
-            patch("src.agent_sdk.pipeline.run_stage3_spike", return_value=stage3),
+            patch("src.agent_sdk.pipeline.run_stage3", return_value=stage3),
             patch(
                 "src.agent_sdk.pipeline.run_stage4",
                 return_value=_fake_stage4(stage3.article),
@@ -198,7 +198,7 @@ class TestRoiTelemetryWiring:
 
         stage3 = _fake_stage3()
         with (
-            patch("src.agent_sdk.pipeline.run_stage3_spike", return_value=stage3),
+            patch("src.agent_sdk.pipeline.run_stage3", return_value=stage3),
             patch(
                 "src.agent_sdk.pipeline.run_stage4",
                 return_value=_fake_stage4(stage3.article),


### PR DESCRIPTION
## Summary

Stage 3 (`src/agent_sdk/stage3_runner.py`) has been the sole production runtime for article + chart generation since the CrewAI removal, but the module docstring, the `SpikeResult` dataclass, and the `run_stage3_spike` function still described themselves as a "Phase 2 spike running side-by-side with CrewAI." That language now misleads future contributors. This PR renames the spike artefacts to production names.

Closes #331

## Renamed symbols

- `run_stage3_spike` → `run_stage3`
- `SpikeResult` → `Stage3Result`
- Module docstring rewritten to reflect production status (removed "Phase 2 spike" / "runs side-by-side" language)

## Callers updated

- `src/agent_sdk/pipeline.py` (import + call site)
- `tests/test_pipeline.py` (6 `patch(...)` targets)
- `tests/test_malformed_article_guard.py` (3 imports + 3 call sites + 1 docstring + 3 test method names)
- `tests/test_empty_research_guard.py` (1 import + 1 call site + 1 docstring + 1 test method name)

No behaviour change. The CLI artefact filenames (`logs/spike/agent_sdk_*.json`) are out of scope — they are file paths, not Python symbols, and the issue scopes the rename to identifiers in `stage3_runner.py`.

## Test plan

- [x] `pytest tests/ -q` — 1813 passed, 27 skipped (no new failures)
- [x] `ruff check --no-fix` — All checks passed
- [x] `ruff format --check` — 5 files already formatted
- [x] `grep -rn "run_stage3_spike\|SpikeResult" --include="*.py"` returns no matches

## Acceptance criteria

- [x] **AC1** — `run_stage3_spike` no longer exists; renamed to `run_stage3`. Same for `SpikeResult` → `Stage3Result`.
- [x] **AC2** — All callers in `src/agent_sdk/pipeline.py` and test files updated.
- [x] **AC3** — Module docstring updated to reflect production status.
- [x] **AC4** — `pytest tests/ -q` passes (no regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)