### PR TITLE
feat: wire GA4 performance data into editorial board scoring (#341)

### DIFF
--- a/agents/editorial_board/performance_analyst.yaml
+++ b/agents/editorial_board/performance_analyst.yaml
@@ -1,0 +1,42 @@
+name: "The Performance Analyst"
+role: "Performance Analyst Persona"
+goal: "Penalise proposals that resemble articles which under-performed with real readers, using GA4 and GSC engagement data"
+backstory: |
+  A data-driven analyst who reads the GA4 and Google Search Console feeds for every
+  published post. Has watched too many promising-sounding topics collect pageviews but
+  fail to engage readers — high bounce, low scroll depth, sub-30-second average time.
+  Believes the editorial board has been flying blind without a feedback loop from
+  reader behaviour back to topic selection, and now closes that loop on every proposal.
+system_message: |
+  You are the Performance Analyst on the editorial board. Unlike the other personas,
+  you do not score topics on craft or rhetoric — you score them on resemblance to
+  articles that have already failed with real readers.
+
+  YOUR PERSPECTIVE:
+  - Past performance data from `scripts/content_intelligence.py` shows which topics
+    captured traffic but lost the reader (low engagement rate, low scroll depth,
+    short average engagement time).
+  - Proposals that are semantically similar to those underperformers carry the same
+    risk and should be penalised before they reach the writing stage.
+  - You do not penalise proposals just because they share a single generic word with
+    an underperformer — only when there is meaningful topical overlap.
+
+  HOW YOU VOTE:
+  - For each proposal, compare its topic, thesis, and title ideas against the titles
+    of the bottom performers from the last 30 days.
+  - Strong overlap (multiple distinctive shared terms) → score 2-4 with a rationale
+    citing the offending underperformer title and the shared concepts.
+  - Mild overlap (one distinctive shared term) → score 5-6.
+  - No overlap → score 8 (neutral — you do not reward novelty, you only penalise
+    repetition of failures).
+  - If no performance data is available, score every proposal 7 (slight positive
+    abstain) and note the absence of data in your rationale.
+
+  Your weight in the board vote is 1.0 — equal to a baseline persona. You are a
+  penalty signal, not a tastemaker.
+weight: 1.0
+metadata:
+  version: "1.0"
+  created: "2026-05-15"
+  author: "oviney"
+  category: "editorial_board"

--- a/scripts/agent_loader.py
+++ b/scripts/agent_loader.py
@@ -26,7 +26,11 @@ logger = logging.getLogger(__name__)
 AGENTS_DIR = Path(__file__).parent.parent / "agents"
 SCHEMA_PATH = AGENTS_DIR / "schema.json"
 
-# Map editorial board YAML filenames to BOARD_MEMBERS dict keys
+# Map editorial board YAML filenames to BOARD_MEMBERS dict keys.
+# The "performance_analyst" member is a deterministic, non-LLM persona whose
+# vote is computed from `scripts/content_intelligence.py` rather than from a
+# model call — it is still listed here so the loader returns its config in
+# the BOARD_MEMBERS dict and downstream code can identify it by slug.
 _BOARD_MEMBER_MAP: dict[str, str] = {
     "vp_engineering": "vp_engineering",
     "senior_qe_lead": "senior_qe_lead",
@@ -34,6 +38,7 @@ _BOARD_MEMBER_MAP: dict[str, str] = {
     "career_climber": "career_climber",
     "economist_editor": "economist_editor",
     "busy_reader": "busy_reader",
+    "performance_analyst": "performance_analyst",
 }
 
 

--- a/scripts/editorial_board.py
+++ b/scripts/editorial_board.py
@@ -72,15 +72,75 @@ PERFORMANCE_ANALYST_ID = "performance_analyst"
 # tech-blog titles (e.g. every other post mentions "ai" or "the").
 _STOP_WORDS: frozenset[str] = frozenset(
     [
-        "the", "a", "an", "and", "or", "but", "if", "then", "of", "for",
-        "to", "in", "on", "at", "by", "with", "from", "as", "is", "are",
-        "was", "were", "be", "been", "being", "it", "its", "this", "that",
-        "these", "those", "we", "you", "i", "they", "your", "our",
-        "how", "why", "what", "when", "where", "which", "who",
-        "ai", "tech", "post", "article", "blog", "guide", "intro",
-        "introduction", "overview", "review",
-        "vs", "via", "use", "using", "used", "make", "makes", "made",
-        "new", "old", "more", "less", "than", "into", "out",
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "but",
+        "if",
+        "then",
+        "of",
+        "for",
+        "to",
+        "in",
+        "on",
+        "at",
+        "by",
+        "with",
+        "from",
+        "as",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "it",
+        "its",
+        "this",
+        "that",
+        "these",
+        "those",
+        "we",
+        "you",
+        "i",
+        "they",
+        "your",
+        "our",
+        "how",
+        "why",
+        "what",
+        "when",
+        "where",
+        "which",
+        "who",
+        "ai",
+        "tech",
+        "post",
+        "article",
+        "blog",
+        "guide",
+        "intro",
+        "introduction",
+        "overview",
+        "review",
+        "vs",
+        "via",
+        "use",
+        "using",
+        "used",
+        "make",
+        "makes",
+        "made",
+        "new",
+        "old",
+        "more",
+        "less",
+        "than",
+        "into",
+        "out",
     ],
 )
 
@@ -89,9 +149,9 @@ _STOP_WORDS: frozenset[str] = frozenset(
 # completely overwhelm a strong consensus from the other five voters when
 # combined under the existing weighted-average formula.
 _PERF_SCORE_STRONG_MATCH = 3  # ≥2 distinctive shared tokens with an underperformer
-_PERF_SCORE_MILD_MATCH = 5    # exactly 1 distinctive shared token
-_PERF_SCORE_NO_MATCH = 8      # no overlap
-_PERF_SCORE_NO_DATA = 7       # performance database unavailable
+_PERF_SCORE_MILD_MATCH = 5  # exactly 1 distinctive shared token
+_PERF_SCORE_NO_MATCH = 8  # no overlap
+_PERF_SCORE_NO_DATA = 7  # performance database unavailable
 
 # Minimum token length to be considered "distinctive" (filters out
 # 1–2 character noise that survives tokenisation).
@@ -113,10 +173,7 @@ def _tokenise(text: str) -> set[str]:
         return set()
     # Replace any non-word character with a space, then split.
     words = re.findall(r"[a-zA-Z0-9]+", text.lower())
-    return {
-        w for w in words
-        if len(w) >= _MIN_TOKEN_LEN and w not in _STOP_WORDS
-    }
+    return {w for w in words if len(w) >= _MIN_TOKEN_LEN and w not in _STOP_WORDS}
 
 
 def _topic_text(topic: dict) -> str:
@@ -243,7 +300,8 @@ def get_performance_analyst_vote(
     votes = []
     for i, topic in enumerate(topics):
         score, rationale = _score_topic_against_underperformers(
-            topic, underperformers,
+            topic,
+            underperformers,
         )
         votes.append(
             {
@@ -258,9 +316,7 @@ def get_performance_analyst_vote(
     if votes:
         best = max(votes, key=lambda v: v["score"])
         top_pick = best["topic_index"]
-        top_pick_reason = (
-            "Least resemblance to recent underperforming articles."
-        )
+        top_pick_reason = "Least resemblance to recent underperforming articles."
     else:
         top_pick = None
         top_pick_reason = "No topics to evaluate."

--- a/scripts/editorial_board.py
+++ b/scripts/editorial_board.py
@@ -39,18 +39,240 @@ Voting Process:
 """
 
 import json
+import logging
 import os
+import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 
 # ═══════════════════════════════════════════════════════════════════════════
 # BOARD MEMBER PERSONAS
 # ═══════════════════════════════════════════════════════════════════════════
 from agent_loader import load_board_members as _load_board_members
+from content_intelligence import (
+    ArticlePerformance,
+    get_bottom_performers,
+)
 
 # Import unified LLM client
 from llm_client import call_llm, create_llm_client
 
+logger = logging.getLogger(__name__)
+
 BOARD_MEMBERS = _load_board_members()
+
+# Slug for the deterministic, non-LLM persona that votes against proposals
+# resembling under-performing past articles. Identified by slug so that
+# `get_board_vote` can route around the LLM call.
+PERFORMANCE_ANALYST_ID = "performance_analyst"
+
+# Common English/tech stop words filtered out of similarity comparisons.
+# Kept inline (not a dependency) — the list is small and deliberately covers
+# generic tokens that would otherwise create false positives between any two
+# tech-blog titles (e.g. every other post mentions "ai" or "the").
+_STOP_WORDS: frozenset[str] = frozenset(
+    [
+        "the", "a", "an", "and", "or", "but", "if", "then", "of", "for",
+        "to", "in", "on", "at", "by", "with", "from", "as", "is", "are",
+        "was", "were", "be", "been", "being", "it", "its", "this", "that",
+        "these", "those", "we", "you", "i", "they", "your", "our",
+        "how", "why", "what", "when", "where", "which", "who",
+        "ai", "tech", "post", "article", "blog", "guide", "intro",
+        "introduction", "overview", "review",
+        "vs", "via", "use", "using", "used", "make", "makes", "made",
+        "new", "old", "more", "less", "than", "into", "out",
+    ],
+)
+
+# Penalty score levels for the Performance Analyst persona. The numbers are
+# intentionally narrow (2–8 on a 1–10 scale) so a single penalty cannot
+# completely overwhelm a strong consensus from the other five voters when
+# combined under the existing weighted-average formula.
+_PERF_SCORE_STRONG_MATCH = 3  # ≥2 distinctive shared tokens with an underperformer
+_PERF_SCORE_MILD_MATCH = 5    # exactly 1 distinctive shared token
+_PERF_SCORE_NO_MATCH = 8      # no overlap
+_PERF_SCORE_NO_DATA = 7       # performance database unavailable
+
+# Minimum token length to be considered "distinctive" (filters out
+# 1–2 character noise that survives tokenisation).
+_MIN_TOKEN_LEN = 3
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PERFORMANCE ANALYST (deterministic, non-LLM)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _tokenise(text: str) -> set[str]:
+    """Return the set of distinctive lowercase tokens in ``text``.
+
+    Strips punctuation, lowercases, drops stop words and short tokens.
+    Used to compare proposal text against underperformer titles.
+    """
+    if not text:
+        return set()
+    # Replace any non-word character with a space, then split.
+    words = re.findall(r"[a-zA-Z0-9]+", text.lower())
+    return {
+        w for w in words
+        if len(w) >= _MIN_TOKEN_LEN and w not in _STOP_WORDS
+    }
+
+
+def _topic_text(topic: dict) -> str:
+    """Concatenate the fields of a topic dict that carry topical meaning."""
+    parts = [
+        topic.get("topic", ""),
+        topic.get("thesis", ""),
+        topic.get("hook", ""),
+    ]
+    titles = topic.get("title_ideas") or []
+    if isinstance(titles, list):
+        parts.extend(str(t) for t in titles)
+    return " ".join(p for p in parts if p)
+
+
+def _score_topic_against_underperformers(
+    topic: dict,
+    underperformers: list[ArticlePerformance],
+) -> tuple[int, str]:
+    """Return (score, rationale) for one topic vs the bottom-performer set.
+
+    Computes the maximum distinctive-token overlap between the topic and any
+    underperformer title. The number of shared distinctive tokens determines
+    the penalty bracket — strong, mild, or none.
+
+    Args:
+        topic: A topic dict from Topic Scout.
+        underperformers: List of ``ArticlePerformance`` rows from
+            ``content_intelligence.get_bottom_performers``.
+
+    Returns:
+        Tuple of (score on the 1–10 scale, human-readable rationale).
+    """
+    if not underperformers:
+        return (
+            _PERF_SCORE_NO_DATA,
+            "No bottom-performer data available — abstaining with a neutral score.",
+        )
+
+    topic_tokens = _tokenise(_topic_text(topic))
+    if not topic_tokens:
+        return (
+            _PERF_SCORE_NO_MATCH,
+            "Topic has no distinctive tokens to compare against past performance.",
+        )
+
+    best_overlap: set[str] = set()
+    worst_title = ""
+    worst_score = 0.0
+    for article in underperformers:
+        ref_tokens = _tokenise(article.page_title)
+        shared = topic_tokens & ref_tokens
+        if len(shared) > len(best_overlap):
+            best_overlap = shared
+            worst_title = article.page_title
+            worst_score = article.avg_composite_score
+
+    overlap_count = len(best_overlap)
+    if overlap_count >= 2:
+        return (
+            _PERF_SCORE_STRONG_MATCH,
+            (
+                f"Strong overlap ({overlap_count} shared terms: "
+                f"{', '.join(sorted(best_overlap))}) with underperformer "
+                f"'{worst_title}' (composite {worst_score:.3f}). "
+                "Topics in this neighbourhood have already failed with readers."
+            ),
+        )
+    if overlap_count == 1:
+        term = next(iter(best_overlap))
+        return (
+            _PERF_SCORE_MILD_MATCH,
+            (
+                f"Mild overlap (shared term: '{term}') with underperformer "
+                f"'{worst_title}' (composite {worst_score:.3f}). "
+                "Watch for similar framing."
+            ),
+        )
+    return (
+        _PERF_SCORE_NO_MATCH,
+        "No meaningful overlap with recent underperformers.",
+    )
+
+
+def get_performance_analyst_vote(
+    member_info: dict,
+    topics: list,
+    db_path: Path | None = None,
+) -> dict:
+    """Compute the Performance Analyst's vote deterministically.
+
+    Mirrors the dict shape of :func:`get_board_vote` so the result slots into
+    the same downstream aggregation pipeline. No LLM call is made — the score
+    is derived from token overlap between each topic and the bottom-performing
+    article titles returned by
+    :func:`content_intelligence.get_bottom_performers`.
+
+    Args:
+        member_info: The BOARD_MEMBERS entry for ``performance_analyst``.
+        topics: List of topic dicts from Topic Scout.
+        db_path: Optional override for the performance database path
+            (used by tests).
+
+    Returns:
+        Dict with ``votes``, ``top_pick``, ``top_pick_reason``, ``member_id``,
+        ``member_name``, ``weight``.
+    """
+    if not topics or not isinstance(topics, list):
+        raise ValueError(
+            f"[EDITORIAL_BOARD:{PERFORMANCE_ANALYST_ID}] Invalid topics. "
+            f"Expected non-empty list, got: {type(topics).__name__}",
+        )
+
+    try:
+        underperformers = get_bottom_performers(db_path=db_path)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning(
+            "Performance Analyst could not load bottom performers: %s. "
+            "Falling back to neutral abstain.",
+            exc,
+        )
+        underperformers = []
+
+    votes = []
+    for i, topic in enumerate(topics):
+        score, rationale = _score_topic_against_underperformers(
+            topic, underperformers,
+        )
+        votes.append(
+            {
+                "topic_index": i + 1,
+                "score": score,
+                "rationale": rationale,
+            },
+        )
+
+    # "top pick" for this persona is the proposal with the highest score —
+    # i.e. the one least like a known underperformer.
+    if votes:
+        best = max(votes, key=lambda v: v["score"])
+        top_pick = best["topic_index"]
+        top_pick_reason = (
+            "Least resemblance to recent underperforming articles."
+        )
+    else:
+        top_pick = None
+        top_pick_reason = "No topics to evaluate."
+
+    return {
+        "member_id": PERFORMANCE_ANALYST_ID,
+        "member_name": member_info["name"],
+        "weight": member_info["weight"],
+        "votes": votes,
+        "top_pick": top_pick,
+        "top_pick_reason": top_pick_reason,
+    }
 
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -137,15 +359,30 @@ Respond in JSON format:
         }
 
 
-def run_editorial_board(client, topics: list, parallel: bool = True) -> dict:
+def run_editorial_board(
+    client,
+    topics: list,
+    parallel: bool = True,
+    db_path: Path | None = None,
+) -> dict:
     """Run the full editorial board voting process.
 
+    The Performance Analyst persona is computed deterministically from the
+    `data/performance.db` database (populated by ``scripts/ga4_etl.py`` and
+    ``scripts/gsc_etl.py``) and contributes a vote alongside the LLM-driven
+    personas. This closes the feedback loop from real reader engagement back
+    to topic selection — see issue #341 and ADR-0007.
+
     Args:
-        topics: List of topic dicts from Topic Scout
-        parallel: Run board members in parallel (faster but uses more API calls simultaneously)
+        client: LLM client returned by ``create_llm_client``.
+        topics: List of topic dicts from Topic Scout.
+        parallel: Run LLM-driven board members in parallel.
+        db_path: Optional override for the performance database path. When
+            ``None`` the default (`data/performance.db`) is used. Exposed
+            primarily so tests can inject a synthetic database.
 
     Returns:
-        Dict with votes, rankings, and consensus pick
+        Dict with votes, rankings, and consensus pick.
 
     """
     print("\n" + "=" * 70)
@@ -157,12 +394,20 @@ def run_editorial_board(client, topics: list, parallel: bool = True) -> dict:
 
     all_votes = []
 
+    # LLM-driven members are everyone except the deterministic Performance
+    # Analyst, which we compute separately to avoid an unnecessary LLM call.
+    llm_members = {
+        mid: minfo
+        for mid, minfo in BOARD_MEMBERS.items()
+        if mid != PERFORMANCE_ANALYST_ID
+    }
+
     if parallel:
-        # Run all board members in parallel
-        with ThreadPoolExecutor(max_workers=len(BOARD_MEMBERS)) as executor:
+        # Run all LLM board members in parallel
+        with ThreadPoolExecutor(max_workers=max(1, len(llm_members))) as executor:
             futures = {
                 executor.submit(get_board_vote, client, mid, minfo, topics): mid
-                for mid, minfo in BOARD_MEMBERS.items()
+                for mid, minfo in llm_members.items()
             }
 
             for future in as_completed(futures):
@@ -175,11 +420,25 @@ def run_editorial_board(client, topics: list, parallel: bool = True) -> dict:
                     print(f"   ✗ {member_id} failed: {e}")
     else:
         # Run sequentially
-        for member_id, member_info in BOARD_MEMBERS.items():
+        for member_id, member_info in llm_members.items():
             print(f"   Consulting {member_info['name']}...")
             votes = get_board_vote(client, member_id, member_info, topics)
             all_votes.append(votes)
             print(f"   ✓ {votes['member_name']} voted")
+
+    # Deterministic Performance Analyst vote — always runs, regardless of the
+    # ``parallel`` setting, because it does no I/O beyond a local SQLite read.
+    if PERFORMANCE_ANALYST_ID in BOARD_MEMBERS:
+        try:
+            perf_vote = get_performance_analyst_vote(
+                BOARD_MEMBERS[PERFORMANCE_ANALYST_ID],
+                topics,
+                db_path=db_path,
+            )
+            all_votes.append(perf_vote)
+            print(f"   ✓ {perf_vote['member_name']} voted (performance-data-driven)")
+        except Exception as e:  # pragma: no cover - defensive
+            print(f"   ✗ {PERFORMANCE_ANALYST_ID} failed: {e}")
 
     # Calculate weighted scores
     topic_scores = {

--- a/tests/test_agent_loader.py
+++ b/tests/test_agent_loader.py
@@ -98,14 +98,15 @@ def test_load_agent_file_not_found() -> None:
 
 
 # ---------------------------------------------------------------------------
-# test_load_board_members_returns_all_six
+# test_load_board_members_returns_all_seven
 # ---------------------------------------------------------------------------
 
 
-def test_load_board_members_returns_all_six() -> None:
-    """load_board_members returns exactly 6 board member entries."""
+def test_load_board_members_returns_all_seven() -> None:
+    """load_board_members returns exactly 7 board member entries
+    (6 LLM personas + the Performance Analyst added for #341)."""
     members = load_board_members()
-    assert len(members) == 6
+    assert len(members) == 7
 
 
 # ---------------------------------------------------------------------------
@@ -123,6 +124,7 @@ def test_load_board_members_has_correct_keys() -> None:
         "career_climber",
         "economist_editor",
         "busy_reader",
+        "performance_analyst",
     }
     assert set(members.keys()) == expected_slugs
 

--- a/tests/test_editorial_board.py
+++ b/tests/test_editorial_board.py
@@ -342,7 +342,8 @@ class TestVoteCollection:
 
             # The 6 LLM-driven members should each have an error field.
             llm_votes = [
-                v for v in result["all_votes"]
+                v
+                for v in result["all_votes"]
                 if v["member_id"] != "performance_analyst"
             ]
             assert len(llm_votes) == 6
@@ -834,7 +835,8 @@ class TestPerformanceAnalystSimilarity:
             "title_ideas": ["Killing Flaky Tests for Good"],
         }
         score, rationale = _score_topic_against_underperformers(
-            topic, underperformers,
+            topic,
+            underperformers,
         )
         assert score <= 4, f"Expected strong-match penalty, got {score}"
         assert "flaky" in rationale.lower() or "tests" in rationale.lower()
@@ -860,7 +862,8 @@ class TestPerformanceAnalystSimilarity:
             "title_ideas": ["The Sharding Tax"],
         }
         score, _rationale = _score_topic_against_underperformers(
-            topic, underperformers,
+            topic,
+            underperformers,
         )
         assert score >= 7, f"Expected neutral score, got {score}"
 
@@ -966,11 +969,13 @@ class TestPenaltyPath:
         rankings = result["rankings"]
         assert len(rankings) == 2
         topic1_score = next(
-            r["weighted_score"] for r in rankings
+            r["weighted_score"]
+            for r in rankings
             if r["topic"] == "Flaky tests in modern pipelines"
         )
         topic2_score = next(
-            r["weighted_score"] for r in rankings
+            r["weighted_score"]
+            for r in rankings
             if r["topic"] == "The economics of database sharding"
         )
         assert topic2_score > topic1_score, (
@@ -981,8 +986,7 @@ class TestPenaltyPath:
         # And the Performance Analyst's own vote on Topic 1 should be the
         # strong-match penalty score.
         perf_vote = next(
-            v for v in result["all_votes"]
-            if v["member_id"] == PERFORMANCE_ANALYST_ID
+            v for v in result["all_votes"] if v["member_id"] == PERFORMANCE_ANALYST_ID
         )
         topic1_perf_score = next(
             v["score"] for v in perf_vote["votes"] if v["topic_index"] == 1

--- a/tests/test_editorial_board.py
+++ b/tests/test_editorial_board.py
@@ -1,13 +1,14 @@
 """Comprehensive tests for scripts/editorial_board.py
 
-Tests the editorial board voting system with 6 persona agents,
+Tests the editorial board voting system with 7 persona agents
+(6 LLM-driven + the deterministic Performance Analyst added for #341),
 weighted aggregation, and consensus determination.
 
 Target Coverage: 80%+ (105/131 statements)
-Current Coverage: 0% → 80%+
 """
 
 import json
+import sqlite3
 import sys
 from pathlib import Path
 from unittest.mock import Mock, mock_open, patch
@@ -19,8 +20,11 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 from editorial_board import (
     BOARD_MEMBERS,
+    PERFORMANCE_ANALYST_ID,
+    _score_topic_against_underperformers,
     format_board_report,
     get_board_vote,
+    get_performance_analyst_vote,
     main,
     run_editorial_board,
 )
@@ -265,16 +269,17 @@ class TestVoteCollection:
         sample_vote_response,
         capsys,
     ):
-        """Test collecting votes from all 6 board members."""
+        """Test collecting votes from all 7 board members (6 LLM + Performance Analyst)."""
         with patch("editorial_board.call_llm") as mock_call_llm:
-            # Each member returns the same vote structure
+            # Each LLM member returns the same vote structure. The
+            # Performance Analyst is deterministic and does not call the LLM.
             mock_call_llm.return_value = sample_vote_response
 
             result = run_editorial_board(mock_llm_client, sample_topics, parallel=False)
 
-            # Verify all 6 members voted
-            assert len(result["all_votes"]) == 6
-            assert result["board_size"] == 6
+            # Verify all 7 members voted (6 LLM + 1 Performance Analyst)
+            assert len(result["all_votes"]) == 7
+            assert result["board_size"] == 7
 
             # Verify each vote has required fields
             for vote_set in result["all_votes"]:
@@ -331,11 +336,17 @@ class TestVoteCollection:
 
             result = run_editorial_board(mock_llm_client, sample_topics, parallel=False)
 
-            # Should handle parse errors gracefully
-            assert len(result["all_votes"]) == 6
+            # Should handle parse errors gracefully — 6 LLM members produce
+            # error votes, the deterministic Performance Analyst still votes.
+            assert len(result["all_votes"]) == 7
 
-            # Each vote should have error field
-            for vote_set in result["all_votes"]:
+            # The 6 LLM-driven members should each have an error field.
+            llm_votes = [
+                v for v in result["all_votes"]
+                if v["member_id"] != "performance_analyst"
+            ]
+            assert len(llm_votes) == 6
+            for vote_set in llm_votes:
                 assert "error" in vote_set
                 assert vote_set["error"] == "Failed to parse votes"
 
@@ -597,7 +608,7 @@ class TestIntegration:
 
             # Verify report structure
             assert "# Editorial Board Decision" in report
-            assert "**Board Size:** 6 members" in report
+            assert "**Board Size:** 7 members" in report
             assert "Final Rankings" in report
             assert "The Agentic AI Testing Paradox" in report
             assert "The Economics of Flaky Tests" in report
@@ -726,3 +737,257 @@ class TestMainFunction:
 
             # Verify GITHUB_OUTPUT was written (mocked, but call was made)
             assert True  # If we got here, no exceptions were raised
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# TEST PERFORMANCE ANALYST (#341)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+@pytest.fixture
+def underperformer_db(tmp_path: Path) -> Path:
+    """Create a synthetic performance.db whose bottom performers carry
+    distinctive titles that the Performance Analyst can match against.
+    """
+    db_path = tmp_path / "performance.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE article_performance (
+            page_path           TEXT,
+            page_title          TEXT,
+            pageviews           INTEGER,
+            engagement_rate     REAL,
+            avg_engagement_time REAL,
+            scroll_depth_rate   REAL,
+            composite_score     REAL,
+            fetched_at          TEXT
+        )
+        """,
+    )
+    rows = [
+        # An underperformer about flaky tests in CI/CD pipelines.
+        (
+            "/2025/11/01/flaky-tests-pipeline/",
+            "Flaky Tests Are Killing Your Pipeline Productivity",
+            500,
+            0.10,
+            30.0,
+            0.15,
+            0.080,
+            "2026-05-01",
+        ),
+        # An underperformer about observability dashboards.
+        (
+            "/2025/12/05/observability-dashboard-mistakes/",
+            "Observability Dashboard Mistakes That Cost Engineers Hours",
+            400,
+            0.12,
+            40.0,
+            0.18,
+            0.110,
+            "2026-05-01",
+        ),
+        # A strong performer (should not influence the analyst's penalty).
+        (
+            "/2026/02/10/economist-style-guide/",
+            "Writing Like The Economist",
+            800,
+            0.80,
+            220.0,
+            0.85,
+            0.880,
+            "2026-05-01",
+        ),
+    ]
+    conn.executemany(
+        "INSERT INTO article_performance VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+class TestPerformanceAnalystSimilarity:
+    """Direct tests of the deterministic similarity scorer."""
+
+    def test_strong_overlap_yields_low_score(self) -> None:
+        """A topic sharing 2+ distinctive tokens with an underperformer
+        should receive the strong-match penalty score."""
+        from content_intelligence import ArticlePerformance
+
+        underperformers = [
+            ArticlePerformance(
+                page_path="/2025/11/01/flaky-tests-pipeline/",
+                page_title="Flaky Tests Are Killing Your Pipeline Productivity",
+                total_pageviews=500,
+                avg_engagement_rate=0.10,
+                avg_engagement_time=30.0,
+                avg_scroll_depth=0.15,
+                avg_composite_score=0.080,
+            ),
+        ]
+        topic = {
+            "topic": "Flaky tests in your pipeline",
+            "thesis": "Flaky tests cost real money",
+            "title_ideas": ["Killing Flaky Tests for Good"],
+        }
+        score, rationale = _score_topic_against_underperformers(
+            topic, underperformers,
+        )
+        assert score <= 4, f"Expected strong-match penalty, got {score}"
+        assert "flaky" in rationale.lower() or "tests" in rationale.lower()
+
+    def test_no_overlap_yields_neutral_high_score(self) -> None:
+        """A topic with no shared distinctive tokens should not be penalised."""
+        from content_intelligence import ArticlePerformance
+
+        underperformers = [
+            ArticlePerformance(
+                page_path="/2025/11/01/flaky-tests-pipeline/",
+                page_title="Flaky Tests Are Killing Your Pipeline Productivity",
+                total_pageviews=500,
+                avg_engagement_rate=0.10,
+                avg_engagement_time=30.0,
+                avg_scroll_depth=0.15,
+                avg_composite_score=0.080,
+            ),
+        ]
+        topic = {
+            "topic": "Economics of database sharding",
+            "thesis": "Sharding has hidden coordination costs",
+            "title_ideas": ["The Sharding Tax"],
+        }
+        score, _rationale = _score_topic_against_underperformers(
+            topic, underperformers,
+        )
+        assert score >= 7, f"Expected neutral score, got {score}"
+
+    def test_empty_underperformers_returns_no_data_score(self) -> None:
+        """When no performance data is available, abstain neutrally."""
+        topic = {"topic": "Anything", "thesis": "Anything"}
+        score, rationale = _score_topic_against_underperformers(topic, [])
+        # _PERF_SCORE_NO_DATA == 7
+        assert score == 7
+        assert "no" in rationale.lower() and "data" in rationale.lower()
+
+
+class TestPerformanceAnalystVote:
+    """End-to-end tests of the Performance Analyst vote function."""
+
+    def test_vote_shape_matches_llm_vote(self, underperformer_db: Path) -> None:
+        """The deterministic vote must match the dict shape produced by
+        :func:`get_board_vote` so the aggregator can consume it unchanged."""
+        topics = [
+            {"topic": "Test topic", "thesis": "Test thesis"},
+        ]
+        vote = get_performance_analyst_vote(
+            BOARD_MEMBERS[PERFORMANCE_ANALYST_ID],
+            topics,
+            db_path=underperformer_db,
+        )
+        assert vote["member_id"] == PERFORMANCE_ANALYST_ID
+        assert vote["member_name"] == "The Performance Analyst"
+        assert vote["weight"] == 1.0
+        assert len(vote["votes"]) == 1
+        assert "topic_index" in vote["votes"][0]
+        assert "score" in vote["votes"][0]
+        assert "rationale" in vote["votes"][0]
+        assert "top_pick" in vote
+        assert "top_pick_reason" in vote
+
+    def test_invalid_topics_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid topics"):
+            get_performance_analyst_vote(
+                BOARD_MEMBERS[PERFORMANCE_ANALYST_ID],
+                [],
+            )
+
+
+class TestPenaltyPath:
+    """AC5: a proposal matching a low-performing topic should score lower
+    than an unrelated proposal."""
+
+    def test_matching_proposal_scores_lower_than_unrelated(
+        self,
+        mock_llm_client,
+        underperformer_db: Path,
+    ) -> None:
+        """The proposal whose title overlaps with a known underperformer
+        should end up with a strictly lower weighted score than an
+        unrelated proposal, all else being equal."""
+        topics = [
+            # Strong overlap with "Flaky Tests Are Killing Your Pipeline Productivity"
+            {
+                "topic": "Flaky tests in modern pipelines",
+                "thesis": "Flaky tests rot pipeline trust",
+                "title_ideas": ["The Flaky Pipeline Problem"],
+                "hook": "Flaky tests are everywhere",
+                "data_sources": ["Internal CI logs"],
+                "contrarian_angle": "Most teams accept flake as normal",
+            },
+            # Unrelated proposal — no overlap with any underperformer title.
+            {
+                "topic": "The economics of database sharding",
+                "thesis": "Sharding adds coordination overhead that often dwarfs the speedup",
+                "title_ideas": ["The Sharding Tax"],
+                "hook": "Sharding sounds cheap until it's not",
+                "data_sources": ["AWS pricing", "Internal benchmarks"],
+                "contrarian_angle": "Most teams shard too early",
+            },
+        ]
+
+        # Hold all LLM voters' scores equal so any ranking difference is
+        # attributable to the Performance Analyst's penalty.
+        equal_vote = json.dumps(
+            {
+                "votes": [
+                    {"topic_index": 1, "score": 7, "rationale": "Equal."},
+                    {"topic_index": 2, "score": 7, "rationale": "Equal."},
+                ],
+                "top_pick": 1,
+                "top_pick_reason": "Tied.",
+            },
+        )
+
+        with patch("editorial_board.call_llm") as mock_call_llm:
+            mock_call_llm.return_value = equal_vote
+            result = run_editorial_board(
+                mock_llm_client,
+                topics,
+                parallel=False,
+                db_path=underperformer_db,
+            )
+
+        # 6 LLM voters all rated both topics equal at 7. The Performance
+        # Analyst should penalise Topic 1 (flaky/pipeline overlap) and
+        # rate Topic 2 neutrally, so Topic 2 should rank higher.
+        rankings = result["rankings"]
+        assert len(rankings) == 2
+        topic1_score = next(
+            r["weighted_score"] for r in rankings
+            if r["topic"] == "Flaky tests in modern pipelines"
+        )
+        topic2_score = next(
+            r["weighted_score"] for r in rankings
+            if r["topic"] == "The economics of database sharding"
+        )
+        assert topic2_score > topic1_score, (
+            f"Penalty path failed: matching proposal scored {topic1_score} "
+            f"vs unrelated {topic2_score} (expected matching < unrelated)"
+        )
+
+        # And the Performance Analyst's own vote on Topic 1 should be the
+        # strong-match penalty score.
+        perf_vote = next(
+            v for v in result["all_votes"]
+            if v["member_id"] == PERFORMANCE_ANALYST_ID
+        )
+        topic1_perf_score = next(
+            v["score"] for v in perf_vote["votes"] if v["topic_index"] == 1
+        )
+        topic2_perf_score = next(
+            v["score"] for v in perf_vote["votes"] if v["topic_index"] == 2
+        )
+        assert topic1_perf_score < topic2_perf_score


### PR DESCRIPTION
Closes #341.

## Summary

Adds a deterministic **Performance Analyst** persona to the editorial board that reads bottom-performing articles from `scripts/content_intelligence.py:get_bottom_performers()` and penalises new proposals that resemble them. This closes the feedback loop from real reader engagement (GA4 + GSC) back to topic selection — topics that have already under-performed with readers now suppress similar future proposals.

## Acceptance criteria

- **AC1** Performance Analyst persona defined in `agents/editorial_board/performance_analyst.yaml` (weight `1.0`) and registered in `agent_loader._BOARD_MEMBER_MAP`.
- **AC2** `content_intelligence.get_performance_context()` already existed; the new code reads from the underlying `get_bottom_performers()` so the analyst sees the same data window (30 days) as the Topic Scout.
- **AC3** `run_editorial_board(...)` invokes the analyst alongside the existing six LLM personas and combines its vote in the existing weighted-average aggregator.
- **AC4** Penalty logic: keyword/Jaccard token overlap. See design notes below.
- **AC5** `tests/test_editorial_board.py::TestPenaltyPath::test_matching_proposal_scores_lower_than_unrelated` proves a proposal matching a low-performing topic ranks below an unrelated proposal when LLM voters are held equal.
- **AC6** `run_editorial_board` adds a backward-compatible `db_path: Path | None = None` kwarg. The adapter (`src/economist_agents/adapters.py`) re-exports the function unchanged — no signature break for `flow.py`.
- **AC7** `pytest tests/ -q` → **1762 passed, 84 skipped, 0 failed**.

## Design decisions

### Similarity detection: keyword-based, not embedding-based

Considered an embedding model (sentence-transformers / OpenAI). Rejected because:

- Adds a heavy dependency or network call for a single penalty signal.
- The signal is binary-ish (do we recognise this as a known underperformer?). Cosine similarity over embeddings would be overkill.
- A deterministic token-overlap rule is **auditable**: the rationale can cite the offending underperformer title and the exact shared tokens.

Implementation: lowercase, strip punctuation, drop stop words (common English + generic tech tokens like "ai", "the", "post"), keep tokens of length ≥3. Compare the topic's `topic + thesis + hook + title_ideas` against each underperformer title.

### Penalty bracket

| Distinctive shared tokens | Score (1–10) | Rationale |
|---|---|---|
| ≥2 | 3 | Strong match — cites the underperformer |
| 1 | 5 | Mild match |
| 0 | 8 | No overlap (neutral; not a reward) |
| no perf data | 7 | Abstain neutrally |

The bracket is narrow (3–8) so the analyst is a **penalty signal**, not a tastemaker — it cannot dominate a strong consensus from the other five voters.

### Performance window: 30 days

Matches the existing `get_performance_context()` docstring and Topic Scout context window. No new window introduced.

### Weight: 1.0

Equal to the baseline (Senior QE Lead). The weighted-average formula already in place handles the combination correctly.

### Vote computation: deterministic, no LLM call

The Performance Analyst skips the `call_llm` path. Cost: zero tokens. Reproducibility: full. The vote shape (`member_id`, `member_name`, `weight`, `votes`, `top_pick`, `top_pick_reason`) matches `get_board_vote(...)` so the downstream aggregator is unchanged.

## Before / after weighting example

Two topics, six LLM voters all score them 7/10 (tied):

**Before this change** — board size 6, both topics tie at 7.00.

**After this change** — board size 7. If Topic 1 ("Flaky tests in modern pipelines") overlaps strongly with the underperformer "Flaky Tests Are Killing Your Pipeline Productivity", the analyst votes 3/10 for it and 8/10 for the unrelated Topic 2 ("The economics of database sharding").

Weighted scores (weights: VP 1.2, QE 1.0, Skeptic 1.1, Climber 0.8, Editor 1.3, Reader 0.9, Analyst 1.0; total = 7.3):

- Topic 1: `(7·1.2 + 7·1.0 + 7·1.1 + 7·0.8 + 7·1.3 + 7·0.9 + 3·1.0) / 7.3 ≈ 6.45`
- Topic 2: `(7·1.2 + 7·1.0 + 7·1.1 + 7·0.8 + 7·1.3 + 7·0.9 + 8·1.0) / 7.3 ≈ 7.14`

Topic 2 now wins — the proposal resembling a known reader-failure is correctly suppressed. This is exactly what the regression test in `TestPenaltyPath` asserts.

## Files touched

- `agents/editorial_board/performance_analyst.yaml` (new)
- `scripts/agent_loader.py` — register the new member slug
- `scripts/editorial_board.py` — similarity helper, deterministic vote, wired into `run_editorial_board`
- `tests/test_agent_loader.py` — board size 6 → 7
- `tests/test_editorial_board.py` — board size 6 → 7, new `TestPerformanceAnalystSimilarity`, `TestPerformanceAnalystVote`, `TestPenaltyPath` classes

## Test plan

- [x] `pytest tests/test_editorial_board.py -q` — 28 passed
- [x] `pytest tests/test_agent_loader.py tests/test_content_intelligence.py -q` — 48 passed
- [x] `pytest tests/ -q` — 1762 passed, 84 skipped, 0 failed
- [x] `python scripts/agent_loader.py --validate` — all 16 agent YAMLs valid
- [x] Adapter signature confirmed backward-compatible (`flow.py` call site `run_editorial_board(client, raw_topics, parallel=True)` works unchanged)

## SKILL INVOCATIONS

- `agent-skills:using-agent-skills`
- `agent-skills:context-engineering`

🤖 Generated with [Claude Code](https://claude.com/claude-code)