### PR TITLE
fix: comprehensive purge of bare-name imports + AST-based CI guard (#395)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,22 +38,8 @@ jobs:
       - name: Run ruff linter
         run: ruff check .
 
-      - name: Forbid bare-name imports of scripts/ modules (#391, ADR-0010)
-        run: |
-          # Modules whose bare-name imports enable sys.path-based module
-          # spoofing. PR #383 and PR #391 fixed the known instances; this
-          # guard prevents regression. Excludes archived/ and docstring
-          # examples (Usage: blocks in module-level """...""").
-          if grep -rEn '^[[:space:]]*from (google_search|arxiv_search|topic_trend_grounding|agent_registry)[[:space:]]+import' \
-              --include='*.py' \
-              --exclude-dir=archived \
-              src/ scripts/ agents/ tests/ mcp_servers/ 2>/dev/null \
-              | grep -v 'scripts/agent_registry.py:8:'; then
-            echo ""
-            echo "::error::Bare-name import of a scripts/ module detected."
-            echo "Use 'from scripts.<module> import ...' instead — see PR #383, #391."
-            exit 1
-          fi
+      - name: Forbid bare-name imports of scripts/ modules (#395, ADR-0010)
+        run: python scripts/check_bare_name_imports.py
 
       - name: Run mypy type checker
         continue-on-error: true

--- a/agents/editor_agent.py
+++ b/agents/editor_agent.py
@@ -16,10 +16,10 @@ from typing import Any
 # Add scripts directory to path for llm_client import
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from agent_loader import (
+from scripts.agent_loader import (
     load_content_agent as _load_content_agent,  # type: ignore
 )
-from llm_client import call_llm  # type: ignore
+from scripts.llm_client import call_llm  # type: ignore
 
 # Sprint 14 Integration: Style Memory RAG
 try:

--- a/agents/graphics_agent.py
+++ b/agents/graphics_agent.py
@@ -25,10 +25,9 @@ if str(_scripts_dir) not in sys.path:
     sys.path.insert(0, str(_scripts_dir))
 
 # Import chart metrics and agent loader
-from agent_loader import (  # noqa: E402
+from scripts.agent_loader import (  # noqa: E402
     load_content_agent as _load_content_agent,  # type: ignore
 )
-
 from src.quality.chart_metrics import get_metrics_collector  # noqa: E402
 
 # Module-level prompt constant loaded from YAML
@@ -143,7 +142,7 @@ class GraphicsAgent:
         max_tokens: int,
     ) -> str:
         """Generate matplotlib code via LLM."""
-        from llm_client import call_llm
+        from scripts.llm_client import call_llm
 
         prompt = self.GRAPHICS_AGENT_PROMPT.format(
             chart_spec=json.dumps(chart_spec, indent=2),

--- a/agents/research_agent.py
+++ b/agents/research_agent.py
@@ -19,11 +19,10 @@ _scripts_dir = Path(__file__).parent.parent / "scripts"
 if str(_scripts_dir) not in sys.path:
     sys.path.insert(0, str(_scripts_dir))
 
-from agent_loader import (  # noqa: E402
+from scripts.agent_loader import (  # noqa: E402
     load_content_agent as _load_content_agent,  # type: ignore
 )
-from llm_client import call_llm  # type: ignore  # noqa: E402
-
+from scripts.llm_client import call_llm  # type: ignore  # noqa: E402
 from src.quality.agent_reviewer import review_agent_output  # noqa: E402
 from src.quality.governance import GovernanceTracker  # noqa: E402
 
@@ -165,7 +164,7 @@ class ResearchAgent:
 
         # Verify citations: fetch URLs and confirm stats appear in source text
         try:
-            from citation_verifier import verify_citations
+            from scripts.citation_verifier import verify_citations
 
             research_data = verify_citations(research_data)
             cv = research_data.get("citation_verification", {})

--- a/agents/writer_agent.py
+++ b/agents/writer_agent.py
@@ -25,11 +25,10 @@ _scripts_dir = Path(__file__).parent.parent / "scripts"
 if str(_scripts_dir) not in sys.path:
     sys.path.insert(0, str(_scripts_dir))
 
-from agent_loader import (  # noqa: E402
+from scripts.agent_loader import (  # noqa: E402
     load_content_agent as _load_content_agent,  # type: ignore
 )
-from llm_client import call_llm  # type: ignore  # noqa: E402
-
+from scripts.llm_client import call_llm  # type: ignore  # noqa: E402
 from src.quality.agent_reviewer import review_agent_output  # noqa: E402
 from src.quality.governance import GovernanceTracker  # noqa: E402
 

--- a/scripts/ab_topic_scout_comparison.py
+++ b/scripts/ab_topic_scout_comparison.py
@@ -49,7 +49,8 @@ if str(_SCRIPTS_DIR) not in sys.path:
 
 import content_intelligence  # noqa: E402
 import topic_scout  # noqa: E402
-from llm_client import create_llm_client  # noqa: E402
+
+from scripts.llm_client import create_llm_client  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/ab_topic_scout_comparison.py
+++ b/scripts/ab_topic_scout_comparison.py
@@ -47,9 +47,10 @@ _SCRIPTS_DIR = Path(__file__).resolve().parent
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
-import content_intelligence  # noqa: E402
-import topic_scout  # noqa: E402
-
+from scripts import (  # noqa: E402
+    content_intelligence,
+    topic_scout,
+)
 from scripts.llm_client import create_llm_client  # noqa: E402
 
 logger = logging.getLogger(__name__)

--- a/scripts/audit_composite_scores.py
+++ b/scripts/audit_composite_scores.py
@@ -34,7 +34,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 _sys.path.insert(0, str(pathlib.Path(__file__).parent))
-from ga4_etl import COMPOSITE_WEIGHTS, normalize
+from scripts.ga4_etl import COMPOSITE_WEIGHTS, normalize
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/check_bare_name_imports.py
+++ b/scripts/check_bare_name_imports.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""CI guard: forbid bare-name imports of scripts/ modules.
+
+A bare-name import (`from llm_client import call_llm` or `import llm_client`)
+resolves through sys.path; if another module named ``llm_client`` exists
+anywhere on sys.path, it silently takes precedence. This is the CVE-377
+adjacent class — module spoofing via sys.path manipulation. ADR-0010 mandates
+fully-qualified imports (``from scripts.llm_client import call_llm``).
+
+This guard walks every .py file under src/, scripts/, agents/, tests/, and
+mcp_servers/ and uses ast to detect either form of the bare-name pattern
+targeting any top-level module in scripts/. AST parsing means it does not
+false-positive on docstring examples — only real import statements count.
+
+Exit code 0 on clean, 1 on any violation.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+SCAN_ROOTS = ["src", "scripts", "agents", "tests", "mcp_servers"]
+EXCLUDE_DIRS = {"archived", "__pycache__", ".venv", "venv", "node_modules"}
+
+# scripts/__init__.py itself is allowed to use `from .X import Y` style;
+# any module in scripts/ that re-exports siblings via relative imports is
+# fine. We only flag bare-name absolute imports.
+
+
+def _collect_scripts_modules() -> set[str]:
+    """Return the set of module names defined at the top level of scripts/."""
+    names: set[str] = set()
+    for p in SCRIPTS_DIR.glob("*.py"):
+        if p.name == "__init__.py":
+            continue
+        names.add(p.stem)
+    return names
+
+
+def _iter_py_files() -> list[Path]:
+    files: list[Path] = []
+    for root in SCAN_ROOTS:
+        root_path = REPO_ROOT / root
+        if not root_path.exists():
+            continue
+        for p in root_path.rglob("*.py"):
+            if any(part in EXCLUDE_DIRS for part in p.parts):
+                continue
+            files.append(p)
+    return files
+
+
+def _check_file(path: Path, scripts_modules: set[str]) -> list[tuple[int, str]]:
+    """Return list of (lineno, snippet) violations for a single file."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    violations: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            # `from X import Y` — flag when X is a bare scripts/ module name
+            # and there is no leading dot (absolute import).
+            if node.level == 0 and node.module in scripts_modules:
+                violations.append(
+                    (node.lineno, f"from {node.module} import ..."),
+                )
+        elif isinstance(node, ast.Import):
+            # `import X` or `import X as Y` — flag when X is a bare
+            # scripts/ module name.
+            for alias in node.names:
+                if alias.name in scripts_modules:
+                    violations.append(
+                        (alias.lineno or node.lineno, f"import {alias.name}"),
+                    )
+    return violations
+
+
+def main() -> int:
+    scripts_modules = _collect_scripts_modules()
+    if not scripts_modules:
+        print("error: no modules found under scripts/", file=sys.stderr)
+        return 1
+
+    all_violations: list[tuple[Path, int, str]] = []
+    for path in _iter_py_files():
+        for lineno, snippet in _check_file(path, scripts_modules):
+            all_violations.append((path, lineno, snippet))
+
+    if not all_violations:
+        print(
+            f"OK: no bare-name imports of {len(scripts_modules)} scripts/ "
+            "modules found across the codebase.",
+        )
+        return 0
+
+    print(
+        f"::error::Bare-name import(s) of scripts/ modules detected "
+        f"({len(all_violations)} site(s)). Use 'from scripts.<module> "
+        "import ...' or 'from scripts import <module>' — see ADR-0010, "
+        "PR #383, PR #391, issue #395.",
+        file=sys.stderr,
+    )
+    for path, lineno, snippet in sorted(all_violations):
+        rel = path.relative_to(REPO_ROOT)
+        print(f"{rel}:{lineno}: {snippet}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/continuous_burndown.py
+++ b/scripts/continuous_burndown.py
@@ -58,10 +58,11 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - direct script execution fallback
     from backlog_groomer import BacklogGroomer
     from ci_health_monitor import CIHealthMonitor
-    from github_issue_claim import GitHubIssueClaimer
     from migrate_backlog_to_github import BacklogParser
-    from sprint_validator import SprintValidator
     from validate_documentation_accuracy import DocumentationValidator
+
+    from scripts.github_issue_claim import GitHubIssueClaimer
+    from scripts.sprint_validator import SprintValidator
 from schemas.validate_schemas import validate_json_file
 
 DEFAULT_REPORT = "logs/continuous_burndown_report.json"

--- a/scripts/deploy_to_blog.py
+++ b/scripts/deploy_to_blog.py
@@ -39,7 +39,7 @@ from typing import Optional
 
 # Allow importing from scripts/ when run directly or via subprocess
 sys.path.insert(0, str(Path(__file__).parent))
-from publication_validator import validate_file  # noqa: E402
+from scripts.publication_validator import validate_file  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/economist_agent.py
+++ b/scripts/economist_agent.py
@@ -24,14 +24,6 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-# Import featured image generator
-from featured_image_agent import generate_featured_image
-
-# Import unified LLM client
-from llm_client import call_llm, create_llm_client
-
-# Import publication validator
-from publication_validator import PublicationValidator
 from slugify import slugify
 
 # Import extracted Editor Agent
@@ -45,6 +37,15 @@ from agents.research_agent import run_research_agent
 
 # Import extracted Writer Agent
 from agents.writer_agent import run_writer_agent
+
+# Import featured image generator
+from scripts.featured_image_agent import generate_featured_image
+
+# Import unified LLM client
+from scripts.llm_client import call_llm, create_llm_client
+
+# Import publication validator
+from scripts.publication_validator import PublicationValidator
 
 # Import agent metrics
 from src.quality.agent_metrics import AgentMetrics

--- a/scripts/editorial_board.py
+++ b/scripts/editorial_board.py
@@ -48,14 +48,14 @@ from pathlib import Path
 # ═══════════════════════════════════════════════════════════════════════════
 # BOARD MEMBER PERSONAS
 # ═══════════════════════════════════════════════════════════════════════════
-from agent_loader import load_board_members as _load_board_members
-from content_intelligence import (
+from scripts.agent_loader import load_board_members as _load_board_members
+from scripts.content_intelligence import (
     ArticlePerformance,
     get_bottom_performers,
 )
 
 # Import unified LLM client
-from llm_client import call_llm, create_llm_client
+from scripts.llm_client import call_llm, create_llm_client
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/llm_client.py
+++ b/scripts/llm_client.py
@@ -191,7 +191,7 @@ def _call_anthropic(
     )
 
     try:
-        from token_usage import log_token_usage
+        from scripts.token_usage import log_token_usage
 
         log_token_usage(
             model=model,
@@ -225,7 +225,7 @@ def _call_openai(
     )
 
     try:
-        from token_usage import log_token_usage
+        from scripts.token_usage import log_token_usage
 
         usage = response.usage
         if usage is not None:

--- a/scripts/po_agent.py
+++ b/scripts/po_agent.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from llm_client import call_llm, create_llm_client
+from scripts.llm_client import call_llm, create_llm_client
 
 # ═══════════════════════════════════════════════════════════════════════════
 # PO AGENT SYSTEM PROMPT

--- a/scripts/publication_validator.py
+++ b/scripts/publication_validator.py
@@ -24,7 +24,7 @@ import yaml
 
 # Import defect prevention rules (learned from historical bugs)
 try:
-    from defect_prevention_rules import DefectPrevention
+    from scripts.defect_prevention_rules import DefectPrevention
 
     DEFECT_PREVENTION_AVAILABLE = True
 except ImportError:

--- a/scripts/topic_scout.py
+++ b/scripts/topic_scout.py
@@ -27,8 +27,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from agent_loader import load_scout_prompts as _load_scout_prompts  # noqa: E402
-
+from scripts.agent_loader import load_scout_prompts as _load_scout_prompts  # noqa: E402
 from scripts.topic_trend_grounding import build_grounded_trend_context  # noqa: E402
 from src.tools.topic_deduplicator import TopicDeduplicator  # noqa: E402
 
@@ -141,10 +140,10 @@ THEME_KEYWORDS: dict[str, list[str]] = {
 }
 
 # Content Intelligence: real blog performance data from GA4 ETL (ADR-0007)
-from content_intelligence import get_performance_context  # noqa: E402
+from scripts.content_intelligence import get_performance_context  # noqa: E402
 
 # Import unified LLM client
-from llm_client import call_llm, create_llm_client  # noqa: E402
+from scripts.llm_client import call_llm, create_llm_client  # noqa: E402
 
 _scout_prompts = _load_scout_prompts()
 SCOUT_AGENT_PROMPT = _scout_prompts["scout"]

--- a/scripts/topic_scout_reproducibility.py
+++ b/scripts/topic_scout_reproducibility.py
@@ -49,8 +49,8 @@ import orjson
 # Ensure scripts/ is on the import path when running directly.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from content_intelligence import get_performance_context
-from topic_scout import create_client, scout_topics
+from scripts.content_intelligence import get_performance_context
+from scripts.topic_scout import create_client, scout_topics
 
 logger = logging.getLogger(__name__)
 

--- a/src/economist_agents/adapters.py
+++ b/src/economist_agents/adapters.py
@@ -12,11 +12,11 @@ _scripts_dir = str(Path(__file__).parent.parent.parent / "scripts")
 if _scripts_dir not in sys.path:
     sys.path.insert(0, _scripts_dir)
 
-from editorial_board import run_editorial_board  # noqa: E402
-from featured_image_agent import generate_featured_image  # noqa: E402
-from llm_client import create_llm_client  # noqa: E402
-from publication_validator import PublicationValidator  # noqa: E402
-from topic_scout import scout_topics  # noqa: E402
+from scripts.editorial_board import run_editorial_board  # noqa: E402
+from scripts.featured_image_agent import generate_featured_image  # noqa: E402
+from scripts.llm_client import create_llm_client  # noqa: E402
+from scripts.publication_validator import PublicationValidator  # noqa: E402
+from scripts.topic_scout import scout_topics  # noqa: E402
 
 __all__ = [
     "PublicationValidator",

--- a/tests/test_ab_topic_scout_comparison.py
+++ b/tests/test_ab_topic_scout_comparison.py
@@ -19,8 +19,8 @@ _SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 if str(_SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_DIR))
 
-import topic_scout  # noqa: E402
-from ab_topic_scout_comparison import (  # noqa: E402
+from scripts import topic_scout  # noqa: E402
+from scripts.ab_topic_scout_comparison import (  # noqa: E402
     _topic_title_set,
     jaccard_similarity,
     qualitative_notes,
@@ -30,7 +30,7 @@ from ab_topic_scout_comparison import (  # noqa: E402
     score_deltas,
     verdict,
 )
-from content_intelligence import ArticlePerformance  # noqa: E402
+from scripts.content_intelligence import ArticlePerformance  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
@@ -507,15 +507,15 @@ class TestRunAbPair:
 
         with (
             patch(
-                "ab_topic_scout_comparison.topic_scout.scout_topics",
+                "scripts.ab_topic_scout_comparison.topic_scout.scout_topics",
                 side_effect=fake_scout_topics,
             ),
             patch(
-                "ab_topic_scout_comparison.content_intelligence.get_top_performers",
+                "scripts.ab_topic_scout_comparison.content_intelligence.get_top_performers",
                 return_value=[],
             ),
             patch(
-                "ab_topic_scout_comparison.content_intelligence.get_bottom_performers",
+                "scripts.ab_topic_scout_comparison.content_intelligence.get_bottom_performers",
                 return_value=[],
             ),
         ):
@@ -553,15 +553,15 @@ class TestRunAbPair:
 
         with (
             patch(
-                "ab_topic_scout_comparison.topic_scout.scout_topics",
+                "scripts.ab_topic_scout_comparison.topic_scout.scout_topics",
                 return_value=sample_topics,
             ),
             patch(
-                "ab_topic_scout_comparison.content_intelligence.get_top_performers",
+                "scripts.ab_topic_scout_comparison.content_intelligence.get_top_performers",
                 return_value=[],
             ),
             patch(
-                "ab_topic_scout_comparison.content_intelligence.get_bottom_performers",
+                "scripts.ab_topic_scout_comparison.content_intelligence.get_bottom_performers",
                 return_value=[],
             ),
         ):

--- a/tests/test_agent_loader.py
+++ b/tests/test_agent_loader.py
@@ -9,7 +9,7 @@ import yaml
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from agent_loader import (
+from scripts.agent_loader import (
     AGENTS_DIR,
     AgentConfig,
     load_agent,

--- a/tests/test_architecture_audit.py
+++ b/tests/test_architecture_audit.py
@@ -15,7 +15,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-import architecture_audit as audit_mod  # noqa: E402
+from scripts import architecture_audit as audit_mod  # noqa: E402
 
 REAL_AGENTS_DIR = REPO_ROOT / ".github" / "agents"
 # Corpus reached the 85% target 2026-04-26 after honest rubric broadening

--- a/tests/test_audit_composite_scores.py
+++ b/tests/test_audit_composite_scores.py
@@ -17,8 +17,6 @@ import pytest
 # pattern used by the scripts themselves at runtime).
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "scripts"))
 
-from ga4_etl import COMPOSITE_WEIGHTS
-
 from scripts.audit_composite_scores import (
     _ACTIVE_WEIGHT_SUM,
     _ZERO_WEIGHT_SUM,
@@ -30,6 +28,7 @@ from scripts.audit_composite_scores import (
     run_sanity_checks,
     select_sample,
 )
+from scripts.ga4_etl import COMPOSITE_WEIGHTS
 
 # ---------------------------------------------------------------------------
 # Helpers & fixtures

--- a/tests/test_audit_composite_scores.py
+++ b/tests/test_audit_composite_scores.py
@@ -17,7 +17,9 @@ import pytest
 # pattern used by the scripts themselves at runtime).
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent / "scripts"))
 
-from audit_composite_scores import (
+from ga4_etl import COMPOSITE_WEIGHTS
+
+from scripts.audit_composite_scores import (
     _ACTIVE_WEIGHT_SUM,
     _ZERO_WEIGHT_SUM,
     build_report,
@@ -28,7 +30,6 @@ from audit_composite_scores import (
     run_sanity_checks,
     select_sample,
 )
-from ga4_etl import COMPOSITE_WEIGHTS
 
 # ---------------------------------------------------------------------------
 # Helpers & fixtures

--- a/tests/test_citation_verifier.py
+++ b/tests/test_citation_verifier.py
@@ -6,7 +6,7 @@ from typing import Any
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from citation_verifier import (
+from scripts.citation_verifier import (
     _normalize,
     _stat_appears_in_text,
     verify_citations,

--- a/tests/test_content_intelligence.py
+++ b/tests/test_content_intelligence.py
@@ -16,7 +16,7 @@ import pytest
 # Add scripts/ to path so we can import content_intelligence directly
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from content_intelligence import (
+from scripts.content_intelligence import (
     ArticlePerformance,
     TrafficSummary,
     _is_article,

--- a/tests/test_economist_agent.py
+++ b/tests/test_economist_agent.py
@@ -34,7 +34,7 @@ import pytest
 scripts_dir = Path(__file__).parent.parent / "scripts"
 sys.path.insert(0, str(scripts_dir))
 
-import economist_agent as ea  # noqa: E402
+from scripts import economist_agent as ea  # noqa: E402
 
 # ============================================================================
 # FIXTURES
@@ -740,8 +740,8 @@ class TestMain:
         """Test main function with default arguments."""
         with (
             patch("sys.argv", ["economist_agent.py"]),
-            patch("economist_agent.generate_economist_post") as mock_generate,
-            patch("economist_agent.create_client") as mock_client,
+            patch("scripts.economist_agent.generate_economist_post") as mock_generate,
+            patch("scripts.economist_agent.create_client") as mock_client,
             patch.dict(os.environ, {}, clear=True),
         ):
             mock_generate.return_value = {"article_path": "/tmp/article.md"}
@@ -755,9 +755,9 @@ class TestMain:
         """Test main function with interactive mode enabled."""
         with (
             patch("sys.argv", ["economist_agent.py", "--interactive"]),
-            patch("economist_agent.generate_economist_post") as mock_generate,
-            patch("economist_agent.create_client") as mock_client,
-            patch("economist_agent.GovernanceTracker") as mock_governance,
+            patch("scripts.economist_agent.generate_economist_post") as mock_generate,
+            patch("scripts.economist_agent.create_client") as mock_client,
+            patch("scripts.economist_agent.GovernanceTracker") as mock_governance,
             patch.dict(os.environ, {"TOPIC": "Test Topic"}, clear=True),
         ):
             mock_generate.return_value = {"article_path": "/tmp/article.md"}
@@ -781,9 +781,9 @@ class TestMain:
                     str(governance_dir),
                 ],
             ),
-            patch("economist_agent.generate_economist_post") as mock_generate,
-            patch("economist_agent.create_client") as mock_client,
-            patch("economist_agent.GovernanceTracker") as mock_governance,
+            patch("scripts.economist_agent.generate_economist_post") as mock_generate,
+            patch("scripts.economist_agent.create_client") as mock_client,
+            patch("scripts.economist_agent.GovernanceTracker") as mock_governance,
             patch.dict(os.environ, {"TOPIC": "Test Topic"}, clear=True),
         ):
             mock_generate.return_value = {"article_path": "/tmp/article.md"}
@@ -808,8 +808,8 @@ class TestMain:
 
         with (
             patch("sys.argv", ["economist_agent.py"]),
-            patch("economist_agent.generate_economist_post") as mock_generate,
-            patch("economist_agent.create_client") as mock_client,
+            patch("scripts.economist_agent.generate_economist_post") as mock_generate,
+            patch("scripts.economist_agent.create_client") as mock_client,
             patch.dict(os.environ, env_vars),
         ):
             mock_generate.return_value = {
@@ -829,8 +829,8 @@ class TestMain:
         """Test main function writes to GITHUB_OUTPUT."""
         with (
             patch("sys.argv", ["economist_agent.py"]),
-            patch("economist_agent.generate_economist_post") as mock_generate,
-            patch("economist_agent.create_client") as mock_client,
+            patch("scripts.economist_agent.generate_economist_post") as mock_generate,
+            patch("scripts.economist_agent.create_client") as mock_client,
             patch("builtins.open", mock_open()) as mock_file,
             patch.dict(
                 os.environ,

--- a/tests/test_economist_agent.py
+++ b/tests/test_economist_agent.py
@@ -223,7 +223,9 @@ class TestRunResearchAgent:
                 "agents.research_agent.ResearchAgent._gather_web_research",
                 return_value=None,
             ),
-            patch("citation_verifier.verify_citations", side_effect=lambda x: x),
+            patch(
+                "scripts.citation_verifier.verify_citations", side_effect=lambda x: x
+            ),
         ):
             # Return the properly structured mock response
             mock_call_llm.return_value = json.dumps(sample_research_output)
@@ -284,7 +286,9 @@ class TestRunResearchAgent:
         with (
             patch("agents.research_agent.call_llm") as mock_call_llm,
             patch("agents.research_agent.review_agent_output") as mock_review,
-            patch("citation_verifier.verify_citations", side_effect=lambda x: x),
+            patch(
+                "scripts.citation_verifier.verify_citations", side_effect=lambda x: x
+            ),
         ):
             mock_call_llm.return_value = json.dumps(sample_research_output)
             mock_review.return_value = (True, [])
@@ -335,7 +339,9 @@ class TestRunResearchAgent:
                 "agents.research_agent.ResearchAgent._gather_web_research",
                 return_value=None,
             ),
-            patch("citation_verifier.verify_citations", side_effect=lambda x: x),
+            patch(
+                "scripts.citation_verifier.verify_citations", side_effect=lambda x: x
+            ),
         ):
             mock_call_llm.return_value = json.dumps(sample_research_output)
             mock_review.return_value = (
@@ -539,7 +545,7 @@ class TestRunGraphicsAgent:
         }
 
         with (
-            patch("llm_client.call_llm") as mock_call_llm,
+            patch("scripts.llm_client.call_llm") as mock_call_llm,
             patch("agents.graphics_agent.get_metrics_collector") as mock_metrics,
             patch("subprocess.run") as mock_subprocess,
             patch("builtins.open", mock_open()),
@@ -588,7 +594,7 @@ class TestRunGraphicsAgent:
         chart_spec = {"title": "Test Chart", "data": []}
 
         with (
-            patch("llm_client.call_llm") as mock_call_llm,
+            patch("scripts.llm_client.call_llm") as mock_call_llm,
             patch("agents.graphics_agent.get_metrics_collector") as mock_metrics,
             patch("subprocess.run") as mock_subprocess,
             patch("builtins.open", mock_open()),
@@ -609,7 +615,7 @@ class TestRunGraphicsAgent:
         chart_spec = {"title": "Test Chart", "data": []}
 
         with (
-            patch("llm_client.call_llm") as mock_call_llm,
+            patch("scripts.llm_client.call_llm") as mock_call_llm,
             patch("agents.graphics_agent.get_metrics_collector") as mock_metrics,
             patch("subprocess.run") as mock_subprocess,
             patch("builtins.open", mock_open()),
@@ -865,7 +871,7 @@ class TestIntegration:
             patch("agents.writer_agent.call_llm") as mock_writer_llm,
             patch("agents.editor_agent.call_llm") as mock_editor_llm,
             patch("agents.writer_agent.review_agent_output") as mock_review,
-            patch("llm_client.call_llm") as mock_graphics_llm,
+            patch("scripts.llm_client.call_llm") as mock_graphics_llm,
             patch("agents.graphics_agent.get_metrics_collector") as mock_metrics,
             patch("subprocess.run") as mock_subprocess,
             patch("builtins.open", mock_open()),

--- a/tests/test_editorial_board.py
+++ b/tests/test_editorial_board.py
@@ -18,7 +18,7 @@ import pytest
 # Add scripts directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from editorial_board import (
+from scripts.editorial_board import (
     BOARD_MEMBERS,
     PERFORMANCE_ANALYST_ID,
     _score_topic_against_underperformers,
@@ -104,7 +104,7 @@ class TestPersonaAgents:
         sample_vote_response,
     ):
         """Test VP of Engineering persona votes on topics."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             mock_call_llm.return_value = sample_vote_response
 
             member_id = "vp_engineering"
@@ -139,7 +139,7 @@ class TestPersonaAgents:
         sample_vote_response,
     ):
         """Test Senior QE Lead persona votes on topics."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             mock_call_llm.return_value = sample_vote_response
 
             member_id = "senior_qe_lead"
@@ -164,7 +164,7 @@ class TestPersonaAgents:
         sample_vote_response,
     ):
         """Test Data Skeptic persona votes on topics."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             mock_call_llm.return_value = sample_vote_response
 
             member_id = "data_skeptic"
@@ -188,7 +188,7 @@ class TestPersonaAgents:
         sample_vote_response,
     ):
         """Test Career Climber persona votes on topics."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             mock_call_llm.return_value = sample_vote_response
 
             member_id = "career_climber"
@@ -212,7 +212,7 @@ class TestPersonaAgents:
         sample_vote_response,
     ):
         """Test Economist Editor persona votes on topics."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             mock_call_llm.return_value = sample_vote_response
 
             member_id = "economist_editor"
@@ -236,7 +236,7 @@ class TestPersonaAgents:
         sample_vote_response,
     ):
         """Test Busy Reader persona votes on topics."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             mock_call_llm.return_value = sample_vote_response
 
             member_id = "busy_reader"
@@ -270,7 +270,7 @@ class TestVoteCollection:
         capsys,
     ):
         """Test collecting votes from all 7 board members (6 LLM + Performance Analyst)."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             # Each LLM member returns the same vote structure. The
             # Performance Analyst is deterministic and does not call the LLM.
             mock_call_llm.return_value = sample_vote_response
@@ -305,7 +305,7 @@ class TestVoteCollection:
         sample_vote_response,
     ):
         """Test handling of API failures during voting."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             # First 3 succeed, rest fail
             mock_call_llm.side_effect = [
                 sample_vote_response,
@@ -330,7 +330,7 @@ class TestVoteCollection:
 
     def test_vote_format_validation(self, mock_llm_client, sample_topics, capsys):
         """Test handling of invalid vote format from LLM."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             # Return invalid JSON
             mock_call_llm.return_value = "This is not valid JSON"
 
@@ -367,7 +367,7 @@ class TestAggregation:
         sample_vote_response,
     ):
         """Test weighted score calculation with different weights."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             # Create different scores for each member
             def create_vote(score1, score2):
                 return json.dumps(
@@ -415,7 +415,7 @@ class TestAggregation:
         sample_vote_response,
     ):
         """Test complete board decision aggregation."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             mock_call_llm.return_value = sample_vote_response
 
             result = run_editorial_board(mock_llm_client, sample_topics, parallel=False)
@@ -437,7 +437,7 @@ class TestAggregation:
 
     def test_consensus_determination(self, mock_llm_client, sample_topics):
         """Test consensus determination (unanimous vs split)."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             # All members pick topic 1 as top pick
             unanimous_vote = json.dumps(
                 {
@@ -457,7 +457,7 @@ class TestAggregation:
             assert result["consensus"] is True
 
         # Test split vote
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             # Members disagree on top pick
             def create_vote(top_pick_idx):
                 return json.dumps(
@@ -496,7 +496,7 @@ class TestOutput:
 
     def test_json_structure(self, mock_llm_client, sample_topics, sample_vote_response):
         """Test board decision JSON structure."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             mock_call_llm.return_value = sample_vote_response
 
             result = run_editorial_board(mock_llm_client, sample_topics, parallel=False)
@@ -521,8 +521,8 @@ class TestOutput:
     ):
         """Test saving board decision to files."""
         with (
-            patch("editorial_board.call_llm") as mock_call_llm,
-            patch("editorial_board.create_llm_client") as mock_create_client,
+            patch("scripts.editorial_board.call_llm") as mock_call_llm,
+            patch("scripts.editorial_board.create_llm_client") as mock_create_client,
             patch("builtins.open", mock_open()),
             patch("os.path.exists") as mock_exists,
         ):
@@ -576,7 +576,7 @@ class TestErrorHandling:
 
     def test_llm_api_errors(self, mock_llm_client, sample_topics):
         """Test handling of LLM API errors."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             # Simulate API error
             mock_call_llm.side_effect = Exception("API connection timeout")
 
@@ -600,7 +600,7 @@ class TestIntegration:
         sample_vote_response,
     ):
         """Test markdown report generation."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             mock_call_llm.return_value = sample_vote_response
 
             result = run_editorial_board(mock_llm_client, sample_topics, parallel=False)
@@ -622,7 +622,7 @@ class TestIntegration:
         sample_vote_response,
     ):
         """Test parallel and sequential voting produce same results."""
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             mock_call_llm.return_value = sample_vote_response
 
             # Run sequentially
