### PR TITLE
fix: update stale chart_metrics import in archived metrics_report.py (#359)

### DIFF
--- a/scripts/archived/metrics_report.py
+++ b/scripts/archived/metrics_report.py
@@ -15,7 +15,7 @@ import argparse
 import json
 from datetime import datetime
 
-from chart_metrics import ChartMetricsCollector
+from src.quality.chart_metrics import ChartMetricsCollector
 
 
 def generate_console_report(


### PR DESCRIPTION
## Summary

PR #357 (ADR-0010) migrated \`chart_metrics\` from \`scripts/\` to \`src/quality/\`. One stale bare-name import remained in \`scripts/archived/metrics_report.py:18\`:

\`\`\`python
-from chart_metrics import ChartMetricsCollector
+from src.quality.chart_metrics import ChartMetricsCollector
\`\`\`

Currently harmless (archived scripts aren't run) but would \`ImportError\` if anyone resurrects the script. Per #359, this is the preferred fix (vs. comment-noting or deletion).

Closes #359.

## Test plan

- [x] \`python -c "import ast; ast.parse(...)"\` — syntax OK
- [x] \`ruff check\` — clean
- [x] \`ruff format --check\` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)