### PR TITLE
chore: ruff format fix-forward for test_brave_search.py (repair main CI)

### DIFF
--- a/tests/test_brave_search.py
+++ b/tests/test_brave_search.py
@@ -60,9 +60,7 @@ class TestBraveSearcher:
         monkeypatch.delenv("BRAVE_API_KEY", raising=False)
         assert BraveSearcher().has_credentials is False
 
-    def test_search_raises_when_no_key(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_search_raises_when_no_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("BRAVE_API_KEY", raising=False)
         with pytest.raises(RuntimeError, match="BRAVE_API_KEY"):
             BraveSearcher().search("x")


### PR DESCRIPTION
Trailing-comma reformat missed when shipping PR #399 slice 2. Auto-merge on #399 squashed before my fix-forward push reached the PR branch, so main currently has a failing `Quality Gates CI` from the missed format pass. This PR repairs it.

1-line change. No logic. Local pytest `tests/test_brave_search.py` still 12/12 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)