@@ -632,7 +632,7 @@ class TestIntegration:
                 parallel=False,
             )
 
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             mock_call_llm.return_value = sample_vote_response
 
             # Run in parallel
@@ -667,8 +667,8 @@ class TestMainFunction:
     ):
         """Test main() with TOPICS environment variable."""
         with (
-            patch("editorial_board.call_llm") as mock_call_llm,
-            patch("editorial_board.create_llm_client") as mock_create_client,
+            patch("scripts.editorial_board.call_llm") as mock_call_llm,
+            patch("scripts.editorial_board.create_llm_client") as mock_create_client,
             patch.dict("os.environ", {"TOPICS": json.dumps(sample_topics)}),
             patch("builtins.open", mock_open()),
         ):
@@ -683,7 +683,7 @@ class TestMainFunction:
     def test_main_with_no_topics(self, capsys):
         """Test main() when no topics available."""
         with (
-            patch("editorial_board.create_llm_client"),
+            patch("scripts.editorial_board.create_llm_client"),
             patch("os.path.exists") as mock_exists,
             patch.dict("os.environ", {}, clear=True),
         ):
@@ -697,7 +697,7 @@ class TestMainFunction:
     def test_main_with_empty_topics(self, mock_llm_client, capsys):
         """Test main() with empty topics list."""
         with (
-            patch("editorial_board.create_llm_client") as mock_create_client,
+            patch("scripts.editorial_board.create_llm_client") as mock_create_client,
             patch("os.path.exists") as mock_exists,
             patch("builtins.open", mock_open(read_data='{"topics": []}')),
         ):
