### PR TITLE
test: close 4 coverage gaps from /ship audit (#392)

### DIFF
--- a/tests/test_agent_reviewer.py
+++ b/tests/test_agent_reviewer.py
@@ -466,6 +466,21 @@ def test_dispatch_unknown_agent_returns_false_with_explanatory_issue(
     assert "AUTOMATED REVIEW" not in capsys.readouterr().out
 
 
+def test_dispatch_research_agent_invokes_research_review(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    research_data = {
+        "headline_stat": {"value": "80%", "source": "Gartner", "verified": True},
+        "data_points": [
+            {"stat": "50%", "source": "Forrester", "verified": True},
+        ],
+    }
+    is_valid, issues = review_agent_output("research_agent", research_data)
+    assert is_valid is True
+    assert issues == []
+    assert "research_agent" in capsys.readouterr().out
+
+
 def test_dispatch_writer_agent_passes_chart_filename_context(
     capsys: pytest.CaptureFixture[str],
 ) -> None:

--- a/tests/test_chart_metrics.py
+++ b/tests/test_chart_metrics.py
@@ -111,23 +111,18 @@ class TestInitialization:
         assert collector.metrics["summary"]["total_charts_generated"] == 0
 
     def test_default_metrics_file_path_resolves_to_repo_skills_dir(self) -> None:
-        # Avoid touching the real file by inspecting the resolved path only
-        collector = ChartMetricsCollector.__new__(ChartMetricsCollector)
-        # Reproduce the path-resolution code from __init__ without executing
-        # the _load_metrics side effect by calling __init__ with a tmp path.
-        # Re-instantiating with default would write to the repo; instead we
-        # assert the default path computation is consistent with the module
-        # layout (three levels up from chart_metrics.py).
+        # Actually invoke ChartMetricsCollector() with no args and assert
+        # the resolved path matches the documented repo layout: three levels
+        # up from chart_metrics.py + skills/chart_metrics.json. __init__
+        # only reads the file (no write on construction), so this is safe.
+        collector = ChartMetricsCollector()
+
         module_file = Path(chart_metrics.__file__).resolve()
         expected = module_file.parent.parent.parent / "skills" / "chart_metrics.json"
 
-        # Sanity: parents chain works as documented
-        assert expected.name == "chart_metrics.json"
-        assert expected.parent.name == "skills"
-
-        # And the collector class is still constructable without args once
-        # an isolated path is provided.
-        del collector
+        assert collector.metrics_file == expected
+        assert collector.metrics_file.name == "chart_metrics.json"
+        assert collector.metrics_file.parent.name == "skills"
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/tests/test_empty_research_guard.py
+++ b/tests/test_empty_research_guard.py
@@ -16,9 +16,27 @@ Verifies that:
 from __future__ import annotations
 
 import asyncio
+import inspect
+from typing import Any
 from unittest.mock import patch
 
 import pytest
+
+
+def _close_coros_then(action):
+    """Build a stand-in for ``asyncio.run`` that closes any coroutine args
+    before invoking *action*. Without the close, the mock receives an
+    unawaited coroutine and Python emits ``RuntimeWarning: coroutine
+    ... was never awaited``, polluting test output."""
+
+    def _stub(*args: Any, **kwargs: Any) -> Any:
+        for a in args:
+            if inspect.iscoroutine(a):
+                a.close()
+        return action(*args, **kwargs)
+
+    return _stub
+
 
 # ── Unit: _shared.py ─────────────────────────────────────────────────────────
 
@@ -182,9 +200,12 @@ class TestEmptyResearchFlowRouting:
 
         flow = EconomistContentFlow()
 
+        def _raise(*a, **k):
+            raise EmptyResearchBriefError("No results")
+
         with patch(
             "src.economist_agents.flow.asyncio.run",
-            side_effect=EmptyResearchBriefError("No results"),
+            new=_close_coros_then(_raise),
         ):
             result = flow.generate_content({"topic": "AI Testing"})
 
@@ -198,9 +219,12 @@ class TestEmptyResearchFlowRouting:
 
         flow = EconomistContentFlow()
 
+        def _raise(*a, **k):
+            raise EmptyResearchBriefError("No results")
+
         with patch(
             "src.economist_agents.flow.asyncio.run",
-            side_effect=EmptyResearchBriefError("No results"),
+            new=_close_coros_then(_raise),
         ):
             draft = flow.generate_content({"topic": "AI Testing"})
 
@@ -217,9 +241,12 @@ class TestEmptyResearchFlowRouting:
         flow.state["revision_feedback"] = ["fix it"]
         flow.state["article_draft"] = {"featured_image": ""}
 
+        def _raise(*a, **k):
+            raise EmptyResearchBriefError("No results")
+
         with patch(
             "src.economist_agents.flow.asyncio.run",
-            side_effect=EmptyResearchBriefError("No results"),
+            new=_close_coros_then(_raise),
         ):
             result = flow.request_revision()
 
@@ -243,12 +270,14 @@ class TestPipelineCliErrorSurfacing:
         from src.agent_sdk._shared import SearchProvidersFailedError
 
         monkeypatch.setattr("sys.argv", ["pipeline.py", "AI Testing"])
+
+        def _raise_failed(*a, **k):
+            raise SearchProvidersFailedError("simulated outage")
+
         monkeypatch.setattr(
             pl.asyncio,
             "run",
-            lambda *a, **k: (_ for _ in ()).throw(
-                SearchProvidersFailedError("simulated outage")
-            ),
+            _close_coros_then(_raise_failed),
         )
 
         with pytest.raises(SystemExit) as exc_info:
@@ -269,12 +298,14 @@ class TestPipelineCliErrorSurfacing:
         from src.agent_sdk._shared import SearchProvidersEmptyError
 
         monkeypatch.setattr("sys.argv", ["pipeline.py", "AI Testing"])
+
+        def _raise_empty(*a, **k):
+            raise SearchProvidersEmptyError("zero results")
+
         monkeypatch.setattr(
             pl.asyncio,
             "run",
-            lambda *a, **k: (_ for _ in ()).throw(
-                SearchProvidersEmptyError("zero results")
-            ),
+            _close_coros_then(_raise_empty),
         )
 
         with pytest.raises(SystemExit) as exc_info:
@@ -296,11 +327,15 @@ class TestPipelineCliErrorSurfacing:
         monkeypatch.setattr(
             "sys.argv", ["pipeline.py", "--research-only", "AI Testing"]
         )
+
         # asyncio.run must NOT be called when --research-only is set
+        def _should_not_run(*a, **k):
+            pytest.fail("asyncio.run called under --research-only")
+
         monkeypatch.setattr(
             pl.asyncio,
             "run",
-            lambda *a, **k: pytest.fail("asyncio.run called under --research-only"),
+            _close_coros_then(_should_not_run),
         )
         monkeypatch.setattr(
             "src.agent_sdk._shared.build_research_brief",
@@ -336,3 +371,33 @@ class TestPipelineCliErrorSurfacing:
 
         assert exc_info.value.code == 2
         assert "providers failed" in capsys.readouterr().err
+
+    def test_research_only_with_providers_empty_exits_3(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        from src.agent_sdk import pipeline as pl
+        from src.agent_sdk._shared import SearchProvidersEmptyError
+
+        monkeypatch.setattr(
+            "sys.argv", ["pipeline.py", "--research-only", "AI Testing"]
+        )
+        monkeypatch.setattr(
+            "src.agent_sdk._shared.build_research_brief",
+            lambda topic: (_ for _ in ()).throw(
+                SearchProvidersEmptyError("zero results")
+            ),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            pl.main()
+
+        assert exc_info.value.code == 3
+        err = capsys.readouterr().err
+        assert "zero sources" in err
+        # --research-only's printer uses a shorter "Try broadening or
+        # rephrasing" (no "it") vs the full-pipeline path's
+        # "broadening it or rephrasing as a noun-phrase."
+        assert "broadening or rephrasing" in err
+        assert "Traceback" not in err


### PR DESCRIPTION
## Summary

Closes #392. Bundles the four small test gaps the /ship audit on 2026-05-17
surfaced in the session that added 334 new src/quality/* tests + the
empty-research gate.

1. **CLI matrix completion** — added \`test_research_only_with_providers_empty_exits_3\`,
   closing the fourth corner of the (failed/empty) × (full-pipeline/research-only)
   matrix in \`tests/test_empty_research_guard.py::TestPipelineCliErrorSurfacing\`.
2. **\`dispatch_agent_review\` research_agent branch** — added the missing
   dispatch test in \`tests/test_agent_reviewer.py\`.
3. **\`chart_metrics\` default-path rewrite** — the prior test bypassed
   \`__init__\` via \`__new__\` and asserted on a path it built itself, so it
   never exercised the default-path resolution. Replaced with a real
   \`ChartMetricsCollector()\` no-arg construction.
4. **Coroutine-leak fix** — six sites where \`asyncio.run\` was patched to a
   lambda that raised without closing the coroutine arg, producing
   \`RuntimeWarning: coroutine 'run_pipeline' was never awaited\` noise. Added
   a \`_close_coros_then(action)\` helper and converted all six sites.

## Test plan

- [x] \`pytest tests/test_empty_research_guard.py -W error::RuntimeWarning\` passes (15/15)
- [x] Full suite: 2109 passed / 84 skipped (was 2107; +2 new tests)
- [x] ruff check + format clean on touched files
- [x] AST bare-name guard still green
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)