### PR TITLE
ci: measure src/ + scripts/ coverage, raise gate to 70% (#364)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,10 +93,11 @@ jobs:
       - name: Run tests with coverage
         run: |
           pytest tests/ -v \
+            --cov=src \
             --cov=scripts \
             --cov-report=term-missing \
             --cov-report=xml \
-            --cov-fail-under=35
+            --cov-fail-under=70
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 


### PR DESCRIPTION
## Summary

PR #357 (ADR-0010) migrated 12 modules from \`scripts/\` to \`src/quality/\` and \`src/backlog/\`, but ci.yml kept \`--cov=scripts\` so the migrated code stopped being coverage-measured in CI. This adds \`--cov=src\` and raises the gate from 35% to 70%.

Closes #364.

## Coverage baseline

Combined \`src/\` + \`scripts/\` on main (post-#358): **72%**.

Selected highlights:
| Path | Coverage |
|---|---|
| \`src/economist_agents/flow.py\` | 90% |
| \`src/telemetry/roi_tracker.py\` | 88% |
| \`src/quality/chart_metrics.py\` | 100% (post-#358) |
| \`src/quality/governance.py\` | 100% (post-#358) |
| \`src/quality/schema_validator.py\` | 99% (post-#358) |
| \`src/quality/validate_closed_loop.py\` | 93% (post-#358) |
| \`src/quality/visual_qa_zones.py\` | 98% (post-#358) |
| \`src/quality/defect_tracker.py\` | 15% (#370 will address) |
| \`src/quality/agent_metrics.py\` | 22% (#371 will address) |
| \`src/manager.py\` | 0% |
| \`src/tools/style_memory_tool.py\` | 34% |

## Gate choice

\`--cov-fail-under=70\` — 2-point cushion below the 72% baseline. Tight enough to catch regressions, loose enough to absorb minor variation. Easy to adjust if the gate flaps.

After #370 + #371 land, the baseline will rise to ~75–78%; the gate can ratchet up in a follow-up.

## Test plan

- [ ] CI green (this PR is the proof — the new gate runs against this PR's diff)
- [x] Local \`pytest --cov=src --cov=scripts\` → 72% (above gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)