@@ -720,8 +720,8 @@ class TestMainFunction:
         github_output = tmp_path / "github_output.txt"
 
         with (
-            patch("editorial_board.call_llm") as mock_call_llm,
-            patch("editorial_board.create_llm_client") as mock_create_client,
+            patch("scripts.editorial_board.call_llm") as mock_call_llm,
+            patch("scripts.editorial_board.create_llm_client") as mock_create_client,
             patch.dict(
                 "os.environ",
                 {
@@ -816,7 +816,7 @@ class TestPerformanceAnalystSimilarity:
     def test_strong_overlap_yields_low_score(self) -> None:
         """A topic sharing 2+ distinctive tokens with an underperformer
         should receive the strong-match penalty score."""
-        from content_intelligence import ArticlePerformance
+        from scripts.content_intelligence import ArticlePerformance
 
         underperformers = [
             ArticlePerformance(
@@ -843,7 +843,7 @@ class TestPerformanceAnalystSimilarity:
 
     def test_no_overlap_yields_neutral_high_score(self) -> None:
         """A topic with no shared distinctive tokens should not be penalised."""
-        from content_intelligence import ArticlePerformance
+        from scripts.content_intelligence import ArticlePerformance
 
         underperformers = [
             ArticlePerformance(
@@ -954,7 +954,7 @@ class TestPenaltyPath:
             },
         )
 
-        with patch("editorial_board.call_llm") as mock_call_llm:
+        with patch("scripts.editorial_board.call_llm") as mock_call_llm:
             mock_call_llm.return_value = equal_vote
             result = run_editorial_board(
                 mock_llm_client,

--- a/tests/test_featured_image_agent.py
+++ b/tests/test_featured_image_agent.py
@@ -22,7 +22,7 @@ import pytest
 # ---------------------------------------------------------------------------
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from featured_image_agent import (
+from scripts.featured_image_agent import (
     ECONOMIST_IMAGE_STYLE,
     create_image_prompt,
     generate_featured_image,
@@ -162,7 +162,7 @@ class TestCreateImagePrompt:
 
     def test_prompt_truncated_to_dalle_max_length(self) -> None:
         """Prompt must never exceed DALLE_MAX_PROMPT_LENGTH (3900 chars)."""
-        from featured_image_agent import DALLE_MAX_PROMPT_LENGTH
+        from scripts.featured_image_agent import DALLE_MAX_PROMPT_LENGTH
 
         # Use an extremely long summary to trigger truncation
         long_summary = "A" * 5000

--- a/tests/test_generate_chart.py
+++ b/tests/test_generate_chart.py
@@ -32,7 +32,7 @@ with (
     patch("matplotlib.pyplot.close", _mock_close),
 ):
     # Import with coverage tracking enabled
-    import generate_chart  # This will execute the script safely
+    from scripts import generate_chart  # noqa: F401  # imported for coverage
 
 
 # ============================================================================

--- a/tests/test_github_integration.py
+++ b/tests/test_github_integration.py
@@ -20,7 +20,7 @@ from pathlib import Path
 # Add scripts to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from sprint_validator import SprintValidator
+from scripts.sprint_validator import SprintValidator
 
 
 class GitHubIntegrationTests:

--- a/tests/test_graphics_agent.py
+++ b/tests/test_graphics_agent.py
@@ -180,7 +180,7 @@ class TestChartGeneration:
         with pytest.raises(ValueError, match="Invalid output_path"):
             agent.generate_chart(valid_chart_spec, None)
 
-    @patch("llm_client.call_llm")
+    @patch("scripts.llm_client.call_llm")
     @patch("subprocess.run")
     def test_generate_chart_success(
         self,
@@ -204,7 +204,7 @@ class TestChartGeneration:
         mock_subprocess.assert_called_once()
         mock_metrics_collector.record_generation.assert_called_once()
 
-    @patch("llm_client.call_llm")
+    @patch("scripts.llm_client.call_llm")
     @patch("subprocess.run")
     def test_generate_chart_subprocess_failure(
         self,
@@ -226,7 +226,7 @@ class TestChartGeneration:
         assert result is None
         mock_metrics_collector.record_generation.assert_called()
 
-    @patch("llm_client.call_llm")
+    @patch("scripts.llm_client.call_llm")
     def test_generate_chart_llm_exception(
         self,
         mock_call_llm,
@@ -248,7 +248,7 @@ class TestChartGeneration:
 class TestMatplotlibCodeGeneration:
     """Test matplotlib code generation."""
 
-    @patch("llm_client.call_llm")
+    @patch("scripts.llm_client.call_llm")
     def test_generate_matplotlib_code(
         self,
         mock_call_llm,
@@ -265,7 +265,7 @@ class TestMatplotlibCodeGeneration:
         assert "import matplotlib.pyplot" in code
         mock_call_llm.assert_called_once()
 
-    @patch("llm_client.call_llm")
+    @patch("scripts.llm_client.call_llm")
     def test_extract_code_from_python_block(
         self,
         mock_call_llm,
@@ -280,7 +280,7 @@ class TestMatplotlibCodeGeneration:
 
         assert code.strip() == "print('test')"
 
-    @patch("llm_client.call_llm")
+    @patch("scripts.llm_client.call_llm")
     def test_extract_code_from_generic_block(
         self,
         mock_call_llm,
@@ -372,7 +372,7 @@ class TestMatplotlibCodeExecution:
 class TestBackwardCompatibility:
     """Test backward compatibility with economist_agent.py."""
 
-    @patch("llm_client.call_llm")
+    @patch("scripts.llm_client.call_llm")
     @patch("subprocess.run")
     def test_run_graphics_agent_function(
         self,
@@ -510,7 +510,7 @@ class TestTaskTemplates:
 class TestMetricsIntegration:
     """Test metrics collection integration."""
 
-    @patch("llm_client.call_llm")
+    @patch("scripts.llm_client.call_llm")
     @patch("subprocess.run")
     def test_metrics_start_chart_called(
         self,
@@ -534,7 +534,7 @@ class TestMetricsIntegration:
             valid_chart_spec,
         )
 
-    @patch("llm_client.call_llm")
+    @patch("scripts.llm_client.call_llm")
     @patch("subprocess.run")
     def test_metrics_record_generation_success(
         self,
@@ -559,7 +559,7 @@ class TestMetricsIntegration:
         # Check kwargs instead of positional args
         assert calls[0].kwargs["success"] is True
 
-    @patch("llm_client.call_llm")
+    @patch("scripts.llm_client.call_llm")
     def test_metrics_record_generation_failure(
         self,
         mock_call_llm,
@@ -589,7 +589,7 @@ class TestMetricsIntegration:
 class TestIntegration:
     """Integration tests."""
 
-    @patch("llm_client.call_llm")
+    @patch("scripts.llm_client.call_llm")
     @patch("subprocess.run")
     def test_full_chart_generation_flow(
         self,

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -14,7 +14,7 @@ import pytest
 # Import functions from llm_client
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from llm_client import (
+from scripts.llm_client import (
     LLMClient,
     call_llm,
     create_llm_client,
@@ -276,11 +276,11 @@ def test_main_execution_success(clean_env, mock_openai_client, capsys):
 
     with mock_openai_import(mock_openai_client):
         # Import and execute the main block
-        import llm_client
+        from scripts import llm_client
 
         # Simulate running as main
         with (
-            patch("llm_client.__name__", "__main__"),
+            patch("scripts.llm_client.__name__", "__main__"),
             contextlib.suppress(SystemExit),
         ):
             # This would normally be executed when script is run directly
@@ -319,10 +319,10 @@ def test_main_execution_failure(clean_env, capsys):
     # No API key set, should fail
 
     # Import the module
-    import llm_client
+    from scripts import llm_client
 
     with (
-        patch("llm_client.__name__", "__main__"),
+        patch("scripts.llm_client.__name__", "__main__"),
         contextlib.suppress(SystemExit),
     ):
         exec(

--- a/tests/test_orchestrator_agent.py
+++ b/tests/test_orchestrator_agent.py
@@ -14,7 +14,7 @@ import pytest
 # Ensure scripts/ is importable.
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-import orchestrator_agent as oa
+from scripts import orchestrator_agent as oa
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers to build lightweight mock PyGithub objects

--- a/tests/test_po_agent.py
+++ b/tests/test_po_agent.py
@@ -16,7 +16,7 @@ import pytest
 # Add scripts directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from po_agent import ProductOwnerAgent
+from scripts.po_agent import ProductOwnerAgent
 
 
 @pytest.fixture
@@ -45,7 +45,7 @@ def temp_backlog():
 @pytest.fixture
 def mock_llm_client():
     """Mock LLM client for deterministic testing"""
-    with patch("po_agent.create_llm_client") as mock_create:
+    with patch("scripts.po_agent.create_llm_client") as mock_create:
         mock_client = MagicMock()
         mock_create.return_value = mock_client
         yield mock_client
@@ -84,7 +84,7 @@ class TestProductOwnerAgent:
             "implementation_notes": "Integrate with existing test infrastructure",
         }
 
-        with patch("po_agent.call_llm") as mock_call:
+        with patch("scripts.po_agent.call_llm") as mock_call:
             mock_call.return_value = json.dumps(mock_response)
             agent = ProductOwnerAgent(backlog_file=temp_backlog)
             story = agent.parse_user_request("We need automated test coverage analysis")
@@ -118,7 +118,7 @@ class TestProductOwnerAgent:
             "implementation_notes": "Needs clarification before implementation",
         }
 
-        with patch("po_agent.call_llm") as mock_call:
+        with patch("scripts.po_agent.call_llm") as mock_call:
             mock_call.return_value = json.dumps(mock_response)
             agent = ProductOwnerAgent(backlog_file=temp_backlog)
             story = agent.parse_user_request("Improve chart quality")
@@ -135,7 +135,7 @@ class TestProductOwnerAgent:
             "[ ] Quality: Generation completes in <2 minutes",
         ]
 
-        with patch("po_agent.call_llm") as mock_call:
+        with patch("scripts.po_agent.call_llm") as mock_call:
             mock_call.return_value = json.dumps(mock_response)
             agent = ProductOwnerAgent(backlog_file=temp_backlog)
             criteria = agent.generate_acceptance_criteria(

--- a/tests/test_pre_commit_arch_check.py
+++ b/tests/test_pre_commit_arch_check.py
@@ -16,7 +16,7 @@ import pytest
 SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from pre_commit_arch_check import (  # noqa: E402
+from scripts.pre_commit_arch_check import (  # noqa: E402
     LLM_IMPORT_EXCEPTIONS,
     CheckResult,
     Violation,

--- a/tests/test_references_feature.py
+++ b/tests/test_references_feature.py
@@ -21,8 +21,8 @@ _scripts_dir = Path(__file__).parent.parent / "scripts"
 if str(_scripts_dir) not in sys.path:
     sys.path.insert(0, str(_scripts_dir))
 
-from publication_validator import PublicationValidator  # noqa: E402
-from writer_agent import WriterAgent  # noqa: E402
+from agents.writer_agent import WriterAgent  # noqa: E402
+from scripts.publication_validator import PublicationValidator  # noqa: E402
 
 
 class TestWriterAgentReferences:
@@ -371,7 +371,7 @@ Content.
 class TestReferencesIntegration:
     """Integration tests for references feature"""
 
-    @patch("writer_agent.call_llm")
+    @patch("agents.writer_agent.call_llm")
     def test_writer_agent_includes_references_guidance(self, mock_llm):
         """Should include references guidance in system prompt"""
         mock_llm.return_value = """---

--- a/tests/test_research_agent.py
+++ b/tests/test_research_agent.py
@@ -420,7 +420,7 @@ class TestIntegrationScenarios:
 
     @patch("agents.research_agent.call_llm")
     @patch("agents.research_agent.review_agent_output")
-    @patch("citation_verifier.verify_citations", side_effect=lambda x: x)
+    @patch("scripts.citation_verifier.verify_citations", side_effect=lambda x: x)
     def test_full_research_pipeline(
         self,
         mock_verify,

--- a/tests/test_sm_agent.py
+++ b/tests/test_sm_agent.py
@@ -18,7 +18,7 @@ import pytest
 # Add scripts directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from sm_agent import (
+from scripts.sm_agent import (
     AgentStatusMonitor,
     EscalationManager,
     QualityGateValidator,
@@ -341,9 +341,9 @@ class TestScrumMasterAgent:
             "backlog_file": str(backlog_file),
         }
 
-    @patch("sm_agent.TaskQueueManager")
-    @patch("sm_agent.AgentStatusMonitor")
-    @patch("sm_agent.EscalationManager")
+    @patch("scripts.sm_agent.TaskQueueManager")
+    @patch("scripts.sm_agent.AgentStatusMonitor")
+    @patch("scripts.sm_agent.EscalationManager")
     def test_agent_initialization(self, mock_esc, mock_monitor, mock_queue):
         """Test SM Agent initialization"""
         agent = ScrumMasterAgent()

--- a/tests/test_token_usage.py
+++ b/tests/test_token_usage.py
@@ -10,7 +10,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from token_usage import (
+from scripts.token_usage import (
     MODEL_COSTS,
     estimate_cost,
     log_token_usage,
@@ -138,7 +138,7 @@ class TestLogTokenUsage:
 
         log_file = tmp_path / "usage.jsonl"
         with (
-            patch("token_usage.Path.open", side_effect=OSError("disk full")),
+            patch("scripts.token_usage.Path.open", side_effect=OSError("disk full")),
             caplog.at_level(logging.WARNING, logger="token_usage"),
         ):
             # Should not raise
@@ -371,7 +371,7 @@ class TestLLMClientLogsUsage:
     def test_call_openai_logs_usage(self, tmp_path, capsys):
         from unittest.mock import Mock, patch
 
-        import llm_client
+        from scripts import llm_client
 
         log_file = tmp_path / "usage.jsonl"
 
@@ -385,7 +385,7 @@ class TestLLMClientLogsUsage:
         mock_response.usage = mock_usage
         mock_client.chat.completions.create.return_value = mock_response
 
-        with patch("token_usage._DEFAULT_LOG_FILE", log_file):
+        with patch("scripts.token_usage._DEFAULT_LOG_FILE", log_file):
             result = llm_client._call_openai(
                 mock_client,
                 "gpt-4o",

--- a/tests/test_topic_scout.py
+++ b/tests/test_topic_scout.py
@@ -13,7 +13,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
-from topic_scout import (
+from scripts.topic_scout import (
     SCOUT_AGENT_PROMPT,
     THEME_KEYWORDS,
     TREND_RESEARCH_PROMPT,
@@ -128,7 +128,7 @@ def mock_dedup_passthrough():
     in tests that don't care about dedup logic — it satisfies the
     fail-closed check added for issue #237 without rejecting anything.
     """
-    with patch("topic_scout.TopicDeduplicator") as MockDedup:
+    with patch("scripts.topic_scout.TopicDeduplicator") as MockDedup:
         instance = MockDedup.return_value
         instance.collection = Mock()
         instance.collection.count = Mock(return_value=19)
@@ -188,10 +188,10 @@ def test_scout_topics_success(
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+        patch("scripts.topic_scout.call_llm", side_effect=call_llm_side_effect),
     ):
         topics = scout_topics(mock_client)
 
@@ -230,10 +230,10 @@ def test_scout_topics_with_focus_area(
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ) as mock_ground,
-        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+        patch("scripts.topic_scout.call_llm", side_effect=call_llm_side_effect),
     ):
         topics = scout_topics(mock_client, focus_area)
 
@@ -256,10 +256,10 @@ def test_scout_topics_empty_results(mock_llm_client, mock_dedup_passthrough):
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=["invalid json response"]),
+        patch("scripts.topic_scout.call_llm", side_effect=["invalid json response"]),
     ):
         topics = scout_topics(mock_client)
 
@@ -284,10 +284,10 @@ def test_scout_topics_json_parse_error(mock_llm_client, mock_dedup_passthrough, 
     # Return valid trends but malformed JSON for topics
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm") as mock_call,
+        patch("scripts.topic_scout.call_llm") as mock_call,
     ):
         mock_call.side_effect = ['[{"bad": json}']
         topics = scout_topics(mock_client)
@@ -310,10 +310,10 @@ def test_scout_topics_no_json_array(mock_llm_client, mock_dedup_passthrough, cap
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=["No array here"]),
+        patch("scripts.topic_scout.call_llm", side_effect=["No array here"]),
     ):
         topics = scout_topics(mock_client)
 
@@ -333,10 +333,10 @@ def test_scout_topics_api_exception(mock_llm_client):
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=Exception("API Error")),
+        patch("scripts.topic_scout.call_llm", side_effect=Exception("API Error")),
         pytest.raises(Exception, match="API Error"),
     ):
         scout_topics(mock_client)
@@ -362,10 +362,10 @@ def test_scout_topics_partial_json(mock_llm_client, mock_dedup_passthrough):
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=[json.dumps(partial_topics)]),
+        patch("scripts.topic_scout.call_llm", side_effect=[json.dumps(partial_topics)]),
     ):
         topics = scout_topics(mock_client)
 
@@ -389,7 +389,7 @@ def test_scout_topics_runs_filter_topics(mock_llm_client, mock_dedup_passthrough
     """scout_topics() must call TopicDeduplicator.filter_topics() on every run."""
     mock_client, call_llm_side_effect = mock_llm_client
 
-    with patch("topic_scout.call_llm", side_effect=call_llm_side_effect):
+    with patch("scripts.topic_scout.call_llm", side_effect=call_llm_side_effect):
         scout_topics(mock_client)
 
     assert mock_dedup_passthrough.filter_topics.called, (
@@ -404,8 +404,8 @@ def test_scout_topics_drops_rejected_duplicates(mock_llm_client, sample_topics):
 
     # Mock dedup to reject the first topic and keep the second.
     with (
-        patch("topic_scout.TopicDeduplicator") as MockDedup,
-        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+        patch("scripts.topic_scout.TopicDeduplicator") as MockDedup,
+        patch("scripts.topic_scout.call_llm", side_effect=call_llm_side_effect),
     ):
         instance = MockDedup.return_value
         instance.collection = Mock()
@@ -428,8 +428,8 @@ def test_scout_topics_fail_closed_when_collection_missing(mock_llm_client):
     mock_client, call_llm_side_effect = mock_llm_client
 
     with (
-        patch("topic_scout.TopicDeduplicator") as MockDedup,
-        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+        patch("scripts.topic_scout.TopicDeduplicator") as MockDedup,
+        patch("scripts.topic_scout.call_llm", side_effect=call_llm_side_effect),
     ):
         instance = MockDedup.return_value
         instance.collection = None  # ChromaDB unavailable
@@ -442,8 +442,8 @@ def test_scout_topics_fail_closed_when_collection_empty(mock_llm_client):
     mock_client, call_llm_side_effect = mock_llm_client
 
     with (
-        patch("topic_scout.TopicDeduplicator") as MockDedup,
-        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+        patch("scripts.topic_scout.TopicDeduplicator") as MockDedup,
+        patch("scripts.topic_scout.call_llm", side_effect=call_llm_side_effect),
     ):
         instance = MockDedup.return_value
         instance.collection = Mock()
@@ -457,8 +457,8 @@ def test_scout_topics_allow_empty_archive_override(mock_llm_client, sample_topic
     mock_client, call_llm_side_effect = mock_llm_client
 
     with (
-        patch("topic_scout.TopicDeduplicator") as MockDedup,
-        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+        patch("scripts.topic_scout.TopicDeduplicator") as MockDedup,
+        patch("scripts.topic_scout.call_llm", side_effect=call_llm_side_effect),
     ):
         instance = MockDedup.return_value
         instance.collection = Mock()
@@ -789,7 +789,7 @@ def test_create_client_returns_client():
     - Function returns non-None value
     - Return type is LLMClient or compatible
     """
-    with patch("topic_scout.create_llm_client") as mock_create:
+    with patch("scripts.topic_scout.create_llm_client") as mock_create:
         mock_create.return_value = Mock()
 
         client = create_client()
@@ -806,7 +806,9 @@ def test_create_client_propagates_exceptions():
     - No silent failures
     """
     with (
-        patch("topic_scout.create_llm_client", side_effect=Exception("Auth error")),
+        patch(
+            "scripts.topic_scout.create_llm_client", side_effect=Exception("Auth error")
+        ),
         pytest.raises(Exception, match="Auth error"),
     ):
         create_client()
@@ -839,14 +841,14 @@ def test_main_success_flow(
     monkeypatch.chdir(tmp_path)
 
     with (
-        patch("topic_scout.create_client", return_value=mock_client),
+        patch("scripts.topic_scout.create_client", return_value=mock_client),
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+        patch("scripts.topic_scout.call_llm", side_effect=call_llm_side_effect),
     ):
-        from topic_scout import main
+        from scripts.topic_scout import main
 
         main()
 
@@ -877,14 +879,14 @@ def test_main_with_focus_area(
     monkeypatch.chdir(tmp_path)
 
     with (
-        patch("topic_scout.create_client", return_value=mock_client),
+        patch("scripts.topic_scout.create_client", return_value=mock_client),
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ) as mock_ground,
-        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+        patch("scripts.topic_scout.call_llm", side_effect=call_llm_side_effect),
     ):
-        from topic_scout import main
+        from scripts.topic_scout import main
 
         main()
 
@@ -912,14 +914,14 @@ def test_main_github_actions_output(
     monkeypatch.chdir(tmp_path)
 
     with (
-        patch("topic_scout.create_client", return_value=mock_client),
+        patch("scripts.topic_scout.create_client", return_value=mock_client),
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+        patch("scripts.topic_scout.call_llm", side_effect=call_llm_side_effect),
     ):
-        from topic_scout import main
+        from scripts.topic_scout import main
 
         main()
 
@@ -945,10 +947,10 @@ def test_main_no_topics(mock_llm_client, tmp_path, monkeypatch, capsys):
     monkeypatch.chdir(tmp_path)
 
     with (
-        patch("topic_scout.create_client", return_value=mock_client),
-        patch("topic_scout.scout_topics", return_value=[]),
+        patch("scripts.topic_scout.create_client", return_value=mock_client),
+        patch("scripts.topic_scout.scout_topics", return_value=[]),
     ):
-        from topic_scout import main
+        from scripts.topic_scout import main
 
         main()
 
@@ -1114,10 +1116,10 @@ def test_scout_topics_single_topic(mock_llm_client, mock_dedup_passthrough):
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=[json.dumps(single_topic)]),
+        patch("scripts.topic_scout.call_llm", side_effect=[json.dumps(single_topic)]),
     ):
         topics = scout_topics(mock_client)
 
@@ -1141,10 +1143,10 @@ def test_scout_topics_unsorted_input(
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=[json.dumps(unsorted)]),
+        patch("scripts.topic_scout.call_llm", side_effect=[json.dumps(unsorted)]),
     ):
         topics = scout_topics(mock_client)
 
@@ -1204,10 +1206,12 @@ def test_scout_topics_network_timeout(mock_llm_client):
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=TimeoutError("Request timeout")),
+        patch(
+            "scripts.topic_scout.call_llm", side_effect=TimeoutError("Request timeout")
+        ),
         pytest.raises(TimeoutError),
     ):
         scout_topics(mock_client)
@@ -1239,16 +1243,18 @@ def test_performance_context_injected_into_scout_prompt(
         "| 0.500 | 1000 | Fake Top Article |\n"
     )
     monkeypatch.setattr(
-        "topic_scout.get_performance_context",
+        "scripts.topic_scout.get_performance_context",
         lambda **kwargs: fake_context,
     )
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=call_llm_side_effect) as mock_call,
+        patch(
+            "scripts.topic_scout.call_llm", side_effect=call_llm_side_effect
+        ) as mock_call,
     ):
         scout_topics(mock_client)
 
@@ -1278,16 +1284,16 @@ def test_performance_context_fallback_when_db_missing(
         "to populate `data/performance.db`._\n"
     )
     monkeypatch.setattr(
-        "topic_scout.get_performance_context",
+        "scripts.topic_scout.get_performance_context",
         lambda **kwargs: fallback,
     )
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+        patch("scripts.topic_scout.call_llm", side_effect=call_llm_side_effect),
     ):
         topics = scout_topics(mock_client)
 
@@ -1308,16 +1314,18 @@ def test_scout_prompt_explicitly_references_performance_data(
     """
     mock_client, call_llm_side_effect = mock_llm_client
     monkeypatch.setattr(
-        "topic_scout.get_performance_context",
+        "scripts.topic_scout.get_performance_context",
         lambda **kwargs: "## Performance Context\n\nfake data\n",
     )
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=call_llm_side_effect) as mock_call,
+        patch(
+            "scripts.topic_scout.call_llm", side_effect=call_llm_side_effect
+        ) as mock_call,
     ):
         scout_topics(mock_client)
 
@@ -1340,14 +1348,14 @@ def test_get_performance_context_called_once_per_scout_run(
         call_count["n"] += 1
         return "## Performance Context\n\nfake\n"
 
-    monkeypatch.setattr("topic_scout.get_performance_context", counting_fake)
+    monkeypatch.setattr("scripts.topic_scout.get_performance_context", counting_fake)
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
-        patch("topic_scout.call_llm", side_effect=call_llm_side_effect),
+        patch("scripts.topic_scout.call_llm", side_effect=call_llm_side_effect),
     ):
         scout_topics(mock_client)
 
@@ -1612,11 +1620,11 @@ def test_scout_topics_diversity_check_triggers_regeneration(
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
         patch(
-            "topic_scout.call_llm",
+            "scripts.topic_scout.call_llm",
             side_effect=lambda *a, **kw: next(call_responses),
         ) as mock_call,
     ):
@@ -1645,11 +1653,11 @@ def test_scout_topics_diversity_check_skipped_for_two_topics(mock_dedup_passthro
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
         patch(
-            "topic_scout.call_llm",
+            "scripts.topic_scout.call_llm",
             side_effect=[json.dumps(two_same_theme)],
         ) as mock_call,
     ):
@@ -1673,11 +1681,11 @@ def test_scout_topics_diversity_passes_no_extra_call(mock_dedup_passthrough):
 
     with (
         patch(
-            "topic_scout.build_grounded_trend_context",
+            "scripts.topic_scout.build_grounded_trend_context",
             return_value="grounded trends",
         ),
         patch(
-            "topic_scout.call_llm",
+            "scripts.topic_scout.call_llm",
             side_effect=[json.dumps(diverse)],
         ) as mock_call,
     ):

--- a/tests/test_topic_scout_reproducibility.py
+++ b/tests/test_topic_scout_reproducibility.py
@@ -15,7 +15,7 @@ import pytest
 # Make scripts/ importable.
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from topic_scout_reproducibility import (
+from scripts.topic_scout_reproducibility import (
     _compute_tf,
     _cosine_similarity,
     _extract_top_performer_keywords,
@@ -550,8 +550,10 @@ def test_run_reproducibility_check_writes_report(tmp_path: Path) -> None:
     mock_client.model = "gpt-4o-mock"
 
     with (
-        patch("topic_scout_reproducibility.get_performance_context") as mock_ctx,
-        patch("topic_scout_reproducibility.scout_topics") as mock_scout,
+        patch(
+            "scripts.topic_scout_reproducibility.get_performance_context"
+        ) as mock_ctx,
+        patch("scripts.topic_scout_reproducibility.scout_topics") as mock_scout,
     ):
         mock_ctx.return_value = "## Performance Context\n\nSome data\n"
         mock_scout.return_value = topics_payload
@@ -579,8 +581,10 @@ def test_run_reproducibility_check_counts_failed_run(tmp_path: Path) -> None:
     mock_client.model = "gpt-4o"
 
     with (
-        patch("topic_scout_reproducibility.get_performance_context") as mock_ctx,
-        patch("topic_scout_reproducibility.scout_topics") as mock_scout,
+        patch(
+            "scripts.topic_scout_reproducibility.get_performance_context"
+        ) as mock_ctx,
+        patch("scripts.topic_scout_reproducibility.scout_topics") as mock_scout,
     ):
         mock_ctx.return_value = "## Performance Context\n\nSome data\n"
         # First call succeeds; second returns empty (simulates JSON failure).
@@ -605,8 +609,10 @@ def test_run_reproducibility_check_handles_exception(tmp_path: Path) -> None:
     mock_client.model = "gpt-4o"
 
     with (
-        patch("topic_scout_reproducibility.get_performance_context") as mock_ctx,
-        patch("topic_scout_reproducibility.scout_topics") as mock_scout,
+        patch(
+            "scripts.topic_scout_reproducibility.get_performance_context"
+        ) as mock_ctx,
+        patch("scripts.topic_scout_reproducibility.scout_topics") as mock_scout,
     ):
         mock_ctx.return_value = "## Performance Context\n\nSome data\n"
         mock_scout.side_effect = RuntimeError("API quota exceeded")
@@ -628,8 +634,10 @@ def test_run_reproducibility_check_creates_output_dir(tmp_path: Path) -> None:
     nested = tmp_path / "deep" / "nested" / "output"
 
     with (
-        patch("topic_scout_reproducibility.get_performance_context") as mock_ctx,
-        patch("topic_scout_reproducibility.scout_topics") as mock_scout,
+        patch(
+            "scripts.topic_scout_reproducibility.get_performance_context"
+        ) as mock_ctx,
+        patch("scripts.topic_scout_reproducibility.scout_topics") as mock_scout,
     ):
         mock_ctx.return_value = "## Performance Context\n\nSome data\n"
         mock_scout.return_value = [_make_topic(i) for i in range(3)]


### PR DESCRIPTION
## Summary

Closes #395. The /ship audit of PR #394 surfaced that the prior bare-name
import fix had only addressed 4 of ~52 vulnerable sites — the same
sys.path-based module-spoofing surface (CVE-377-adjacent) still extended
across 31 production callsites + 17 test imports + 6 `import X` form
bypasses + an indented function-level import inside scripts/llm_client.py.

Shipped as three reviewable slices:

- **Slice 1** (48a3431) — 14 production files in agents/, scripts/, src/
  migrated from `from llm_client import call_llm` to
  `from scripts.llm_client import call_llm`. Patch targets in 3 test files
  updated in the same commit to keep the build green.
- **Slice 2** (429228a) — 16 test files migrated (17 `from X import ...`
  sites + 6 `import X` -> `from scripts import X` bypasses + ~120 patch()
  target updates). Also caught a production bug: indented function-level
  `from token_usage import log_token_usage` inside
  `scripts/llm_client._call_anthropic/_call_openai` — exactly the failure
  mode bare-name imports invite (two copies in sys.modules, test mocks
  missed the real one).
- **Slice 3** (8687ef2) — Replaces the hand-typed grep guard with
  `scripts/check_bare_name_imports.py`: an AST walker that dynamically
  enumerates all 49 top-level modules under scripts/ and detects both
  `ast.ImportFrom` (level 0) and `ast.Import` forms. AST-based detection
  inherently ignores docstring `Usage:` examples. Running it caught 6
  more sites Slices 1/2 missed (publication_validator,
  test_audit_composite_scores, test_architecture_audit,
  test_economist_agent + 12 patch targets, test_generate_chart,
  test_orchestrator_agent) — fixed in the same commit so the guard
  exits 0 on a fresh checkout.

## Why this matters

`from llm_client import call_llm` resolves through sys.path. If any module
named `llm_client` sits anywhere on sys.path — a stray script, a
test-only module, a pip-installed package — it silently takes precedence
over scripts/llm_client. `llm_client` brokers reads of both
ANTHROPIC_API_KEY and OPENAI_API_KEY, so a successful spoof would
exfiltrate both. The /ship security-auditor escalated the original
finding from MEDIUM (4 sites) to HIGH (50+ sites + the credential
blast radius).

## Test plan

- [x] Full pytest suite: 2107 passed / 84 skipped (verified after each slice)
- [x] ruff check + ruff format clean on every file touched in this PR
- [x] AST guard reports clean across all 49 scripts/ modules
- [x] No new ruff errors introduced beyond the 4 pre-existing on main
      (scripts/deploy_to_blog.py UP045 x3, tests/test_stage3_style_memory_wiring.py I001)
- [ ] CI green on this branch

## Out of scope (filed as follow-up?)

- `tests/test_improvements.py` imports `validate_schemas` from `schemas/`
  via the same bare-name pattern, but `schemas/` is a separate directory
  outside the `scripts/` blast radius. Per Rule 0.5 (Scope Discipline),
  not touched here.
- The 4 pre-existing ruff errors on main (UP045 + I001) — orthogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)