### PR TITLE
fix: purge remaining bare-name imports + CI regression guard (#391)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,23 @@ jobs:
       - name: Run ruff linter
         run: ruff check .
 
+      - name: Forbid bare-name imports of scripts/ modules (#391, ADR-0010)
+        run: |
+          # Modules whose bare-name imports enable sys.path-based module
+          # spoofing. PR #383 and PR #391 fixed the known instances; this
+          # guard prevents regression. Excludes archived/ and docstring
+          # examples (Usage: blocks in module-level """...""").
+          if grep -rEn '^[[:space:]]*from (google_search|arxiv_search|topic_trend_grounding|agent_registry)[[:space:]]+import' \
+              --include='*.py' \
+              --exclude-dir=archived \
+              src/ scripts/ agents/ tests/ mcp_servers/ 2>/dev/null \
+              | grep -v 'scripts/agent_registry.py:8:'; then
+            echo ""
+            echo "::error::Bare-name import of a scripts/ module detected."
+            echo "Use 'from scripts.<module> import ...' instead — see PR #383, #391."
+            exit 1
+          fi
+
       - name: Run mypy type checker
         continue-on-error: true
         run: |

--- a/agents/research_agent.py
+++ b/agents/research_agent.py
@@ -29,7 +29,7 @@ from src.quality.governance import GovernanceTracker  # noqa: E402
 
 # Import arXiv integration (optional dependency)
 try:
-    from arxiv_search import search_arxiv_for_topic  # type: ignore
+    from scripts.arxiv_search import search_arxiv_for_topic
 
     ARXIV_AVAILABLE = True
 except ImportError:
@@ -37,7 +37,7 @@ except ImportError:
 
 # Import Google Search integration (optional dependency)
 try:
-    from google_search import search_google_for_topic  # type: ignore
+    from scripts.google_search import search_google_for_topic
 
     GOOGLE_SEARCH_AVAILABLE = True
 except ImportError:

--- a/scripts/topic_scout.py
+++ b/scripts/topic_scout.py
@@ -28,8 +28,8 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from agent_loader import load_scout_prompts as _load_scout_prompts  # noqa: E402
-from topic_trend_grounding import build_grounded_trend_context  # noqa: E402
 
+from scripts.topic_trend_grounding import build_grounded_trend_context  # noqa: E402
 from src.tools.topic_deduplicator import TopicDeduplicator  # noqa: E402
 
 logger = logging.getLogger(__name__)

--- a/scripts/topic_trend_grounding.py
+++ b/scripts/topic_trend_grounding.py
@@ -104,7 +104,7 @@ def _get_searcher() -> Any:
     # Import lazily to keep module importable even when google_search has
     # heavy optional deps.
     try:
-        from google_search import GoogleSearcher
+        from scripts.google_search import GoogleSearcher
     except ImportError as exc:
         logger.warning(
             "SERPER_API_KEY is set but google_search is unavailable; "

--- a/tests/test_topic_trend_grounding.py
+++ b/tests/test_topic_trend_grounding.py
@@ -7,17 +7,13 @@ are made during the test suite.
 
 from __future__ import annotations
 
-import sys
 from datetime import datetime
-from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-
-from topic_trend_grounding import (
+from scripts.topic_trend_grounding import (
     EvidenceItem,
     TrendEvidence,
     _default_queries,
@@ -188,7 +184,9 @@ class TestFetchHnTopStories:
                     return mock_resp
             return MagicMock()  # pragma: no cover
 
-        with patch("topic_trend_grounding.requests.get", side_effect=get_side_effect):
+        with patch(
+            "scripts.topic_trend_grounding.requests.get", side_effect=get_side_effect
+        ):
             stories = _fetch_hn_top_stories(max_items=3)
 
         assert len(stories) == 3
@@ -201,7 +199,7 @@ class TestFetchHnTopStories:
         import requests
 
         with patch(
-            "topic_trend_grounding.requests.get",
+            "scripts.topic_trend_grounding.requests.get",
             side_effect=requests.RequestException("timeout"),
         ):
             stories = _fetch_hn_top_stories()
@@ -224,7 +222,9 @@ class TestFetchHnTopStories:
                 return mock_top_resp
             return mock_item_resp
 
-        with patch("topic_trend_grounding.requests.get", side_effect=get_side_effect):
+        with patch(
+            "scripts.topic_trend_grounding.requests.get", side_effect=get_side_effect
+        ):
             stories = _fetch_hn_top_stories()
         assert stories == []
 
@@ -252,7 +252,9 @@ class TestFetchHnTopStories:
                 return mock_top_resp
             return mock_item_resp
 
-        with patch("topic_trend_grounding.requests.get", side_effect=get_side_effect):
+        with patch(
+            "scripts.topic_trend_grounding.requests.get", side_effect=get_side_effect
+        ):
             stories = _fetch_hn_top_stories()
         assert stories == []
 
@@ -274,7 +276,9 @@ class TestFetchHnTopStories:
             mock_item.raise_for_status = MagicMock()
             return mock_item
 
-        with patch("topic_trend_grounding.requests.get", side_effect=get_side_effect):
+        with patch(
+            "scripts.topic_trend_grounding.requests.get", side_effect=get_side_effect
+        ):
             stories = _fetch_hn_top_stories(max_items=2)
         assert len(stories) == 2
 
@@ -295,8 +299,13 @@ class TestGatherTrendEvidence:
         mock_searcher.search_web.return_value = _make_web_results(2)
 
         with (
-            patch("topic_trend_grounding._get_searcher", return_value=mock_searcher),
-            patch("topic_trend_grounding._fetch_hn_top_stories", return_value=[]),
+            patch(
+                "scripts.topic_trend_grounding._get_searcher",
+                return_value=mock_searcher,
+            ),
+            patch(
+                "scripts.topic_trend_grounding._fetch_hn_top_stories", return_value=[]
+            ),
         ):
             evidence = gather_trend_evidence(queries=["q1", "q2"], include_hn=True)
 
@@ -322,11 +331,11 @@ class TestGatherTrendEvidence:
 
         with (
             patch(
-                "topic_trend_grounding._get_searcher",
+                "scripts.topic_trend_grounding._get_searcher",
                 return_value=mock_searcher,
             ),
             patch(
-                "topic_trend_grounding._fetch_hn_top_stories",
+                "scripts.topic_trend_grounding._fetch_hn_top_stories",
                 return_value=[hn_item],
             ),
         ):
@@ -345,10 +354,10 @@ class TestGatherTrendEvidence:
 
         with (
             patch(
-                "topic_trend_grounding._get_searcher",
+                "scripts.topic_trend_grounding._get_searcher",
                 return_value=mock_searcher,
             ),
-            patch("topic_trend_grounding._fetch_hn_top_stories") as mock_hn,
+            patch("scripts.topic_trend_grounding._fetch_hn_top_stories") as mock_hn,
         ):
             evidence = gather_trend_evidence(queries=["q1"], include_hn=False)
 
@@ -367,10 +376,12 @@ class TestGatherTrendEvidence:
 
         with (
             patch(
-                "topic_trend_grounding._get_searcher",
+                "scripts.topic_trend_grounding._get_searcher",
                 return_value=mock_searcher,
             ),
-            patch("topic_trend_grounding._fetch_hn_top_stories", return_value=[]),
+            patch(
+                "scripts.topic_trend_grounding._fetch_hn_top_stories", return_value=[]
+            ),
         ):
             evidence = gather_trend_evidence(queries=None, include_hn=False)
 
@@ -389,7 +400,7 @@ class TestGatherTrendEvidence:
         )
 
         with patch(
-            "topic_trend_grounding._fetch_hn_top_stories",
+            "scripts.topic_trend_grounding._fetch_hn_top_stories",
             return_value=[hn_item],
         ):
             evidence = gather_trend_evidence(queries=["q1"], include_hn=True)
@@ -551,7 +562,7 @@ class TestBuildGroundedTrendContext:
             ),
         ]
         with patch(
-            "topic_trend_grounding.gather_trend_evidence",
+            "scripts.topic_trend_grounding.gather_trend_evidence",
             return_value=evidence,
         ):
             context = build_grounded_trend_context()
@@ -574,7 +585,7 @@ class TestBuildGroundedTrendContext:
             return []
 
         with patch(
-            "topic_trend_grounding.gather_trend_evidence",
+            "scripts.topic_trend_grounding.gather_trend_evidence",
             side_effect=mock_gather,
         ):
             build_grounded_trend_context(focus_area="test automation")
@@ -591,7 +602,9 @@ class TestBuildGroundedTrendContext:
         """Returns fallback text when no evidence collected."""
         monkeypatch.delenv("SERPER_API_KEY", raising=False)
 
-        with patch("topic_trend_grounding.gather_trend_evidence", return_value=[]):
+        with patch(
+            "scripts.topic_trend_grounding.gather_trend_evidence", return_value=[]
+        ):
             context = build_grounded_trend_context()
 
         assert "[UNVERIFIED]" in context
@@ -613,7 +626,7 @@ class TestBuildGroundedTrendContext:
             return []
 
         with patch(
-            "topic_trend_grounding.gather_trend_evidence",
+            "scripts.topic_trend_grounding.gather_trend_evidence",
             side_effect=mock_gather,
         ):
             build_grounded_trend_context(focus_area=None)


### PR DESCRIPTION
## Summary

Closes #391. Fixes the remaining bare-name imports that the \`/ship\` audit flagged (and three more it missed) — same module-spoofing class as PR #383, applied to the rest of the live tree. Adds a CI grep guard so the class can't re-emerge.

Two commits:
1. \`fix(#391): purge remaining bare-name imports\` — 4 files, 5 import sites
2. \`ci(#391): forbid bare-name imports of scripts/ modules (regression guard)\` — adds the guard

## Audit-flagged (2)

| File:line | Before | After |
|---|---|---|
| \`scripts/topic_trend_grounding.py:107\` | \`from google_search import GoogleSearcher\` | \`from scripts.google_search import ...\` |
| \`scripts/topic_scout.py:31\` | \`from topic_trend_grounding import ...\` | \`from scripts.topic_trend_grounding import ...\` |

## Found during recon (3 more the audit missed)

| File:line | Before | After |
|---|---|---|
| \`agents/research_agent.py:32\` | \`from arxiv_search import search_arxiv_for_topic\` (inside try/except) | \`from scripts.arxiv_search import ...\` |
| \`agents/research_agent.py:40\` | \`from google_search import search_google_for_topic\` (inside try/except) | \`from scripts.google_search import ...\` |
| \`tests/test_topic_trend_grounding.py:18-20\` | sys.path hack + bare import | \`from scripts.topic_trend_grounding import ...\` (hack dropped) |

The two in \`research_agent.py\` sit inside try/except ImportError — same shape as the bug PR #383 fixed in \`_shared.py\`. Kept the try/except (it serves graceful degradation for optional deps); just made the import fully-qualified inside.

The test file had ADR-0010's sys.path.insert leftover; dropped it along with the now-unused \`import sys\` and \`from pathlib import Path\` that only existed to support the hack.

Also updated all 19 \`patch()\` targets in test_topic_trend_grounding.py from \`"topic_trend_grounding.X"\` to \`"scripts.topic_trend_grounding.X"\` — without this the mocks resolve against a module that no longer exists at the bare name, triggering ModuleNotFoundError in test setup (caught during verification — would have shipped broken without it).

## Regression guard (Slice 2)

CI step in Code Quality Checks (\`.github/workflows/ci.yml\`):

\`\`\`bash
grep -rEn '^[[:space:]]*from (google_search|arxiv_search|topic_trend_grounding|agent_registry)[[:space:]]+import' \\
    --include='*.py' --exclude-dir=archived \\
    src/ scripts/ agents/ tests/ mcp_servers/ \\
    | grep -v 'scripts/agent_registry.py:8:'  # docstring Usage: example
\`\`\`

Exits non-zero with an actionable \`::error::\` message if any future PR reintroduces a bare-name import of these four modules.

## Out of scope (noted in commit message for follow-up)

- \`scripts/topic_scout.py\` still has bare \`from agent_loader import ...\`, \`from content_intelligence import ...\`, \`from llm_client import ...\`. Same anti-pattern, different modules — not in this issue's named scope.
- \`scripts/topic_scout.py\` sys.path.insert hack at lines 26-28 is retained because the above bare-name imports depend on it.

These warrant a sister follow-up issue if blanket cleanup is desired.

## Verification

- \`pytest tests/ -q\` → **2107 passed**, 84 skipped (baseline preserved)
- \`tests/test_topic_trend_grounding.py\` → 28/28 passed
- \`ruff check . && ruff format --check .\` → clean
- Grep guard verified locally: exits 0 on current tree, exits 1 if any of the 4 imports are reintroduced
- No remaining bare-name imports of the four guarded modules in live tree (only match is the docstring Usage: example at \`scripts/agent_registry.py:8\`, explicitly excluded)

## Test plan

- [x] All verifications above pass locally
- [ ] CI green (the new grep guard is itself a CI step — proves itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)