### PR TITLE
feat: multi-provider research fallback — Semantic Scholar + Brave + Tavily (#388)

### DIFF
--- a/scripts/brave_search.py
+++ b/scripts/brave_search.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Brave Search API integration.
+
+Wraps `api.search.brave.com/res/v1/web/search`. Free tier is 2,000
+queries/month; requires a ``BRAVE_API_KEY`` env var (sign up at
+brave.com/search/api). When the key is absent the provider returns
+``success=False`` so the multi-provider fallback can skip it cleanly.
+
+Public surface
+--------------
+BraveSearcher                — class
+search_brave_for_topic(topic, max_results=5) -> dict
+    Returns::
+
+        {
+            "success": bool,
+            "topic": str,
+            "results_found": int,
+            "results": list[dict],   # title, url, snippet, age
+            "error": str | None,
+        }
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import orjson
+import requests
+
+logger = logging.getLogger(__name__)
+
+_API_URL = "https://api.search.brave.com/res/v1/web/search"
+_DEFAULT_TIMEOUT = 10
+
+
+class BraveSearcher:
+    """Thin wrapper around the Brave Search web endpoint."""
+
+    def __init__(self, max_results: int = 5, timeout: int = _DEFAULT_TIMEOUT) -> None:
+        self.max_results = max_results
+        self.timeout = timeout
+        self._api_key = os.environ.get("BRAVE_API_KEY")
+
+    @property
+    def has_credentials(self) -> bool:
+        return bool(self._api_key)
+
+    def _headers(self) -> dict[str, str]:
+        # X-Subscription-Token is the auth header per Brave's docs.
+        # Accept: application/json keeps responses JSON-shaped even when
+        # the upstream defaults change.
+        return {
+            "X-Subscription-Token": self._api_key or "",
+            "Accept": "application/json",
+        }
+
+    def search(self, query: str) -> list[dict[str, Any]]:
+        """Return up to ``max_results`` web results for ``query``.
+
+        Raises ``RuntimeError`` when no key is configured (caller maps
+        this to ``success=False`` rather than letting it propagate).
+        Raises ``requests.HTTPError`` on transport-level failures.
+        """
+        if not self.has_credentials:
+            raise RuntimeError("BRAVE_API_KEY is not set")
+        params = {"q": query, "count": self.max_results}
+        resp = requests.get(
+            _API_URL,
+            params=params,
+            headers=self._headers(),
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        body = orjson.loads(resp.content)
+        web = body.get("web") or {}
+        return web.get("results", []) or []
+
+
+def _normalise(raw: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a Brave web result into a uniform dict."""
+    return {
+        "title": raw.get("title", "Unknown"),
+        "url": raw.get("url", ""),
+        "snippet": raw.get("description", ""),
+        # Brave returns `age` like "3 days ago" — preserve as-is; the
+        # writer prompt can quote it directly for currency context.
+        "age": raw.get("age", ""),
+    }
+
+
+def search_brave_for_topic(topic: str, max_results: int = 5) -> dict[str, Any]:
+    """Run a Brave Search query and return a uniform research dict.
+
+    Mirrors ``search_arxiv_for_topic`` / ``search_semantic_scholar_for_topic``
+    so callers can iterate providers uniformly.
+
+    Args:
+        topic: Search query.
+        max_results: Cap on returned results (default 5).
+
+    Returns:
+        ``{"success", "topic", "results_found", "results", "error"}``.
+
+    """
+    try:
+        searcher = BraveSearcher(max_results=max_results)
+        raw = searcher.search(topic)
+        results = [_normalise(r) for r in raw]
+        return {
+            "success": True,
+            "topic": topic,
+            "results_found": len(results),
+            "results": results,
+            "error": None,
+        }
+    except Exception as exc:
+        logger.warning("Brave search failed for '%s': %s", topic, exc)
+        return {
+            "success": False,
+            "topic": topic,
+            "results_found": 0,
+            "results": [],
+            "error": str(exc),
+        }
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    logging.basicConfig(level=logging.INFO)
+    query = sys.argv[1] if len(sys.argv) > 1 else "AI testing tools"
+    result = search_brave_for_topic(query, max_results=3)
+    print(orjson.dumps(result, option=orjson.OPT_INDENT_2).decode())

--- a/scripts/semantic_scholar_search.py
+++ b/scripts/semantic_scholar_search.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Semantic Scholar Academic Search integration.
+
+Wraps the public Semantic Scholar Graph API (`api.semanticscholar.org/graph/v1`).
+No API key required for low-volume use; an optional ``SEMANTIC_SCHOLAR_API_KEY``
+env var unlocks higher rate limits. Mirrors the contract of
+``scripts/arxiv_search.search_arxiv_for_topic`` so it slots into
+``src/agent_sdk/_shared._run_web_searches`` with the same shape.
+
+Public surface
+--------------
+SemanticScholarSearcher       — class, configurable rate-limit/timeout
+search_semantic_scholar_for_topic(topic, max_papers=5) -> dict
+    Convenience function returning::
+
+        {
+            "success": bool,
+            "topic": str,
+            "papers_found": int,
+            "papers": list[dict],   # title, authors, year, abstract, doi, url, citation_count
+            "error": str | None,
+        }
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import orjson
+import requests
+
+logger = logging.getLogger(__name__)
+
+_API_URL = "https://api.semanticscholar.org/graph/v1/paper/search"
+_DEFAULT_FIELDS = "title,authors,year,abstract,externalIds,url,citationCount,venue"
+_DEFAULT_TIMEOUT = 10
+
+
+class SemanticScholarSearcher:
+    """Thin wrapper around the Semantic Scholar paper search endpoint."""
+
+    def __init__(self, max_results: int = 5, timeout: int = _DEFAULT_TIMEOUT) -> None:
+        self.max_results = max_results
+        self.timeout = timeout
+        # Optional key — Semantic Scholar accepts unauthenticated requests
+        # under a shared lower-tier rate limit. The key boosts to
+        # ~1 req/sec when present.
+        self._api_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY")
+
+    def _headers(self) -> dict[str, str]:
+        if self._api_key:
+            return {"x-api-key": self._api_key}
+        return {}
+
+    def search(self, query: str) -> list[dict[str, Any]]:
+        """Return up to ``max_results`` papers for ``query``.
+
+        Raises ``requests.HTTPError`` on transport-level failures so the
+        caller's try/except can mark the provider failed.
+        """
+        params = {
+            "query": query,
+            "limit": self.max_results,
+            "fields": _DEFAULT_FIELDS,
+        }
+        resp = requests.get(
+            _API_URL,
+            params=params,
+            headers=self._headers(),
+            timeout=self.timeout,
+        )
+        resp.raise_for_status()
+        body = orjson.loads(resp.content)
+        return body.get("data", []) or []
+
+
+def _normalise(raw: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a Semantic Scholar paper record into a uniform dict.
+
+    Semantic Scholar nests authors as ``[{"authorId": ..., "name": ...}]``
+    and DOIs under ``externalIds``. Flatten for prompt-friendliness.
+    """
+    authors_raw = raw.get("authors") or []
+    authors = ", ".join(a.get("name", "") for a in authors_raw if a.get("name"))
+    external = raw.get("externalIds") or {}
+    doi = external.get("DOI", "")
+    return {
+        "title": raw.get("title", "Unknown"),
+        "authors": authors or "Unknown",
+        "year": raw.get("year") or "N/A",
+        "abstract": (raw.get("abstract") or "")[:500],
+        "doi": doi,
+        "url": raw.get("url", ""),
+        "citation_count": raw.get("citationCount", 0),
+        "venue": raw.get("venue", ""),
+    }
+
+
+def search_semantic_scholar_for_topic(
+    topic: str,
+    max_papers: int = 5,
+) -> dict[str, Any]:
+    """Run a Semantic Scholar query and return a uniform research dict.
+
+    Mirrors the shape of ``search_arxiv_for_topic`` and
+    ``search_google_for_topic`` so callers can iterate providers uniformly.
+
+    Args:
+        topic: Search query, typically a noun-phrase.
+        max_papers: Cap on returned papers (default 5).
+
+    Returns:
+        ``{"success", "topic", "papers_found", "papers", "error"}``.
+
+    """
+    try:
+        searcher = SemanticScholarSearcher(max_results=max_papers)
+        raw_papers = searcher.search(topic)
+        papers = [_normalise(p) for p in raw_papers]
+        return {
+            "success": True,
+            "topic": topic,
+            "papers_found": len(papers),
+            "papers": papers,
+            "error": None,
+        }
+    except Exception as exc:
+        logger.warning("Semantic Scholar search failed for '%s': %s", topic, exc)
+        return {
+            "success": False,
+            "topic": topic,
+            "papers_found": 0,
+            "papers": [],
+            "error": str(exc),
+        }
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    logging.basicConfig(level=logging.INFO)
+    query = sys.argv[1] if len(sys.argv) > 1 else "AI testing tools"
+    result = search_semantic_scholar_for_topic(query, max_papers=3)
+    print(orjson.dumps(result, option=orjson.OPT_INDENT_2).decode())

--- a/scripts/tavily_search.py
+++ b/scripts/tavily_search.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Tavily AI-native search integration.
+
+Wraps `api.tavily.com/search`. Tavily returns ranked + pre-summarized
+results (and optionally a generated answer) which saves writer-side
+tokens compared with raw snippet lists. Free tier is 1,000 queries/month;
+requires a ``TAVILY_API_KEY`` env var (sign up at tavily.com).
+
+Public surface
+--------------
+TavilySearcher                — class
+search_tavily_for_topic(topic, max_results=5) -> dict
+    Returns::
+
+        {
+            "success": bool,
+            "topic": str,
+            "results_found": int,
+            "results": list[dict],   # title, url, snippet, score
+            "answer": str,           # Tavily's generated summary, may be ""
+            "error": str | None,
+        }
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import orjson
+import requests
+
+logger = logging.getLogger(__name__)
+
+_API_URL = "https://api.tavily.com/search"
+_DEFAULT_TIMEOUT = 15  # Tavily summarises server-side, runs a bit slower
+
+
+class TavilySearcher:
+    """Thin wrapper around the Tavily search endpoint."""
+
+    def __init__(
+        self,
+        max_results: int = 5,
+        timeout: int = _DEFAULT_TIMEOUT,
+        include_answer: bool = True,
+    ) -> None:
+        self.max_results = max_results
+        self.timeout = timeout
+        self.include_answer = include_answer
+        self._api_key = os.environ.get("TAVILY_API_KEY")
+
+    @property
+    def has_credentials(self) -> bool:
+        return bool(self._api_key)
+
+    def search(self, query: str) -> dict[str, Any]:
+        """Return the raw Tavily response body for ``query``.
+
+        Returns the parsed JSON so the caller can pull both ``results``
+        and the optional ``answer`` field. Raises ``RuntimeError`` when
+        no key is configured; ``requests.HTTPError`` on transport failure.
+        """
+        if not self.has_credentials:
+            raise RuntimeError("TAVILY_API_KEY is not set")
+        # Tavily uses POST with the key in the JSON body (not a header).
+        payload = {
+            "api_key": self._api_key,
+            "query": query,
+            "max_results": self.max_results,
+            "include_answer": self.include_answer,
+            "search_depth": "basic",
+        }
+        resp = requests.post(_API_URL, json=payload, timeout=self.timeout)
+        resp.raise_for_status()
+        return orjson.loads(resp.content)
+
+
+def _normalise(raw: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a Tavily result item into a uniform dict."""
+    return {
+        "title": raw.get("title", "Unknown"),
+        "url": raw.get("url", ""),
+        "snippet": raw.get("content", ""),
+        # Tavily ranks results; the score helps the writer pick the
+        # strongest source to cite when multiple cover the same point.
+        "score": raw.get("score", 0.0),
+    }
+
+
+def search_tavily_for_topic(topic: str, max_results: int = 5) -> dict[str, Any]:
+    """Run a Tavily query and return a uniform research dict.
+
+    Args:
+        topic: Search query.
+        max_results: Cap on returned results (default 5).
+
+    Returns:
+        ``{"success", "topic", "results_found", "results", "answer", "error"}``.
+
+    """
+    try:
+        searcher = TavilySearcher(max_results=max_results)
+        body = searcher.search(topic)
+        raw_results = body.get("results", []) or []
+        results = [_normalise(r) for r in raw_results]
+        return {
+            "success": True,
+            "topic": topic,
+            "results_found": len(results),
+            "results": results,
+            "answer": body.get("answer", "") or "",
+            "error": None,
+        }
+    except Exception as exc:
+        logger.warning("Tavily search failed for '%s': %s", topic, exc)
+        return {
+            "success": False,
+            "topic": topic,
+            "results_found": 0,
+            "results": [],
+            "answer": "",
+            "error": str(exc),
+        }
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    logging.basicConfig(level=logging.INFO)
+    query = sys.argv[1] if len(sys.argv) > 1 else "AI testing tools"
+    result = search_tavily_for_topic(query, max_results=3)
+    print(orjson.dumps(result, option=orjson.OPT_INDENT_2).decode())

--- a/src/agent_sdk/_shared.py
+++ b/src/agent_sdk/_shared.py
@@ -140,25 +140,48 @@ def build_research_brief(topic: str) -> str:
 
 
 def _run_web_searches(topic: str) -> tuple[str, dict[str, Any]]:
-    """Combine arXiv and Google search results for ``topic``.
+    """Combine multi-provider search results for ``topic`` (#388).
 
-    Returns a tuple of (formatted_markdown, diagnostics) where diagnostics is:
+    Fans out to arXiv, Google (via Serper, when ``SERPER_API_KEY`` is set),
+    Semantic Scholar (no key required), Brave (when ``BRAVE_API_KEY`` is
+    set), and Tavily (when ``TAVILY_API_KEY`` is set). Each provider is
+    isolated in its own try/except so a single outage / missing key
+    cannot poison the others. Diagnostics shape:
 
         {
-            "source_counts": {"arxiv": int, "google_web": int, "google_scholar": int},
-            "provider_failed": {"arxiv": bool, "google": bool},
+            "source_counts": {
+                "arxiv": int, "google_web": int, "google_scholar": int,
+                "semantic_scholar": int, "brave": int, "tavily": int,
+            },
+            "provider_failed": {
+                "arxiv": bool, "google": bool, "semantic_scholar": bool,
+                "brave": bool, "tavily": bool,
+            },
         }
 
-    A provider is considered ``failed`` if it raised an exception during
-    import or call, or if its top-level response shape signals an error
-    (``success=False`` for arxiv; the topic-level wrapper for google also
-    sets ``success=False`` on transport failures). A provider that ran
-    cleanly but returned zero results is **not** marked failed.
+    A provider is ``failed`` if it raised, returned ``success=False``,
+    or returned only error-stub results. A provider that ran cleanly
+    but returned zero results is **not** marked failed (lets the gate
+    distinguish topic-too-narrow from provider-outage).
     """
     results: list[str] = []
-    source_counts: dict[str, int] = {"arxiv": 0, "google_web": 0, "google_scholar": 0}
-    provider_failed: dict[str, bool] = {"arxiv": False, "google": False}
+    source_counts: dict[str, int] = {
+        "arxiv": 0,
+        "google_web": 0,
+        "google_scholar": 0,
+        "semantic_scholar": 0,
+        "brave": 0,
+        "tavily": 0,
+    }
+    provider_failed: dict[str, bool] = {
+        "arxiv": False,
+        "google": False,
+        "semantic_scholar": False,
+        "brave": False,
+        "tavily": False,
+    }
 
+    # ── arXiv ────────────────────────────────────────────────────────
     try:
         from scripts.arxiv_search import search_arxiv_for_topic
 
@@ -181,6 +204,7 @@ def _run_web_searches(topic: str) -> tuple[str, dict[str, Any]]:
         logger.warning("arXiv search failed: %s", exc)
         provider_failed["arxiv"] = True
 
+    # ── Google (Serper) ──────────────────────────────────────────────
     try:
         from scripts.google_search import search_google_for_topic
 
@@ -197,7 +221,7 @@ def _run_web_searches(topic: str) -> tuple[str, dict[str, Any]]:
             web = [r for r in google.get("web_results", []) if "error" not in r]
             if web:
                 source_counts["google_web"] = len(web[:5])
-                results.append("\n## Web Sources")
+                results.append("\n## Web Sources (Google)")
                 for r in web[:5]:
                     results.append(
                         f"- [{r.get('title', 'Unknown')}]({r.get('link', '')})\n"
@@ -228,6 +252,84 @@ def _run_web_searches(topic: str) -> tuple[str, dict[str, Any]]:
     except Exception as exc:
         logger.warning("Google search failed: %s", exc)
         provider_failed["google"] = True
+
+    # ── Semantic Scholar ─────────────────────────────────────────────
+    try:
+        from scripts.semantic_scholar_search import search_semantic_scholar_for_topic
+
+        ss = search_semantic_scholar_for_topic(topic, max_papers=5)
+        if not ss.get("success", False):
+            provider_failed["semantic_scholar"] = True
+        else:
+            papers = ss.get("papers", [])
+            if papers:
+                source_counts["semantic_scholar"] = len(papers[:5])
+                results.append("\n## Semantic Scholar")
+                for p in papers[:5]:
+                    citation_str = (
+                        f" — cited {p['citation_count']}x"
+                        if p.get("citation_count")
+                        else ""
+                    )
+                    results.append(
+                        f"- [{p.get('title', 'Unknown')}]({p.get('url', '')})\n"
+                        f"  Authors: {p.get('authors', 'Unknown')} "
+                        f"({p.get('year', 'N/A')}){citation_str}\n"
+                        f"  DOI: {p.get('doi', '')}\n"
+                        f"  Abstract: {p.get('abstract', '')}",
+                    )
+    except Exception as exc:
+        logger.warning("Semantic Scholar search failed: %s", exc)
+        provider_failed["semantic_scholar"] = True
+
+    # ── Brave ────────────────────────────────────────────────────────
+    try:
+        from scripts.brave_search import search_brave_for_topic
+
+        brave = search_brave_for_topic(topic, max_results=5)
+        if not brave.get("success", False):
+            provider_failed["brave"] = True
+        else:
+            br = brave.get("results", [])
+            if br:
+                source_counts["brave"] = len(br[:5])
+                results.append("\n## Web Sources (Brave)")
+                for r in br[:5]:
+                    age_str = f" ({r['age']})" if r.get("age") else ""
+                    results.append(
+                        f"- [{r.get('title', 'Unknown')}]({r.get('url', '')})"
+                        f"{age_str}\n"
+                        f"  Snippet: {r.get('snippet', 'N/A')}",
+                    )
+    except Exception as exc:
+        logger.warning("Brave search failed: %s", exc)
+        provider_failed["brave"] = True
+
+    # ── Tavily ───────────────────────────────────────────────────────
+    try:
+        from scripts.tavily_search import search_tavily_for_topic
+
+        tavily = search_tavily_for_topic(topic, max_results=5)
+        if not tavily.get("success", False):
+            provider_failed["tavily"] = True
+        else:
+            tv = tavily.get("results", [])
+            if tv:
+                source_counts["tavily"] = len(tv[:5])
+                results.append("\n## Web Sources (Tavily, AI-ranked)")
+                answer = tavily.get("answer", "")
+                if answer:
+                    results.append(f"_Synthesis:_ {answer}\n")
+                for r in tv[:5]:
+                    score_str = f" (score {r['score']:.2f})" if r.get("score") else ""
+                    results.append(
+                        f"- [{r.get('title', 'Unknown')}]({r.get('url', '')})"
+                        f"{score_str}\n"
+                        f"  Snippet: {r.get('snippet', 'N/A')}",
+                    )
+    except Exception as exc:
+        logger.warning("Tavily search failed: %s", exc)
+        provider_failed["tavily"] = True
 
     diagnostics: dict[str, Any] = {
         "source_counts": source_counts,

--- a/tests/test_brave_search.py
+++ b/tests/test_brave_search.py
@@ -1,0 +1,137 @@
+"""Tests for scripts/brave_search.py (#388)."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import orjson
+import pytest
+
+from scripts.brave_search import (
+    BraveSearcher,
+    _normalise,
+    search_brave_for_topic,
+)
+
+
+def _mock_response(payload: dict) -> Mock:
+    r = Mock()
+    r.content = orjson.dumps(payload)
+    r.raise_for_status = Mock()
+    return r
+
+
+def _result(title: str = "Result") -> dict:
+    return {
+        "title": title,
+        "url": f"https://example.com/{title.lower()}",
+        "description": f"A snippet about {title}.",
+        "age": "3 days ago",
+    }
+
+
+class TestNormalise:
+    def test_maps_description_to_snippet(self) -> None:
+        out = _normalise(_result("X"))
+        assert out["snippet"] == "A snippet about X."
+
+    def test_preserves_age_string_verbatim(self) -> None:
+        out = _normalise({"age": "yesterday"})
+        assert out["age"] == "yesterday"
+
+    def test_defaults_missing_fields_to_safe_sentinels(self) -> None:
+        out = _normalise({})
+        assert out["title"] == "Unknown"
+        assert out["url"] == ""
+        assert out["snippet"] == ""
+        assert out["age"] == ""
+
+
+class TestBraveSearcher:
+    def test_has_credentials_true_when_key_present(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BRAVE_API_KEY", "tok")
+        assert BraveSearcher().has_credentials is True
+
+    def test_has_credentials_false_when_key_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+        assert BraveSearcher().has_credentials is False
+
+    def test_search_raises_when_no_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="BRAVE_API_KEY"):
+            BraveSearcher().search("x")
+
+    def test_sends_subscription_token_header(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BRAVE_API_KEY", "tok-123")
+        with patch("scripts.brave_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_response({"web": {"results": []}})
+            BraveSearcher().search("AI testing")
+        headers = mock_get.call_args.kwargs["headers"]
+        assert headers["X-Subscription-Token"] == "tok-123"
+        assert headers["Accept"] == "application/json"
+
+    def test_returns_results_from_web_results_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BRAVE_API_KEY", "tok")
+        with patch("scripts.brave_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_response(
+                {"web": {"results": [_result("A"), _result("B")]}}
+            )
+            results = BraveSearcher(max_results=3).search("q")
+        assert len(results) == 2
+        assert results[0]["title"] == "A"
+
+    def test_handles_missing_web_key_gracefully(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Brave occasionally returns only spell-check / faq sections
+        monkeypatch.setenv("BRAVE_API_KEY", "tok")
+        with patch("scripts.brave_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_response({"query": "x"})
+            assert BraveSearcher().search("x") == []
+
+
+class TestSearchBraveForTopic:
+    def test_success_path_returns_normalised_results(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BRAVE_API_KEY", "tok")
+        with patch("scripts.brave_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_response(
+                {"web": {"results": [_result("First"), _result("Second")]}}
+            )
+            result = search_brave_for_topic("flaky tests", max_results=5)
+        assert result["success"] is True
+        assert result["results_found"] == 2
+        assert result["results"][0]["snippet"].startswith("A snippet about")
+        assert result["error"] is None
+
+    def test_missing_key_returns_failure_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+        result = search_brave_for_topic("anything")
+        assert result["success"] is False
+        assert "BRAVE_API_KEY" in result["error"]
+        assert result["results_found"] == 0
+
+    def test_http_error_returns_failure_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BRAVE_API_KEY", "tok")
+        with patch(
+            "scripts.brave_search.requests.get",
+            side_effect=ConnectionError("network down"),
+        ):
+            result = search_brave_for_topic("x")
+        assert result["success"] is False
+        assert "network down" in result["error"]

--- a/tests/test_empty_research_guard.py
+++ b/tests/test_empty_research_guard.py
@@ -157,20 +157,111 @@ class TestEmptyResearchBriefError:
                 "scholar_results": [{"error": "HTTP error from Serper API: 400"}],
             }
 
+        # Stub the three new providers (#388) so the test isolates the
+        # error-stub behaviour of the Google path: each returns a clean
+        # zero-result success so neither counts nor failure flags fire.
+        def fake_empty_success(*args, **kwargs):
+            return {"success": True, "papers": [], "results": [], "answer": ""}
+
         with (
             patch("scripts.arxiv_search.search_arxiv_for_topic", fake_arxiv),
             patch("scripts.google_search.search_google_for_topic", fake_google),
+            patch(
+                "scripts.semantic_scholar_search.search_semantic_scholar_for_topic",
+                fake_empty_success,
+            ),
+            patch("scripts.brave_search.search_brave_for_topic", fake_empty_success),
+            patch("scripts.tavily_search.search_tavily_for_topic", fake_empty_success),
         ):
             _, diag = _run_web_searches("AI Testing")
-            assert diag["source_counts"] == {
-                "arxiv": 0,
-                "google_web": 0,
-                "google_scholar": 0,
-            }
+            # All six counters at zero — error stubs filtered, new providers
+            # returned clean empties.
+            assert sum(diag["source_counts"].values()) == 0
+            assert diag["source_counts"]["google_web"] == 0
+            assert diag["source_counts"]["google_scholar"] == 0
+            # Google must still be marked failed (error-stub provenance);
+            # the new providers ran cleanly so they stay non-failed.
             assert diag["provider_failed"]["google"] is True
+            assert diag["provider_failed"]["semantic_scholar"] is False
+            assert diag["provider_failed"]["brave"] is False
+            assert diag["provider_failed"]["tavily"] is False
 
             with pytest.raises(SearchProvidersFailedError):
                 build_research_brief("AI Testing")
+
+    def test_multi_provider_mixed_success_aggregates_sources_across_providers(
+        self,
+    ) -> None:
+        """#388: when arXiv/Google fail but Semantic Scholar + Brave +
+        Tavily return results, the brief must be built from those and
+        the gate must NOT fire. Proves the fan-out makes the pipeline
+        resilient to single-provider outages (the original motivation
+        for filing #388 — Serper credits exhausted, arXiv rate-limited)."""
+        from src.agent_sdk._shared import _run_web_searches
+
+        with (
+            patch(
+                "scripts.arxiv_search.search_arxiv_for_topic",
+                return_value={"success": False, "insights": {}, "error": "rate-limit"},
+            ),
+            patch(
+                "scripts.google_search.search_google_for_topic",
+                return_value={"success": False, "error": "no credits"},
+            ),
+            patch(
+                "scripts.semantic_scholar_search.search_semantic_scholar_for_topic",
+                return_value={
+                    "success": True,
+                    "papers": [
+                        {
+                            "title": "Paper",
+                            "authors": "X",
+                            "year": 2025,
+                            "abstract": "abs",
+                            "doi": "10.0/x",
+                            "url": "https://semanticscholar.org/p/1",
+                            "citation_count": 5,
+                        }
+                    ],
+                },
+            ),
+            patch(
+                "scripts.brave_search.search_brave_for_topic",
+                return_value={
+                    "success": True,
+                    "results": [
+                        {"title": "B", "url": "https://b.example", "snippet": "s"}
+                    ],
+                },
+            ),
+            patch(
+                "scripts.tavily_search.search_tavily_for_topic",
+                return_value={
+                    "success": True,
+                    "results": [
+                        {
+                            "title": "T",
+                            "url": "https://t.example",
+                            "snippet": "s",
+                            "score": 0.9,
+                        }
+                    ],
+                    "answer": "Synthesized insight.",
+                },
+            ),
+        ):
+            text, diag = _run_web_searches("AI Testing")
+
+        # arXiv + google both failed; the new three carried the load.
+        assert diag["provider_failed"]["arxiv"] is True
+        assert diag["provider_failed"]["google"] is True
+        assert diag["provider_failed"]["semantic_scholar"] is False
+        assert diag["provider_failed"]["brave"] is False
+        assert diag["provider_failed"]["tavily"] is False
+        # Three sources counted (one from each surviving provider).
+        assert sum(diag["source_counts"].values()) == 3
+        # Tavily's generated answer surfaces in the brief for the writer.
+        assert "Synthesized insight." in text
 
     def test_run_stage3_propagates_empty_research_error(self) -> None:
         """EmptyResearchBriefError (and subclasses) must not be swallowed by run_stage3."""

--- a/tests/test_semantic_scholar_search.py
+++ b/tests/test_semantic_scholar_search.py
@@ -1,0 +1,142 @@
+"""Tests for scripts/semantic_scholar_search.py (#388)."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import orjson
+import pytest
+
+from scripts.semantic_scholar_search import (
+    SemanticScholarSearcher,
+    _normalise,
+    search_semantic_scholar_for_topic,
+)
+
+
+def _mock_response(payload: dict, status: int = 200) -> Mock:
+    r = Mock()
+    r.status_code = status
+    r.content = orjson.dumps(payload)
+    r.raise_for_status = Mock()
+    return r
+
+
+def _paper(title: str = "Paper", year: int = 2025, doi: str = "10.0/x") -> dict:
+    return {
+        "title": title,
+        "authors": [{"name": "A. One"}, {"name": "B. Two"}],
+        "year": year,
+        "abstract": "An abstract about something." * 30,
+        "externalIds": {"DOI": doi},
+        "url": f"https://semanticscholar.org/paper/{doi}",
+        "citationCount": 42,
+        "venue": "ICSE",
+    }
+
+
+class TestNormalise:
+    def test_collapses_authors_to_csv_string(self) -> None:
+        out = _normalise(_paper())
+        assert out["authors"] == "A. One, B. Two"
+
+    def test_truncates_abstract_to_500_chars(self) -> None:
+        out = _normalise(_paper())
+        assert len(out["abstract"]) == 500
+
+    def test_extracts_doi_from_external_ids(self) -> None:
+        out = _normalise(_paper(doi="10.1145/test"))
+        assert out["doi"] == "10.1145/test"
+
+    def test_missing_fields_default_to_sentinels(self) -> None:
+        out = _normalise({})
+        assert out["title"] == "Unknown"
+        assert out["authors"] == "Unknown"
+        assert out["year"] == "N/A"
+        assert out["doi"] == ""
+        assert out["citation_count"] == 0
+
+    def test_handles_none_authors_list(self) -> None:
+        # Semantic Scholar can return authors: None for some papers
+        out = _normalise({"title": "x", "authors": None})
+        assert out["authors"] == "Unknown"
+
+
+class TestSemanticScholarSearcher:
+    def test_sends_api_key_header_when_env_var_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("SEMANTIC_SCHOLAR_API_KEY", "secret-token")
+        searcher = SemanticScholarSearcher()
+        with patch("scripts.semantic_scholar_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_response({"data": []})
+            searcher.search("AI testing")
+        kwargs = mock_get.call_args.kwargs
+        assert kwargs["headers"] == {"x-api-key": "secret-token"}
+
+    def test_omits_header_when_env_var_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("SEMANTIC_SCHOLAR_API_KEY", raising=False)
+        searcher = SemanticScholarSearcher()
+        with patch("scripts.semantic_scholar_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_response({"data": []})
+            searcher.search("AI testing")
+        assert mock_get.call_args.kwargs["headers"] == {}
+
+    def test_returns_papers_from_data_field(self) -> None:
+        searcher = SemanticScholarSearcher(max_results=3)
+        with patch("scripts.semantic_scholar_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_response(
+                {"data": [_paper("First"), _paper("Second")]}
+            )
+            result = searcher.search("flaky tests")
+        assert len(result) == 2
+        assert result[0]["title"] == "First"
+
+    def test_raises_on_http_error(self) -> None:
+        searcher = SemanticScholarSearcher()
+        with patch("scripts.semantic_scholar_search.requests.get") as mock_get:
+            err_resp = Mock()
+            err_resp.raise_for_status.side_effect = Exception("HTTP 429")
+            mock_get.return_value = err_resp
+            with pytest.raises(Exception, match="HTTP 429"):
+                searcher.search("x")
+
+
+class TestSearchSemanticScholarForTopic:
+    def test_returns_success_dict_with_normalised_papers(self) -> None:
+        with patch("scripts.semantic_scholar_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_response(
+                {"data": [_paper("First"), _paper("Second")]}
+            )
+            result = search_semantic_scholar_for_topic("AI testing", max_papers=5)
+
+        assert result["success"] is True
+        assert result["topic"] == "AI testing"
+        assert result["papers_found"] == 2
+        assert result["error"] is None
+        # Normalised shape
+        assert result["papers"][0]["authors"] == "A. One, B. Two"
+        assert result["papers"][0]["doi"] == "10.0/x"
+
+    def test_returns_failure_dict_on_exception(self) -> None:
+        with patch(
+            "scripts.semantic_scholar_search.requests.get",
+            side_effect=ConnectionError("no internet"),
+        ):
+            result = search_semantic_scholar_for_topic("anything")
+        assert result["success"] is False
+        assert result["papers_found"] == 0
+        assert result["papers"] == []
+        assert "no internet" in result["error"]
+
+    def test_zero_results_is_success_with_empty_list(self) -> None:
+        # Provider ran cleanly; topic too narrow. Caller distinguishes via
+        # papers_found, not success.
+        with patch("scripts.semantic_scholar_search.requests.get") as mock_get:
+            mock_get.return_value = _mock_response({"data": []})
+            result = search_semantic_scholar_for_topic("xxxnonexistentyyy")
+        assert result["success"] is True
+        assert result["papers_found"] == 0
+        assert result["papers"] == []

--- a/tests/test_tavily_search.py
+++ b/tests/test_tavily_search.py
@@ -48,17 +48,13 @@ class TestNormalise:
 
 
 class TestTavilySearcher:
-    def test_has_credentials_follows_env(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_has_credentials_follows_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("TAVILY_API_KEY", raising=False)
         assert TavilySearcher().has_credentials is False
         monkeypatch.setenv("TAVILY_API_KEY", "tok")
         assert TavilySearcher().has_credentials is True
 
-    def test_search_raises_when_no_key(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_search_raises_when_no_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("TAVILY_API_KEY", raising=False)
         with pytest.raises(RuntimeError, match="TAVILY_API_KEY"):
             TavilySearcher().search("x")

--- a/tests/test_tavily_search.py
+++ b/tests/test_tavily_search.py
@@ -1,0 +1,143 @@
+"""Tests for scripts/tavily_search.py (#388)."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import orjson
+import pytest
+
+from scripts.tavily_search import (
+    TavilySearcher,
+    _normalise,
+    search_tavily_for_topic,
+)
+
+
+def _mock_response(payload: dict) -> Mock:
+    r = Mock()
+    r.content = orjson.dumps(payload)
+    r.raise_for_status = Mock()
+    return r
+
+
+def _result(title: str = "Result", score: float = 0.9) -> dict:
+    return {
+        "title": title,
+        "url": f"https://example.com/{title.lower()}",
+        "content": f"Pre-summarised content about {title}.",
+        "score": score,
+    }
+
+
+class TestNormalise:
+    def test_maps_content_to_snippet(self) -> None:
+        out = _normalise(_result("X"))
+        assert out["snippet"] == "Pre-summarised content about X."
+
+    def test_preserves_score(self) -> None:
+        out = _normalise(_result(score=0.42))
+        assert out["score"] == 0.42
+
+    def test_defaults_missing_fields(self) -> None:
+        out = _normalise({})
+        assert out["title"] == "Unknown"
+        assert out["url"] == ""
+        assert out["snippet"] == ""
+        assert out["score"] == 0.0
+
+
+class TestTavilySearcher:
+    def test_has_credentials_follows_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        assert TavilySearcher().has_credentials is False
+        monkeypatch.setenv("TAVILY_API_KEY", "tok")
+        assert TavilySearcher().has_credentials is True
+
+    def test_search_raises_when_no_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="TAVILY_API_KEY"):
+            TavilySearcher().search("x")
+
+    def test_posts_with_api_key_in_body_not_header(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Tavily authenticates via JSON body field, not Authorization header.
+        # Asserting this prevents an easy migration mistake.
+        monkeypatch.setenv("TAVILY_API_KEY", "tok-99")
+        with patch("scripts.tavily_search.requests.post") as mock_post:
+            mock_post.return_value = _mock_response({"results": []})
+            TavilySearcher(max_results=4).search("AI testing")
+        body = mock_post.call_args.kwargs["json"]
+        assert body["api_key"] == "tok-99"
+        assert body["query"] == "AI testing"
+        assert body["max_results"] == 4
+        assert body["include_answer"] is True
+
+    def test_returns_parsed_response_body(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "tok")
+        with patch("scripts.tavily_search.requests.post") as mock_post:
+            mock_post.return_value = _mock_response(
+                {"results": [_result("A")], "answer": "Summary text."}
+            )
+            body = TavilySearcher().search("q")
+        assert body["answer"] == "Summary text."
+        assert len(body["results"]) == 1
+
+
+class TestSearchTavilyForTopic:
+    def test_success_path_includes_results_and_answer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "tok")
+        with patch("scripts.tavily_search.requests.post") as mock_post:
+            mock_post.return_value = _mock_response(
+                {
+                    "results": [_result("First", 0.95), _result("Second", 0.8)],
+                    "answer": "Both papers agree on X.",
+                }
+            )
+            result = search_tavily_for_topic("flaky tests", max_results=5)
+        assert result["success"] is True
+        assert result["results_found"] == 2
+        assert result["answer"] == "Both papers agree on X."
+        # Scores preserved for the writer to rank by
+        assert result["results"][0]["score"] == 0.95
+        assert result["error"] is None
+
+    def test_answer_defaults_to_empty_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "tok")
+        with patch("scripts.tavily_search.requests.post") as mock_post:
+            mock_post.return_value = _mock_response({"results": []})
+            result = search_tavily_for_topic("x")
+        assert result["answer"] == ""
+
+    def test_missing_key_returns_failure_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        result = search_tavily_for_topic("anything")
+        assert result["success"] is False
+        assert "TAVILY_API_KEY" in result["error"]
+        assert result["results_found"] == 0
+        assert result["answer"] == ""
+
+    def test_http_error_returns_failure_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "tok")
+        with patch(
+            "scripts.tavily_search.requests.post",
+            side_effect=ConnectionError("network down"),
+        ):
+            result = search_tavily_for_topic("x")
+        assert result["success"] is False
+        assert "network down" in result["error"]


### PR DESCRIPTION
## Summary

Closes #388. Replaces the single-provider research path (arXiv + Serper-Google + Serper-Scholar) with a five-provider fan-out so the pipeline survives any single provider outage. Each provider runs in isolation and a missing key is a clean skip, not a crash.

Provider mix per the design decision:
- **arXiv** — unchanged, free, no key
- **Semantic Scholar** — NEW, free, optional \`SEMANTIC_SCHOLAR_API_KEY\` for higher rate limits
- **Brave Search** — NEW, free 2k/mo, requires \`BRAVE_API_KEY\` (brave.com/search/api)
- **Tavily** — NEW, free 1k/mo, requires \`TAVILY_API_KEY\` (tavily.com), AI-native (returns synthesised answer + scored results)
- **Serper (Google + Scholar)** — kept as optional fallback per the design decision

Four reviewable slices:

- **Slice 1** (8e26797) — \`scripts/semantic_scholar_search.py\` + 12 tests
- **Slice 2** (40d1ab2) — \`scripts/brave_search.py\` + 12 tests
- **Slice 3** (c92b1ef) — \`scripts/tavily_search.py\` + 11 tests
- **Slice 4** (63e9043) — wire all three into \`src/agent_sdk/_shared._run_web_searches\`; expanded diagnostics; backwards-compatible gate behaviour

## Why this matters

The Serper credits ran out on 2026-05-17 and the pipeline lost its only Google web surface. With this PR, you can lose any single provider (or any pair) and the pipeline still produces a brief — as long as one source comes back, the gate doesn't fire. Tavily additionally pre-summarises results server-side, saving writer-side tokens.

## Test plan

- [x] Full suite: 2145 passed / 84 skipped (was 2107 on main; +38 new tests)
- [x] New mixed-success integration test proves arXiv + Google failures + 3 surviving providers produce a complete brief
- [x] Backwards compat: existing \`_diag()\`-mocked tests still pass because the gate iterates dict values, not keys
- [x] ruff check + format clean
- [x] AST bare-name guard updated automatically: 52 modules scanned (was 49)
- [ ] CI green
- [ ] (Manual, post-merge) Add \`BRAVE_API_KEY\` and \`TAVILY_API_KEY\` to \`.env\` and re-run the failing pipeline topic from yesterday to confirm end-to-end recovery

## Follow-up

- \`requirements.txt\`: no new deps — all three providers use \`requests\` + \`orjson\` which are already pinned
- \`.env.example\` could note the two new keys; not added in this PR to keep scope tight
- #389 (hybrid research) and #390 (recursive multi-hop) remain open as separate research directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)