### PR TITLE
ci: add per-module coverage gate for src/quality/* (#393)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,15 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
+      - name: Enforce src/quality/ per-module coverage gate (#393)
+        # The aggregate --cov-fail-under=70 above does not defend the
+        # per-module gains in src/quality/ (currently ~98%). Without this
+        # secondary gate, deleting any single src/quality test file
+        # would silently drop that module from ~100% to 0% while the
+        # aggregate barely moves. 90% leaves ~8 points of breathing
+        # room above current; any larger regression trips CI.
+        run: coverage report --include='src/quality/*' --fail-under=90
+
       - name: Token usage summary
         if: always()
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,9 @@ def new_function():
 
 - ✅ **Type hints on all functions** (`mypy scripts/` passes)
 - ✅ **Docstrings for all public functions** (Google style)
-- ✅ **>80% test coverage** (100% for refactored code)
+- ✅ **>70% aggregate test coverage** (CI gate: `--cov-fail-under=70` across `src/` + `scripts/`)
+- ✅ **>90% coverage on `src/quality/*`** (CI gate: per-module floor; see `.github/workflows/ci.yml` step "Enforce src/quality/ per-module coverage gate (#393)")
+- ✅ **>80% target on new code** (100% for refactored code)
 - ✅ **Zero linting violations** (`ruff check .` passes)
 - ✅ **Proper error handling** with specific exceptions
 - ✅ **Use `orjson` instead of `json`**


### PR DESCRIPTION
## Summary

Closes #393. The /ship audit on 2026-05-17 caught that PR #373's
\`--cov-fail-under=70\` is an **aggregate** gate across \`src/\` + \`scripts/\`,
not per-module. So the session that lifted \`src/quality/\` from 23% to 98%
isn't actually defended by CI: deleting any single \`test_*.py\` for an
\`src/quality\` module would drop that module from ~100% to 0% while the
aggregate barely moves (the 137-stmt \`agent_metrics\` is only ~0.5pp of total).

This PR adds a second CI step right after the aggregate step:

\`\`\`
coverage report --include='src/quality/*' --fail-under=90
\`\`\`

(coverage.py's \`.coverage\` data file persists between job steps, so no
second pytest run is needed.)

## Why 90%?

- Current \`src/quality/\` total: 98% (lowest module: \`validate_closed_loop\` at 93%)
- 90% leaves ~8pp of headroom for minor regressions
- Locally verified: deleting tests for any single module trips it
  | Module deleted | Stmts | New total | Trips gate? |
  | --- | --- | --- | --- |
  | agent_metrics | 137 | 87.6% | yes |
  | governance | 130 | 88.2% | yes |
  | chart_metrics | 119 | 89.0% | yes |
  | visual_qa_zones | 108 | 89.9% | yes (marginal) |

## Test plan

- [x] \`coverage report --include='src/quality/*' --fail-under=90\` exits 0 on current main (98% passes)
- [x] Same command with \`--fail-under=99\` exits 2 (mechanism fires as intended)
- [x] CONTRIBUTING.md updated to document both gates side by side
- [ ] CI green on this branch (validates the step actually runs in the workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)