### PR TITLE
fix: use fully-qualified scripts.* imports in _shared web search path

### DIFF
--- a/src/agent_sdk/_shared.py
+++ b/src/agent_sdk/_shared.py
@@ -112,7 +112,7 @@ def _run_web_searches(topic: str) -> str:
     """Combine arXiv and Google search results for ``topic``."""
     results: list[str] = []
     try:
-        from arxiv_search import search_arxiv_for_topic
+        from scripts.arxiv_search import search_arxiv_for_topic
 
         arxiv = search_arxiv_for_topic(topic, max_papers=5)
         if arxiv.get("success"):
@@ -130,7 +130,7 @@ def _run_web_searches(topic: str) -> str:
         logger.warning("arXiv search failed: %s", exc)
 
     try:
-        from google_search import search_google_for_topic
+        from scripts.google_search import search_google_for_topic
 
         google = search_google_for_topic(topic, max_results=5)
         if google.get("success"):


### PR DESCRIPTION
## Summary

Two bare-name imports in \`src/agent_sdk/_shared.py._run_web_searches\` were missed by ADR-0010's migration (PR #344) because they sit inside \`try/except\` blocks and tests mock the research path. Running the pipeline directly raises \`EmptyResearchBriefError\` because both providers silently fail to import.

\`\`\`python
-        from arxiv_search import search_arxiv_for_topic
+        from scripts.arxiv_search import search_arxiv_for_topic
...
-        from google_search import search_google_for_topic
+        from scripts.google_search import search_google_for_topic
\`\`\`

## How it was found

End-to-end pipeline run during a smoke-test of post-cleanup state surfaced:

\`\`\`
WARNING src.agent_sdk._shared: arXiv search failed: No module named 'arxiv_search'
WARNING src.agent_sdk._shared: Google search failed: No module named 'google_search'
...
src.agent_sdk._shared.EmptyResearchBriefError: No web search results returned.
\`\`\`

Both \`scripts/arxiv_search.py\` and \`scripts/google_search.py\` are present and live (see \`docs/adr/0010-scripts-to-src-migration.md\` SPEC.md §2 KEEP list); they just weren't importable as bare names without \`scripts/\` on \`sys.path\`. The fix matches the rest of the codebase post-#344 (no \`sys.path\` hacks, all imports fully-qualified).

## Why CI didn't catch it

- \`tests/test_empty_research_guard.py\` mocks the research path → never exercises the actual import
- \`tests/test_flow_agent_sdk.py\` and similar pipeline tests also mock LLM/search
- No smoke-test that exercises \`python -m src.agent_sdk.pipeline --help\` or any top-level import sweep

## Follow-up worth filing (not in this PR)

An import-only smoke test would catch this and similar regressions. Two cheap options:
1. A CI step that runs \`python -m src.agent_sdk.pipeline --help\` (forces top-level imports without network/LLM calls)
2. A pytest that does \`importlib.import_module(\"src.agent_sdk._shared\"); _shared._run_web_searches.__call__\` to force inner-function import resolution

## Test plan

- [x] Repro: \`python -m src.agent_sdk.pipeline \"<topic>\"\` failed with EmptyResearchBriefError before this fix
- [ ] CI green
- [ ] Re-run pipeline after merge to confirm research path activates

🤖 Generated with [Claude Code](https://claude.com/claude-code)