### PR TITLE
fix(#384): filter provider error stubs so they don't count as sources

### DIFF
--- a/src/agent_sdk/_shared.py
+++ b/src/agent_sdk/_shared.py
@@ -188,7 +188,13 @@ def _run_web_searches(topic: str) -> tuple[str, dict[str, Any]]:
         if not google.get("success", False):
             provider_failed["google"] = True
         else:
-            web = google.get("web_results", [])
+            # search_web and search_scholar in scripts/google_search.py catch
+            # requests.HTTPError internally and return [{"error": "..."}] as
+            # the result list. search_google_for_topic does NOT filter those
+            # out, so success=True can coexist with error-stub results. Filter
+            # them here so they don't get counted as real sources or rendered
+            # as fake bullets with "Unknown" titles.
+            web = [r for r in google.get("web_results", []) if "error" not in r]
             if web:
                 source_counts["google_web"] = len(web[:5])
                 results.append("\n## Web Sources")
@@ -198,7 +204,9 @@ def _run_web_searches(topic: str) -> tuple[str, dict[str, Any]]:
                         f"  Snippet: {r.get('snippet', 'N/A')}\n"
                         f"  Date: {r.get('date', 'N/A')}",
                     )
-            scholar = google.get("scholar_results", [])
+            scholar = [
+                r for r in google.get("scholar_results", []) if "error" not in r
+            ]
             if scholar:
                 source_counts["google_scholar"] = len(scholar[:5])
                 results.append("\n## Google Scholar")
@@ -208,6 +216,15 @@ def _run_web_searches(topic: str) -> tuple[str, dict[str, Any]]:
                         f"  Year: {r.get('year', 'N/A')}\n"
                         f"  Cited by: {r.get('cited_by', 'N/A')}",
                     )
+            # If google reported success but ALL results were error stubs that
+            # we just filtered out, the provider effectively failed. Mark it
+            # so the gate categorises this as SearchProvidersFailedError
+            # (transient/environmental) rather than SearchProvidersEmptyError
+            # (topic too narrow).
+            if not web and not scholar and (
+                google.get("web_results") or google.get("scholar_results")
+            ):
+                provider_failed["google"] = True
     except Exception as exc:
         logger.warning("Google search failed: %s", exc)
         provider_failed["google"] = True

--- a/tests/test_empty_research_guard.py
+++ b/tests/test_empty_research_guard.py
@@ -109,6 +109,51 @@ class TestEmptyResearchBriefError:
 
         assert "Some result" in brief
 
+    def test_provider_error_stubs_are_filtered_and_categorised_as_failed(
+        self,
+    ) -> None:
+        """When search_web/search_scholar return [{"error": "..."}] stubs
+        (HTTPError caught internally), they must NOT be counted as sources
+        and the provider must be marked failed so the gate categorises as
+        SearchProvidersFailedError rather than SearchProvidersEmptyError.
+
+        Reproduces the regression discovered post-#385 with --research-only
+        on a Serper-rejected query.
+        """
+        from src.agent_sdk._shared import (
+            SearchProvidersFailedError,
+            _run_web_searches,
+            build_research_brief,
+        )
+
+        # arxiv: clean empty success; google: success=True but results are
+        # all error stubs from the underlying search_web/scholar methods
+        def fake_arxiv(*args, **kwargs):
+            return {"success": True, "insights": {"papers_analyzed": []}}
+
+        def fake_google(*args, **kwargs):
+            return {
+                "success": True,
+                "topic": "x",
+                "web_results": [{"error": "HTTP error from Serper API: 400"}],
+                "scholar_results": [{"error": "HTTP error from Serper API: 400"}],
+            }
+
+        with (
+            patch("scripts.arxiv_search.search_arxiv_for_topic", fake_arxiv),
+            patch("scripts.google_search.search_google_for_topic", fake_google),
+        ):
+            _, diag = _run_web_searches("AI Testing")
+            assert diag["source_counts"] == {
+                "arxiv": 0,
+                "google_web": 0,
+                "google_scholar": 0,
+            }
+            assert diag["provider_failed"]["google"] is True
+
+            with pytest.raises(SearchProvidersFailedError):
+                build_research_brief("AI Testing")
+
     def test_run_stage3_propagates_empty_research_error(self) -> None:
         """EmptyResearchBriefError (and subclasses) must not be swallowed by run_stage3."""
         from src.agent_sdk._shared import EmptyResearchBriefError


### PR DESCRIPTION
## Summary

Fix-forward for a bug surfaced immediately after #385 merged. The source-count gate from #385 had a hole: \`scripts/google_search.py\`'s \`search_web\` / \`search_scholar\` catch \`requests.HTTPError\` internally and return \`[{"error": "..."}]\` as the result list. \`search_google_for_topic\` returns \`success=True\` regardless. My new \`_run_web_searches\` counted each error stub as a real source, defeating the gate.

## Reproduction (same query as #384 / #385)

Before this fix, on the live machine:

\`\`\`
$ python -m src.agent_sdk.pipeline --research-only "What RDE and FDE all about? ..."
# Serper returned 400, but the brief got rendered with:
## Web Sources
- [Unknown]()
  Snippet: N/A
  Date: N/A

## Google Scholar
- [Unknown]()
  Year: N/A
  Cited by: N/A
\`\`\`

Exit code: 0. Gate did not engage. The writer (in non-research-only mode) would still run and waste tokens on this nonsense brief.

After this fix:

\`\`\`
$ python -m src.agent_sdk.pipeline --research-only "<same topic>"
Research aborted: providers failed.
  No usable sources returned for topic '...'. provider_failed={'arxiv': False, 'google': True}, source_counts={'arxiv': 0, 'google_web': 0, 'google_scholar': 0}.
  Likely causes: provider outage, missing/invalid SERPER_API_KEY, or query rejected by provider (HTTP 4xx). Retry in a few minutes or rephrase the topic.
\`\`\`

Exit code: 2. Total wall time: ~3 seconds.

## Changes

In \`src/agent_sdk/_shared.py._run_web_searches\`:

1. Filter \`web\` and \`scholar\` lists to entries without an \`"error"\` key before counting or rendering. Prevents bogus counts AND fake \`[Unknown]()\` bullets in the brief.
2. If google reported \`success=True\` but all results were error stubs (filtered to empty), mark \`provider_failed["google"] = True\` so the gate categorises this as \`SearchProvidersFailedError\` (transient/environmental — retry or rephrase) rather than \`SearchProvidersEmptyError\` (topic too narrow — broaden). Matches the actual user-facing fix path.

## Test

\`test_provider_error_stubs_are_filtered_and_categorised_as_failed\` (regression):
- arxiv returns clean empty success
- google returns \`success=True\` with \`web_results=[{"error": ...}]\` and \`scholar_results=[{"error": ...}]\`
- Asserts \`source_counts\` all 0, \`provider_failed["google"]\` True
- Asserts \`build_research_brief\` raises \`SearchProvidersFailedError\` (not the \`Empty\` variant)

## Verification

- \`pytest tests/test_empty_research_guard.py -v\` → 14 passed (was 13)
- \`pytest tests/ -q\` → 2107 passed (+1), 84 skipped
- Manual end-to-end with the original problem query: exit 2, ~3 second fail, no LLM spend

## Why this slipped past #385's tests

#385's mocks fed clean tuples directly to \`build_research_brief\` rather than going through the real \`_run_web_searches\` with mocked underlying providers. The bug lives in \`_run_web_searches\`'s handling of the provider response shape, which the mocks bypassed. This PR fixes that and adds a test that exercises \`_run_web_searches\` directly with the real-shaped (broken) provider output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)