### PR TITLE
feat: wire StyleMemoryTool into stage3_runner writer prompt (#339)

### DIFF
--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -51,6 +51,32 @@ from src.agent_sdk._shared import (
 logger = logging.getLogger(__name__)
 
 
+def _fetch_style_context(topic: str) -> str:
+    """Fetch a style-memory exemplar block for the writer prompt.
+
+    Isolated from ``run_stage3`` so the StyleMemoryTool import (which
+    transitively pulls in ChromaDB) is paid only when the runtime needs
+    it, and so tests can monkeypatch this function without touching the
+    tool itself.
+
+    Returns an empty string when the tool is unavailable, errors out, or
+    returns no exemplars above the relevance threshold — callers must
+    omit the ``## Style Memory`` section entirely in that case.
+    """
+    try:
+        from src.tools.style_memory_tool import StyleMemoryTool
+    except ImportError as exc:
+        logger.info("StyleMemoryTool unavailable (%s); skipping style context", exc)
+        return ""
+
+    try:
+        tool = StyleMemoryTool()
+        return tool.get_style_context(topic)
+    except Exception as exc:  # noqa: BLE001 — style memory is best-effort
+        logger.warning("StyleMemoryTool.get_style_context failed: %s", exc)
+        return ""
+
+
 class MalformedArticleError(ValueError):
     """Raised when the writer agent returns output that is not a well-formed article."""
 
@@ -286,6 +312,13 @@ async def run_stage3(
     research_brief = build_research_brief(topic)
     logger.info("Research brief: %d chars", len(research_brief))
 
+    style_context = _fetch_style_context(topic)
+    if style_context:
+        logger.info("Style memory: %d chars of exemplars", len(style_context))
+        style_section = f"\n\n## Style Memory\n\n{style_context}"
+    else:
+        style_section = ""
+
     writer_prompt = (
         f"Write the complete Economist-style article on this topic: {topic}\n\n"
         f"Output the entire article text with YAML frontmatter at the top. "
@@ -310,6 +343,7 @@ async def run_stage3(
         f"RESEARCH BRIEF (use ONLY these sources and statistics — do NOT "
         f"invent any statistics, researcher names, or URLs):\n\n"
         f"{research_brief}"
+        f"{style_section}"
     )
     raw_writer_output, writer_cost = await _collect_text(
         writer_prompt,

--- a/src/tools/style_memory_tool.py
+++ b/src/tools/style_memory_tool.py
@@ -235,6 +235,63 @@ class StyleMemoryTool:
             print(f"⚠️  Style Memory query failed: {e}")
             return []
 
+    def get_style_context(
+        self,
+        topic: str,
+        n_results: int = 3,
+        min_score: float = 0.7,
+    ) -> str:
+        """Return a formatted markdown block of style exemplars for a topic.
+
+        Designed for injection into the Stage 3 writer prompt. Queries the
+        underlying ChromaDB collection for paragraphs from Gold Standard
+        articles most relevant to ``topic`` and returns them as a markdown
+        snippet the writer can use as voice exemplars.
+
+        Graceful degradation: returns an empty string when ChromaDB is
+        unavailable, the collection is empty, or no results clear the
+        ``min_score`` threshold. Callers should treat an empty return as
+        "omit the section entirely" — never emit an empty heading.
+
+        Args:
+            topic: Article topic to retrieve style exemplars for.
+            n_results: Maximum number of exemplars to return.
+            min_score: Minimum relevance score (0-1) to include.
+
+        Returns:
+            Markdown-formatted style exemplars, or ``""`` if none are
+            available.
+
+        """
+        if not topic or not topic.strip():
+            return ""
+
+        results = self.query(topic, n_results=n_results, min_score=min_score)
+        if not results:
+            return ""
+
+        lines: list[str] = [
+            "Reference these voice exemplars from Gold Standard articles. "
+            "Mirror their cadence, sentence shape, and tone — do not copy "
+            "their facts.",
+            "",
+        ]
+        for idx, result in enumerate(results, 1):
+            source = result.get("source", "unknown")
+            score = result.get("score", 0.0)
+            text = result.get("text", "").strip()
+            if not text:
+                continue
+            lines.append(f"{idx}. (source: {source}, score: {score:.2f})")
+            lines.append(f"   > {text}")
+            lines.append("")
+
+        # If every result had empty text, return "" rather than a header.
+        if len(lines) <= 2:
+            return ""
+
+        return "\n".join(lines).rstrip() + "\n"
+
     def get_stats(self) -> dict[str, Any]:
         """Get Style Memory Tool statistics.
 

--- a/tests/test_stage3_style_memory_wiring.py
+++ b/tests/test_stage3_style_memory_wiring.py
@@ -115,9 +115,7 @@ class TestStyleMemoryWiring:
         # AC2 — heading must appear after the research brief, not before.
         brief_idx = prompt.index("RESEARCH BRIEF")
         style_idx = prompt.index("## Style Memory")
-        assert style_idx > brief_idx, (
-            "## Style Memory must appear after RESEARCH BRIEF"
-        )
+        assert style_idx > brief_idx, "## Style Memory must appear after RESEARCH BRIEF"
 
     def test_style_section_omitted_when_chromadb_empty(
         self, stub_pipeline, captured_prompts
@@ -152,9 +150,7 @@ class TestGetStyleContextMethod:
 
         tool = StyleMemoryTool.__new__(StyleMemoryTool)
         tool.collection = object()  # truthy — passes the early-return gate
-        with patch.object(
-            StyleMemoryTool, "query", return_value=[]
-        ):
+        with patch.object(StyleMemoryTool, "query", return_value=[]):
             assert tool.get_style_context("anything") == ""
 
     def test_returns_empty_for_empty_topic(self) -> None:
@@ -216,6 +212,5 @@ class TestFetchStyleContextHelper:
             return_value=_FakeTool(),
         ):
             assert (
-                stage3_runner._fetch_style_context("a topic")
-                == "exemplars for a topic"
+                stage3_runner._fetch_style_context("a topic") == "exemplars for a topic"
             )

--- a/tests/test_stage3_style_memory_wiring.py
+++ b/tests/test_stage3_style_memory_wiring.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Tests for issue #339 — StyleMemoryTool wiring into ``run_stage3``.
+
+Validates that the writer prompt built inside
+``src.agent_sdk.stage3_runner.run_stage3`` includes a ``## Style Memory``
+section populated from ``StyleMemoryTool.get_style_context(topic)`` when
+ChromaDB returns results, and omits the section entirely when it does
+not.
+
+We exercise ``run_stage3`` end-to-end with two patches:
+
+1. ``build_research_brief`` is stubbed to a deterministic string so the
+   research path does not hit the network.
+2. ``_collect_text`` is stubbed to capture the writer/graphics prompts
+   instead of calling the Anthropic API. The captured writer prompt is
+   the unit under test.
+
+``_fetch_style_context`` is patched directly to model the two states the
+tool can be in (results vs. empty) without depending on a populated
+ChromaDB collection at test time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import src.agent_sdk.stage3_runner as stage3_runner
+from src.agent_sdk.stage3_runner import run_stage3
+
+
+VALID_ARTICLE = (
+    "---\n"
+    "layout: post\n"
+    "title: Test\n"
+    "date: 2026-01-01\n"
+    "author: Test\n"
+    "categories: Software Engineering\n"
+    "image: /assets/images/test.png\n"
+    "description: Test description.\n"
+    "image_alt: Test alt.\n"
+    "image_caption: Test caption.\n"
+    "---\n"
+    "\n"
+    "A debatable thesis paragraph that opens the article.\n"
+    "\n"
+    "## References\n"
+    "\n"
+    "1. https://example.com\n"
+)
+
+
+@pytest.fixture
+def captured_prompts() -> dict[str, str]:
+    """Container the patched ``_collect_text`` writes into."""
+    return {}
+
+
+@pytest.fixture
+def stub_pipeline(captured_prompts):
+    """Stub research + Agent SDK calls so ``run_stage3`` runs offline.
+
+    The first call to ``_collect_text`` (the writer) records its prompt
+    under ``captured_prompts["writer"]`` and returns a minimally valid
+    article. The second call (graphics) returns a trivial JSON chart.
+    """
+
+    async def fake_collect_text(prompt, system_prompt, **kwargs):
+        if "writer" not in captured_prompts:
+            captured_prompts["writer"] = prompt
+            return VALID_ARTICLE, 0.0
+        captured_prompts["graphics"] = prompt
+        return '{"title": "t", "data": []}', 0.0
+
+    with (
+        patch.object(
+            stage3_runner,
+            "build_research_brief",
+            return_value="STUB RESEARCH BRIEF",
+        ),
+        patch.object(
+            stage3_runner,
+            "_collect_text",
+            AsyncMock(side_effect=fake_collect_text),
+        ),
+    ):
+        yield
+
+
+class TestStyleMemoryWiring:
+    """``run_stage3`` injects style-memory exemplars when available."""
+
+    def test_style_section_present_when_chromadb_returns_results(
+        self, stub_pipeline, captured_prompts
+    ) -> None:
+        """AC2 — the ``## Style Memory`` section appears after the brief."""
+        exemplars = (
+            "Reference these voice exemplars from Gold Standard articles.\n"
+            "\n"
+            "1. (source: foo.md, score: 0.91)\n"
+            "   > Sample exemplar paragraph.\n"
+        )
+        with patch.object(
+            stage3_runner, "_fetch_style_context", return_value=exemplars
+        ):
+            asyncio.run(run_stage3("a topic"))
+
+        prompt = captured_prompts["writer"]
+        assert "## Style Memory" in prompt, "Style Memory heading missing from prompt"
+        assert "Sample exemplar paragraph." in prompt
+
+        # AC2 — heading must appear after the research brief, not before.
+        brief_idx = prompt.index("RESEARCH BRIEF")
+        style_idx = prompt.index("## Style Memory")
+        assert style_idx > brief_idx, (
+            "## Style Memory must appear after RESEARCH BRIEF"
+        )
+
+    def test_style_section_omitted_when_chromadb_empty(
+        self, stub_pipeline, captured_prompts
+    ) -> None:
+        """AC3 — empty/cold ChromaDB results omit the section entirely."""
+        with patch.object(stage3_runner, "_fetch_style_context", return_value=""):
+            asyncio.run(run_stage3("a topic"))
+
+        prompt = captured_prompts["writer"]
+        assert "## Style Memory" not in prompt, (
+            "Empty style context must not emit an empty heading"
+        )
+        # No trailing whitespace explosion at the join site.
+        assert not re.search(r"STUB RESEARCH BRIEF\s{3,}$", prompt)
+
+    def test_run_stage3_invokes_fetch_style_context_with_topic(
+        self, stub_pipeline, captured_prompts
+    ) -> None:
+        """AC1 — ``run_stage3`` calls the style fetcher with the topic."""
+        with patch.object(
+            stage3_runner, "_fetch_style_context", return_value=""
+        ) as mock_fetch:
+            asyncio.run(run_stage3("how AI agents change software testing"))
+        mock_fetch.assert_called_once_with("how AI agents change software testing")
+
+
+class TestGetStyleContextMethod:
+    """``StyleMemoryTool.get_style_context`` formats exemplars correctly."""
+
+    def test_returns_empty_when_query_returns_no_results(self) -> None:
+        from src.tools.style_memory_tool import StyleMemoryTool
+
+        tool = StyleMemoryTool.__new__(StyleMemoryTool)
+        tool.collection = object()  # truthy — passes the early-return gate
+        with patch.object(
+            StyleMemoryTool, "query", return_value=[]
+        ):
+            assert tool.get_style_context("anything") == ""
+
+    def test_returns_empty_for_empty_topic(self) -> None:
+        from src.tools.style_memory_tool import StyleMemoryTool
+
+        tool = StyleMemoryTool.__new__(StyleMemoryTool)
+        tool.collection = object()
+        assert tool.get_style_context("") == ""
+        assert tool.get_style_context("   ") == ""
+
+    def test_formats_results_as_markdown_block(self) -> None:
+        from src.tools.style_memory_tool import StyleMemoryTool
+
+        tool = StyleMemoryTool.__new__(StyleMemoryTool)
+        tool.collection = object()
+        fake_results = [
+            {
+                "text": "Companies are racing to ship AI agents.",
+                "score": 0.88,
+                "source": "ai-agents.md",
+                "paragraph": 0,
+            },
+            {
+                "text": "The chart makes clear how fast adoption grew.",
+                "score": 0.81,
+                "source": "adoption.md",
+                "paragraph": 4,
+            },
+        ]
+        with patch.object(StyleMemoryTool, "query", return_value=fake_results):
+            out = tool.get_style_context("ai agents")
+
+        assert "Companies are racing" in out
+        assert "The chart makes clear" in out
+        assert "ai-agents.md" in out
+        assert "adoption.md" in out
+        # Format checks: numbered, scores rendered, no empty trailing heading.
+        assert "1. (source: ai-agents.md" in out
+        assert "2. (source: adoption.md" in out
+
+
+class TestFetchStyleContextHelper:
+    """``_fetch_style_context`` swallows failures and returns ``''``."""
+
+    def test_returns_empty_when_tool_raises(self) -> None:
+        with patch(
+            "src.tools.style_memory_tool.StyleMemoryTool",
+            side_effect=RuntimeError("chromadb down"),
+        ):
+            assert stage3_runner._fetch_style_context("any topic") == ""
+
+    def test_returns_tool_output_on_success(self) -> None:
+        class _FakeTool:
+            def get_style_context(self, topic):
+                return f"exemplars for {topic}"
+
+        with patch(
+            "src.tools.style_memory_tool.StyleMemoryTool",
+            return_value=_FakeTool(),
+        ):
+            assert (
+                stage3_runner._fetch_style_context("a topic")
+                == "exemplars for a topic"
+            )


### PR DESCRIPTION
## Summary

Closes #339.

`StyleMemoryTool` and its ChromaDB cache (`.chromadb/`) were warmed by CI but never queried — `run_stage3` built the writer prompt directly from the research brief and ignored the RAG store. This PR wires the tool into the Stage 3 writer path so Gold Standard style exemplars actually reach the writer agent.

## Call site

`src/agent_sdk/stage3_runner.py:run_stage3()` now calls `_fetch_style_context(topic)` immediately after `build_research_brief(topic)`. When the helper returns a non-empty markdown block, it is appended to the writer prompt as a `## Style Memory` section after the `RESEARCH BRIEF` block. When the helper returns `""` (cold ChromaDB, no results above the relevance threshold, tool unavailable, or an exception), the section is omitted entirely — no empty heading is emitted.

`_fetch_style_context` is intentionally a module-level helper so:
- the `StyleMemoryTool` import (and its transitive `chromadb` import) is lazy and paid only at runtime
- tests can monkeypatch a single seam without touching ChromaDB

`StyleMemoryTool.get_style_context(topic)` is a new public method that wraps `.query()` and formats the returned paragraphs into a markdown exemplar block ("Reference these voice exemplars... mirror their cadence, do not copy their facts"). Empty topics, empty results, and all-empty-text results all return `""`.

## Test approach

New file `tests/test_stage3_style_memory_wiring.py` (8 tests):

- `TestStyleMemoryWiring` — exercises `run_stage3` end-to-end with `build_research_brief` and `_collect_text` stubbed, then asserts on the captured writer prompt:
  - AC2: `## Style Memory` heading appears *after* `RESEARCH BRIEF` when the fetcher returns content
  - AC3: heading omitted entirely when fetcher returns `""`
  - AC1: `_fetch_style_context` is invoked once with the supplied topic
- `TestGetStyleContextMethod` — covers the new `StyleMemoryTool.get_style_context` method: empty query → `""`, empty topic → `""`, two results → formatted markdown with source attributions and scores
- `TestFetchStyleContextHelper` — covers the helper's fault-tolerance: tool raises → `""`, tool succeeds → result passed through verbatim

Full suite: `pytest tests/ -q` — 1764 passed, 84 skipped, 0 failures (AC5).

## Test plan

- [x] New tests pass (`pytest tests/test_stage3_style_memory_wiring.py -v` — 8/8)
- [x] No regressions in the full suite (`pytest tests/ -q` — 1764 passed)
- [x] AC1: `run_stage3` calls `_fetch_style_context(topic)` before building the writer prompt
- [x] AC2: result injected as `## Style Memory` after the research brief
- [x] AC3: empty/None result → section omitted (no empty heading)
- [x] AC4: tests cover both populated and empty paths

## SKILL INVOCATIONS

- `agent-skills:using-agent-skills`
- `agent-skills:context-engineering`

🤖 Generated with [Claude Code](https://claude.com/claude-code)