### PR TITLE
feat: chart render + human-in-the-loop image handshake (#403, closes #402)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,73 @@ Thank you for your interest in contributing to the Economist-Agents project! Thi
    make quality  # Runs format, lint, type-check, and tests
    ```
 
+## ✏️ Generating an article — the image handshake (#403)
+
+The pipeline is **two-step** to keep the cost of a featured image zero
+(no paid DALL-E/Imagen/etc. API). Stage 3 produces the article + chart
+and pauses with a paste-ready prompt; you generate the image yourself
+in chat.openai.com (or any web image tool) and drop the PNG at a known
+path; `--resume` then runs Stage 4 and finalises the article.
+
+### Step 1 — run Stage 3
+
+```bash
+python -m src.agent_sdk.pipeline "your noun-phrasey topic"
+```
+
+Stage 3 writes:
+
+- `output/posts/<slug>.md` — the article draft
+- `output/charts/<slug>.png` — the rendered chart (matplotlib, no API)
+- `output/posts/<slug>.image_prompt.md` — the prompt to paste into ChatGPT
+- `output/state/<slug>.json` — handshake state for `--resume`
+
+Then it **exits 10** and prints the prompt + the exact drop path + the
+resume command. Cost so far is the Stage 3 LLM spend only (~$0.30).
+
+### Step 2 — generate the hero image
+
+Open chat.openai.com, paste the prompt from
+`output/posts/<slug>.image_prompt.md`, generate the image, and save the
+PNG (1792×1024 landscape) to:
+
+```
+output/posts/images/<slug>.png
+```
+
+The deterministic gate enforces format/dimensions/size; visual quality
+is your call.
+
+### Step 3 — resume
+
+```bash
+# With a hero image:
+python -m src.agent_sdk.pipeline --resume <slug>
+
+# Or chart-only (no hero — the chart becomes the visual anchor):
+python -m src.agent_sdk.pipeline --resume <slug> --no-image
+```
+
+Stage 4 polishes the article, runs the publication validator, and
+writes the final version back to `output/posts/<slug>.md`.
+
+### Exit codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0    | Stage 4 complete (full pipeline done) |
+| 1    | Operator error (unknown slug, missing article) |
+| 2    | Research providers failed (transient — retry or rephrase) |
+| 3    | Research providers returned zero sources (topic too narrow) |
+| 10   | Stage 3 complete — awaiting image-prompt handshake |
+| 11   | `--resume` image-gate failed (missing/wrong-size/wrong-dims PNG) |
+
+### Deploying
+
+After Stage 4 passes, the article at `output/posts/<slug>.md` is ready
+for `python -m scripts.deploy_to_blog --article output/posts/<slug>.md`.
+See the deploy script's `--help` for blog-repo config.
+
 ## 🎯 Development Workflow
 
 We follow a **quality-first workflow** with automated gates (checkpoints) to ensure code excellence.

--- a/docs/archive/plans/plan-issue-344-completed.md
+++ b/docs/archive/plans/plan-issue-344-completed.md
@@ -1,0 +1,104 @@
+# Plan: Migrate domain modules from scripts/ to src/ (issue #344)
+
+**Spec**: SPEC.md
+**ADR**: docs/adr/0010-scripts-to-src-migration.md
+**Date**: 2026-05-15
+
+## Dependency graph
+
+```
+T0 (create src/quality/, src/backlog/ packages)
+  │
+  ├──► T1..T8 (migrate Group A — 8 modules, one per slice)
+  │       ├── T1: agent_reviewer (callers: writer_agent, research_agent, test_quality_system)
+  │       ├── T2: governance (callers: writer_agent, research_agent, economist_agent)
+  │       ├── T3: chart_metrics (callers: graphics_agent, economist_agent)
+  │       ├── T4: schema_validator (callers: test_quality_system)
+  │       ├── T5: agent_metrics (callers: economist_agent, quality_dashboard, test_quality_dashboard mocks)
+  │       ├── T6: defect_tracker (callers: quality_dashboard, test_quality_dashboard mocks)
+  │       ├── T7: validate_closed_loop (callers: test_closed_loop_validation subprocess)
+  │       └── T8: visual_qa_zones (callers: economist_agent)
+  │
+  ├──► T9..T12 (migrate Group B — 4 modules, one per slice)
+  │       ├── T9:  backlog_groomer
+  │       ├── T10: ci_health_monitor
+  │       ├── T11: migrate_backlog_to_github
+  │       └── T12: validate_documentation_accuracy
+  │       (all four callers in scripts/continuous_burndown.py)
+  │
+  ├──► T13 (skills_manager: convert to fully-qualified imports)
+  │
+  ├──► T14 (remove sys.path hack from tests/test_architecture_compliance.py)
+  │
+  ├──► T15 (move 12 originals to scripts/archived/)
+  │
+  └──► T16 (update SPEC.md §2 - mark †-rows as MIGRATED; final verification)
+```
+
+Each task is one commit. Verification after every task:
+- `pytest tests/ -q` shows same pass/skip count as baseline
+- `ruff check --no-fix` and `ruff format --check` clean
+
+## Baseline
+
+Before starting, capture baseline test count: `pytest tests/ -q`.
+Expected: 1741 passed, 84 skipped (per worker brief).
+
+## Tasks
+
+### T0 — Create empty src/quality/ and src/backlog/ packages
+
+- Create `src/quality/__init__.py` (empty)
+- Create `src/backlog/__init__.py` (empty)
+- Verify: `pytest tests/ -q` unchanged
+
+### T1..T8 — Group A migrations (one module per commit)
+
+For each module M (in T1..T8):
+1. `git mv scripts/M.py src/quality/M.py`
+2. Update bare-name imports in all callers to `from src.quality.M import …`
+3. Run `pytest tests/ -q` — must show baseline count
+4. Run ruff — must be clean
+5. Commit: `refactor: migrate scripts/M.py to src/quality/M.py (#344)`
+
+### T9..T12 — Group B migrations (one module per commit)
+
+For each module M (in T9..T12):
+1. `git mv scripts/M.py src/backlog/M.py`
+2. Update `scripts/continuous_burndown.py` to `from src.backlog.M import …`
+3. Run tests + ruff
+4. Commit: `refactor: migrate scripts/M.py to src/backlog/M.py (#344)`
+
+### T13 — Convert skills_manager bare imports to fully-qualified
+
+Files: `tests/test_quality_system.py`, `tests/test_closed_loop_validation.py`.
+Change `from skills_manager import SkillsManager`
+to `from scripts.skills_manager import SkillsManager`.
+
+Verify pytest unchanged, commit.
+
+### T14 — Remove sys.path hack
+
+`tests/test_architecture_compliance.py:22`: remove
+`sys.path.insert(0, str(SCRIPTS_DIR))`. Keep `import sys` only if still
+used; otherwise remove that too. Keep `SCRIPTS_DIR` (used for file scan).
+
+Verify pytest unchanged, commit.
+
+### T15 — Move 12 originals to scripts/archived/
+
+Single commit: `git mv` all 12 to `scripts/archived/`. Run full test
+suite + ruff. Commit.
+
+### T16 — Update SPEC.md §2 and final verification
+
+Update the 12 KEEP entries marked `†` in SPEC.md §2 — they now
+classify as MIGRATED rather than KEEP. Add a note at the top of §2
+linking to this issue's PR.
+
+Final checks:
+- `pytest tests/ -q` shows baseline count
+- `ruff check --no-fix && ruff format --check` clean
+- `grep -rEn '^(from|import) (agent_reviewer|governance|chart_metrics|schema_validator|agent_metrics|defect_tracker|validate_closed_loop|backlog_groomer|ci_health_monitor|migrate_backlog_to_github|validate_documentation_accuracy|visual_qa_zones)\b' agents/ src/ tests/ mcp_servers/` returns ZERO results
+
+Commit and open PR.

--- a/docs/archive/plans/todo-issue-344-completed.md
+++ b/docs/archive/plans/todo-issue-344-completed.md
@@ -1,0 +1,43 @@
+# TODO: Migrate domain modules from scripts/ to src/ (#344)
+
+## In Progress
+
+- [ ] T16 — Open PR + close #344
+
+## Done
+
+- [x] T0  — Scaffold src/quality/ and src/backlog/ packages
+- [x] T1  — Migrate agent_reviewer.py to src/quality/
+- [x] T2  — Migrate governance.py to src/quality/
+- [x] T3  — Migrate chart_metrics.py to src/quality/
+- [x] T4  — Migrate schema_validator.py to src/quality/
+- [x] T5  — Migrate agent_metrics.py to src/quality/
+- [x] T6  — Migrate defect_tracker.py to src/quality/ (+ fix latent test mock bug)
+- [x] T7  — Migrate validate_closed_loop.py to src/quality/
+- [x] T8  — Migrate visual_qa_zones.py to src/quality/
+- [x] T9–T12 — Migrate backlog modules to src/backlog/ (single commit;
+       scripts/continuous_burndown.py imports all four atomically)
+- [x] T13 — Convert skills_manager bare imports to scripts.skills_manager
+- [x] T14 — Remove sys.path.insert from tests/test_architecture_compliance.py
+- [x] T15 — Originals removed from scripts/ via git mv (AC6 satisfied —
+       no empty stubs left to archive)
+- [x] T16 — Update SPEC.md §2 (12 †-rows moved to new MIGRATED section)
+
+## Verification
+
+- Pytest: 1756 passed, 84 skipped (matches baseline ±0)
+- Ruff check: All checks passed!
+- Ruff format: 229 files already formatted
+- No bare-name imports of any of the 12 migrated modules remain in
+  agents/, src/, tests/, or mcp_servers/
+- sys.path.insert(0, str(SCRIPTS_DIR)) removed from test_architecture_compliance.py:22
+
+## Acceptance criteria
+
+- AC1 (12 modules to src/): ✓
+- AC2 (callers updated): ✓ (agents/* + tests + scripts/continuous_burndown.py
+  + scripts/economist_agent.py + scripts/quality_dashboard.py)
+- AC3 (sys.path hack removed): ✓
+- AC4 (pytest same count): ✓ (1756 + 84 vs 1756 + 84 baseline)
+- AC5 (mock patch paths updated): ✓ (4× agent_metrics, 3× defect_tracker)
+- AC6 (originals archived/removed): ✓ (originals removed via git mv)

--- a/docs/specs/featured-image-handshake.md
+++ b/docs/specs/featured-image-handshake.md
@@ -1,6 +1,6 @@
 # SPEC: Path A — chart-rendered hero, human-in-the-loop featured image
 
-**Status**: DRAFT (awaiting human approval)
+**Status**: IMPLEMENTED in PR #404 (end-to-end human smoke pending)
 **GitHub issue**: oviney/economist-agents#403
 **Date**: 2026-05-19
 **Supersedes for default path**: `scripts/featured_image_agent.py` (DALL-E auto path remains opt-in for users with `OPENAI_API_KEY`)
@@ -72,7 +72,7 @@ logs/spike/
 docs/specs/
   featured-image-handshake.md     ← THIS FILE
 
-docs/CONTRIBUTING.md       ← +handoff workflow section
+CONTRIBUTING.md            ← +handoff workflow section
 
 tasks/
   plan.md                  ← per-feature plan

--- a/docs/specs/featured-image-handshake.md
+++ b/docs/specs/featured-image-handshake.md
@@ -1,0 +1,173 @@
+# SPEC: Path A — chart-rendered hero, human-in-the-loop featured image
+
+**Status**: DRAFT (awaiting human approval)
+**GitHub issue**: oviney/economist-agents#403
+**Date**: 2026-05-19
+**Supersedes for default path**: `scripts/featured_image_agent.py` (DALL-E auto path remains opt-in for users with `OPENAI_API_KEY`)
+
+---
+
+## 1. Objective
+
+Today the pipeline emits an article whose YAML frontmatter promises a hero image and a chart PNG that were never rendered. Deploy ships broken `<img>` tags. Two distinct defects:
+
+- **Defect A — chart never rendered.** Stage 3 produces `pipeline_chart.json` (a spec) and never converts it to a PNG. No matplotlib step exists.
+- **Defect B — featured image never generated.** `featured_image_agent.py` exists but is not wired; the writer prompt still emits an `image:` line that points to a nonexistent file.
+
+This spec defines a fix that:
+
+1. Always renders the chart locally via matplotlib (no API, no key, deterministic).
+2. Replaces the DALL-E auto-call with a **prompt-handoff handshake**: the pipeline generates an editorial illustration prompt, pauses, the human runs that prompt in ChatGPT web, drops the resulting PNG at a known path, then resumes Stage 4 which validates the image via multimodal Read.
+3. Lets the article ship without a hero image when the human declines the handshake — chart becomes the sole visual.
+
+## 2. Tech Stack
+
+- matplotlib (already in `requirements.txt`) for chart rendering
+- `claude_agent_sdk` for prompt synthesis (already wired)
+- Multimodal `Read` tool for image validation (Claude Code built-in; human-orchestrated, not pipeline-orchestrated — see Decision Q1)
+- No new dependencies, no new API keys
+
+## 3. Commands
+
+```bash
+# Stage 1-3 (research + writer + chart-spec + chart-render + prompt-synth):
+python -m src.agent_sdk.pipeline "topic"
+
+# After Stage 3 the pipeline pauses with a clear handoff message and exits 10
+# (new exit code). Output includes:
+#   - output/posts/<slug>.md             (article draft)
+#   - output/charts/<slug>.png           (rendered chart)
+#   - output/posts/<slug>.image_prompt.md (prompt to paste into ChatGPT)
+# Expected drop path: output/posts/images/<slug>.png
+
+# After dropping the image, OR choosing to skip:
+python -m src.agent_sdk.pipeline --resume <slug>              # with image
+python -m src.agent_sdk.pipeline --resume <slug> --no-image   # chart-only
+```
+
+## 4. Project Structure
+
+```
+src/agent_sdk/
+  pipeline.py              ← +--resume, +--no-image, +exit-code 10/11
+  stage3_runner.py         ← +chart_renderer call; +prompt-synth call
+  image_prompt_synth.py    ← NEW — composes editorial illustration prompt
+  chart_renderer.py        ← NEW — chart.json -> PNG via matplotlib
+
+scripts/
+  featured_image_agent.py  ← unchanged; remains opt-in for DALL-E path
+  publication_validator.py ← image: required -> image: optional-but-must-exist
+  defect_prevention_rules.py ← BUG-017 false-positive fix (path comparison)
+
+output/
+  posts/<slug>.md                 ← article (canonical location)
+  posts/<slug>.image_prompt.md    ← handoff artefact
+  posts/images/<slug>.png         ← human drops file here
+  charts/<slug>.png               ← chart renderer output
+  state/<slug>.json               ← stage-3 state file for --resume
+
+logs/spike/
+  pipeline_metrics.json    ← telemetry only (no longer canonical artefacts)
+
+docs/specs/
+  featured-image-handshake.md     ← THIS FILE
+
+docs/CONTRIBUTING.md       ← +handoff workflow section
+
+tasks/
+  plan.md                  ← per-feature plan
+  todo.md                  ← per-feature task list
+```
+
+## 5. Code Style
+
+Chart renderer interface (new module):
+
+```python
+def render_chart(spec: dict, output_path: Path) -> Path:
+    """Render an Economist-style chart from a Stage 3 chart spec.
+
+    Spec shape (existing, unchanged):
+        {"title": str, "subtitle": str,
+         "data": [{"metric": str, "value": float, "unit": str, "color": str}],
+         "source": str}
+
+    Returns the written path on success. Raises ChartRenderError on
+    malformed spec or matplotlib failure.
+    """
+```
+
+Prompt synthesis returns a single multi-line string in this format:
+
+```
+[Editorial illustration in The Economist's style — bold, high-contrast, no text]
+
+Subject: <one-sentence visual metaphor>
+Mood: <e.g. satirical, ominous, dispassionate>
+Composition: <e.g. one figure centred, three small figures at edges>
+Palette: Economist red #E3120B, deep navy, off-white, one accent
+Aspect ratio: 1792x1024 (landscape hero)
+Constraints: no text, no words, no captions, no logos
+```
+
+## 6. Testing Strategy
+
+- pytest, mirrors existing `tests/test_*` layout
+- New tests:
+  - `tests/test_chart_renderer.py` — spec → PNG; malformed spec raises; output file exists with expected dimensions
+  - `tests/test_image_prompt_synth.py` — given article + title, prompt contains required clauses (no-text constraint, aspect ratio, Economist palette)
+  - `tests/test_pipeline_handshake.py` — Stage 3 writes prompt artefact and exits 10; `--resume <slug>` reads dropped image and runs Stage 4; `--no-image` strips `image:` and runs Stage 4
+  - `tests/test_publication_validator_image_optional.py` — validator accepts articles without `image:`; still rejects when `image:` references a nonexistent file
+  - `tests/test_defect_prevention_bug017.py` — BUG-017 rule fires only when hero + chart point to the same asset (not when paths differ by directory)
+- Target ≥ 80% coverage on new modules; `src/quality/*` per-module gate (90%) unchanged
+- One end-to-end smoke test gated on `RUN_E2E=1` (skipped by default; runs the full real pipeline once)
+
+## 7. Boundaries
+
+**Always:**
+- Render the chart on every Stage 3 (no flag)
+- Generate the image prompt on every Stage 3 (no flag)
+- Run deterministic image gate (dims, format, size) in `--resume` before Stage 4
+- Articles can ship without `image:` line (chart-only mode)
+
+**Ask first:**
+- Adding any new third-party image service (Replicate, HF, Gemini, etc.)
+- Changing the editorial-illustration prompt template significantly
+- Modifying the chart spec schema (it is the LLM's output contract)
+- Removing the DALL-E opt-in path (`featured_image_agent.py`)
+
+**Never:**
+- Auto-call a paid image API as the default path
+- Ship an article whose `image:` references a file not on disk
+- Embed PII or proprietary data in the prompt artefact
+
+## 8. Success Criteria
+
+1. Running `python -m src.agent_sdk.pipeline "<topic>"` produces:
+   - `output/charts/<slug>.png` rendered from the spec (no API call), and
+   - `output/posts/<slug>.image_prompt.md` containing a complete, paste-ready prompt, and
+   - `output/state/<slug>.json` recording stage-3 state, and
+   - Exit code 10 and a clear "next step" message
+2. Running `--resume <slug>` after dropping a PNG at `output/posts/images/<slug>.png`:
+   - Deterministic gate validates dimensions (1792×1024 ±5%), format (PNG), size (>50 KB), file exists
+   - On pass: Stage 4 runs, validator green, article finalised with both `image:` and chart embed
+   - On reject: exit code 11 with a clear message naming the failed check
+3. Running `--resume <slug> --no-image`:
+   - Strips `image:` from frontmatter
+   - Validator accepts (chart-only is publishable)
+4. `deploy_to_blog.py` deploys without broken-image regressions in either mode
+5. Test suite ≥ 2150 passing; new modules ≥ 80% covered
+
+## 9. Locked Decisions
+
+| Open Q | Decision |
+|---|---|
+| Multimodal validation in pipeline? | No. Pipeline runs deterministic checks only (dims/format/size/exists). Visual-quality grade is human-orchestrated (operator reads the file via Read tool when in the loop). |
+| Handoff message verbosity? | Verbose. Full prompt embedded inline + exact drop-path + next command, so the human can copy-paste without context-switching back to chat. |
+| Resume timeout? | None. `--resume <slug>` is open-ended. State lives on disk; multiple pipelines can coexist identified by slug. |
+
+## 10. Notes
+
+- DALL-E auto path (`featured_image_agent.py`) stays in the repo as an opt-in for any user with `OPENAI_API_KEY`. Out of scope for this spec to remove it; in scope to NOT call it by default.
+- Slug derivation reuses whatever `deploy_to_blog.py` uses today (`article_path.stem`); to be verified in Task 3.2.
+- `logs/spike/pipeline_*` files become telemetry-only — the canonical artefacts live under `output/`.

--- a/mcp_servers/blog_deployer_server.py
+++ b/mcp_servers/blog_deployer_server.py
@@ -15,6 +15,7 @@ Usage:
 
 import logging
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -77,7 +78,7 @@ def list_deployable_articles(output_dir: str = "output") -> list[str]:
         return []
 
     articles = sorted(
-        output_path.glob("*.md"),
+        [*output_path.glob("posts/*.md"), *output_path.glob("*.md")],
         key=lambda p: p.stat().st_mtime,
         reverse=True,
     )
@@ -159,11 +160,25 @@ def deploy_article(
         content = content.replace("output/charts/", "/assets/charts/")
         (posts_dir / article.name).write_text(content)
 
-        # Copy associated charts
-        charts_dir = article.parent / "charts"
-        chart_file = charts_dir / f"{slug}.png"
-        if chart_file.exists():
-            shutil.copy2(chart_file, assets_charts / f"{slug}.png")
+        # Canonical handshake articles live under output/posts/, while
+        # legacy articles live directly under output/.
+        output_dir = (
+            article.parent.parent if article.parent.name == "posts" else article.parent
+        )
+
+        # Copy associated charts. A referenced chart without a source PNG
+        # would publish a broken <img>, so block the deploy explicitly.
+        charts_dir = output_dir / "charts"
+        chart_refs = sorted(set(re.findall(r"/assets/charts/([^)\s]+\.png)", content)))
+        chart_files = [charts_dir / Path(ref).name for ref in chart_refs]
+        if not chart_files:
+            fallback_chart = charts_dir / f"{slug}.png"
+            if fallback_chart.exists():
+                chart_files.append(fallback_chart)
+        for chart_file in chart_files:
+            if not chart_file.exists():
+                raise FileNotFoundError(f"Chart asset not found: {chart_file}")
+            shutil.copy2(chart_file, assets_charts / chart_file.name)
 
         # Copy associated images
         images_dir = article.parent / "images"

--- a/mcp_servers/publication_validator_server.py
+++ b/mcp_servers/publication_validator_server.py
@@ -49,6 +49,7 @@ mcp = FastMCP("publication-validator")
 def validate_for_publication(
     content: str,
     expected_date: str | None = None,
+    require_image_file: bool = False,
 ) -> dict:
     """Validate an article against publication quality gates.
 
@@ -59,6 +60,12 @@ def validate_for_publication(
         content: Full article text including YAML front matter.
         expected_date: Expected publication date in ``YYYY-MM-DD`` format.
             Defaults to today's date when omitted.
+        require_image_file: When True, an article with an ``image:`` line
+            must have the referenced PNG present on disk under
+            ``output/posts/images/``. Defaults to False because the MCP
+            tool is typically called on drafts before the hero asset
+            has been generated; deploy-time validation passes True
+            (#403).
 
     Returns:
         A dictionary with the following keys:
@@ -75,7 +82,10 @@ def validate_for_publication(
         len(content),
     )
 
-    validator = PublicationValidator(expected_date=expected_date)
+    validator = PublicationValidator(
+        expected_date=expected_date,
+        require_image_file=require_image_file,
+    )
     try:
         is_valid, issues = validator.validate(content)
     except Exception as exc:

--- a/mcp_servers/publication_validator_server.py
+++ b/mcp_servers/publication_validator_server.py
@@ -118,14 +118,15 @@ def validate_post(post_path: str) -> dict:
 
     * YAML front-matter delimiters are present (``---`` … ``---``).
     * Required fields are present: ``layout``, ``title``, ``date``,
-      ``author``, ``categories``, ``image``.
+      ``author``, ``categories``.
     * ``layout`` equals ``"post"``.
     * ``title`` is a non-empty string.
     * ``date`` matches ``YYYY-MM-DD`` format.
     * ``author`` is a non-empty string.
     * Every item in ``categories`` is one of :data:`VALID_CATEGORIES`.
-    * ``image`` refers to a path that exists on the filesystem (local paths
-      only; ``http://`` / ``https://`` URLs are accepted without checking).
+    * When present, ``image`` refers to a path that exists on the filesystem
+      (local paths only; ``http://`` / ``https://`` URLs are accepted without
+      checking). Chart-only articles may omit ``image`` (#403).
 
     Args:
         post_path: Absolute or relative path to the markdown post file.
@@ -191,7 +192,7 @@ def validate_post(post_path: str) -> dict:
     # ------------------------------------------------------------------
     # Required fields
     # ------------------------------------------------------------------
-    required_fields = ["layout", "title", "date", "author", "categories", "image"]
+    required_fields = ["layout", "title", "date", "author", "categories"]
     for field in required_fields:
         if field not in frontmatter:
             errors.append(f"Missing required field: {field}")
@@ -252,9 +253,7 @@ def validate_post(post_path: str) -> dict:
     # image — local paths must exist on the filesystem
     # ------------------------------------------------------------------
     image = frontmatter.get("image")
-    if image is None or (isinstance(image, str) and not image.strip()):
-        errors.append("image field must be a non-empty value")
-    else:
+    if image is not None and str(image).strip():
         image_str = str(image).strip()
         if not image_str.startswith(("http://", "https://")):
             image_path = Path(image_str)

--- a/scripts/defect_prevention_rules.py
+++ b/scripts/defect_prevention_rules.py
@@ -195,12 +195,18 @@ class DefectPrevention:
         return ""
 
     def _check_duplicate_chart(self, content: str, metadata: dict) -> str:
-        """BUG-017 Prevention: Detect duplicate chart display paths
+        """BUG-017 Prevention: Detect duplicate chart display paths.
 
-        Pattern: Jekyll 'image:' field + markdown embed = duplicate display
-        Root Cause: Requirements gap - unclear featured image vs embed
+        Pattern: Jekyll 'image:' field + markdown embed referencing the
+                 SAME file = the same chart renders twice on the page.
+        Root Cause: Requirements gap - unclear featured image vs embed.
 
-        Check: If chart markdown present, YAML must NOT have 'image:' field
+        Check: Only flag when the hero 'image:' path and a body chart
+        embed point at the SAME file. Different paths (e.g. hero at
+        /assets/images/X.png and chart at /assets/charts/X.png) are TWO
+        different assets — that's a hero + chart layout, not a duplicate
+        (#402 false-positive fix). Same basename in different
+        directories counts as different (treated as distinct files).
         """
         # Extract YAML frontmatter
         yaml_match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
@@ -209,18 +215,30 @@ class DefectPrevention:
 
         frontmatter = yaml_match.group(1)
 
-        # Check for image field in frontmatter
-        has_image_field = bool(re.search(r"^image:", frontmatter, re.MULTILINE))
+        # Hero image path from frontmatter
+        image_match = re.search(r"^image:\s*(\S+)", frontmatter, re.MULTILINE)
+        if not image_match:
+            return ""
+        hero_path = image_match.group(1).strip()
 
-        # Check for chart markdown in body
-        chart_pattern = r"!\[.*?\]\(.*?\.png\)"
-        has_chart_embed = bool(re.search(chart_pattern, content))
+        # All chart-like embeds in the body (PNG only — Jekyll convention)
+        chart_paths = re.findall(r"!\[[^\]]*\]\((\S+\.png)\)", content)
+        if not chart_paths:
+            return ""
 
-        if has_image_field and has_chart_embed:
+        # Normalise once (strip trailing slashes, collapse double-slashes)
+        def _norm(p: str) -> str:
+            return re.sub(r"/+", "/", p.rstrip("/"))
+
+        hero_norm = _norm(hero_path)
+        duplicates = [c for c in chart_paths if _norm(c) == hero_norm]
+        if duplicates:
             return (
-                "Duplicate chart display detected: 'image:' field in frontmatter "
-                "AND chart markdown in body. Remove 'image:' field. "
-                "This prevents BUG-017 (duplicate chart rendering)."
+                f"Duplicate chart display detected: hero image and body "
+                f"chart embed both reference {hero_norm!r}. Use distinct "
+                f"paths (e.g. hero in /assets/images/, chart in "
+                f"/assets/charts/) or remove one of the references. "
+                f"This prevents BUG-017 (duplicate chart rendering)."
             )
 
         return ""

--- a/scripts/deploy_to_blog.py
+++ b/scripts/deploy_to_blog.py
@@ -35,7 +35,6 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
 
 # Allow importing from scripts/ when run directly or via subprocess
 sys.path.insert(0, str(Path(__file__).parent))
@@ -64,7 +63,7 @@ class DeployResult:
 # ---------------------------------------------------------------------------
 
 
-def run_command(cmd: str, cwd: Optional[Path] = None) -> str:
+def run_command(cmd: str, cwd: Path | None = None) -> str:
     """Run *cmd* in a shell and return stdout (stripped).
 
     Raises :class:`DeployError` if the command exits non-zero.  When the
@@ -93,7 +92,8 @@ def find_latest_article() -> Path:
     """Find the most recent generated article.
 
     Prefers ``article_path.txt`` written by ``content-pipeline.yml`` (precise).
-    Falls back to mtime scan of ``output/*.md`` with a warning (fragile).
+    Falls back to an mtime scan of canonical ``output/posts/*.md`` and
+    legacy ``output/*.md`` locations with a warning (fragile).
     """
     article_path_file = Path("article_path.txt")
     if article_path_file.exists():
@@ -107,7 +107,7 @@ def find_latest_article() -> Path:
         )
 
     output_dir = Path("output")
-    articles = list(output_dir.glob("*.md"))
+    articles = list(output_dir.glob("posts/*.md")) + list(output_dir.glob("*.md"))
     if not articles:
         raise DeployError(
             "No articles found in output/ directory. "
@@ -225,12 +225,22 @@ def deploy(
     content = content.replace("output/charts/", "/assets/charts/")
     target_article.write_text(content)
 
-    # Copy chart PNG, if present.
-    chart_file = charts_dir / f"{slug}.png"
-    if chart_file.exists():
-        target_chart = assets_dir / f"{slug}.png"
+    # Copy each referenced chart PNG. An embedded chart without a source
+    # asset would ship a broken <img>, so fail before validation instead
+    # of silently skipping the copy.
+    chart_refs = sorted(set(re.findall(r"/assets/charts/([^)\s]+\.png)", content)))
+    chart_files = [charts_dir / Path(ref).name for ref in chart_refs]
+    if not chart_files:
+        fallback_chart = charts_dir / f"{slug}.png"
+        if fallback_chart.exists():
+            chart_files.append(fallback_chart)
+
+    for chart_file in chart_files:
+        if not chart_file.exists():
+            raise DeployError(f"Chart asset not found: {chart_file}")
+        target_chart = assets_dir / chart_file.name
         logger.info("Copying chart: %s → %s", chart_file, target_chart)
-        run_command(f"cp {chart_file} {target_chart}")
+        shutil.copy2(chart_file, target_chart)
 
     # Copy featured PNG + generate WebP — the blog's responsive-image
     # include emits a <source srcset="…webp">, so the .webp must exist
@@ -334,7 +344,7 @@ def deploy(
 - [ ] British spelling
 - [ ] References section
 
-**Charts:** {chart_file.name if chart_file.exists() else "None"}
+**Charts:** {", ".join(chart.name for chart in chart_files) or "None"}
 
 ## Automated Validation
 ```
@@ -369,7 +379,7 @@ def deploy(
 # ---------------------------------------------------------------------------
 
 
-def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Deploy article to blog via Pull Request"
     )
@@ -403,7 +413,7 @@ def _parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: Optional[list[str]] = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     """CLI entry point. Returns process exit code."""
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     args = _parse_args(argv)

--- a/scripts/publication_validator.py
+++ b/scripts/publication_validator.py
@@ -99,13 +99,25 @@ class PublicationValidator:
         },
     }
 
-    def __init__(self, expected_date: str | None = None):
+    def __init__(
+        self,
+        expected_date: str | None = None,
+        *,
+        require_image_file: bool = True,
+    ):
         """Args:
         expected_date: Expected publication date (YYYY-MM-DD).
                       Defaults to today.
+        require_image_file: When True (default), an article whose
+                      ``image:`` line points to ``/assets/images/X.png``
+                      must have a real file at ``output/posts/images/X.png``
+                      (#403). Set False in unit tests that don't care
+                      about hero-image presence or in pipeline modes that
+                      have not yet reached the deploy gate.
 
         """
         self.expected_date = expected_date or datetime.now().strftime("%Y-%m-%d")
+        self.require_image_file = require_image_file
         self.issues = []
 
         # Initialize defect prevention checker
@@ -551,65 +563,117 @@ class PublicationValidator:
             pass
 
     def _check_image_contract(self, content: str) -> None:
-        """Reject placeholder or incomplete image metadata for publication."""
+        """Validate hero-image metadata, with hero now optional (#403 slice 2).
+
+        Path A from docs/specs/featured-image-handshake.md: an article may
+        ship chart-only (no hero image at all). When the writer omits the
+        ``image:`` field, no hero-related metadata is required.
+
+        When ``image:`` IS present:
+        - The file it points to must exist on disk (caller resolves
+          ``/assets/images/X.png`` to ``output/posts/images/X.png``;
+          this matches what deploy_to_blog.py copies from).
+        - ``image_alt`` and ``image_caption`` are still required (a real
+          hero needs accessible alt + an editorial caption).
+        - ``blog-default.svg`` is still rejected as a fallback.
+        """
         try:
-            if content.startswith("---"):
-                parts = content.split("---", 2)
-                if len(parts) >= 2:
-                    front_matter = yaml.safe_load(parts[1])
-                    if not isinstance(front_matter, dict):
-                        return
+            if not content.startswith("---"):
+                return
+            parts = content.split("---", 2)
+            if len(parts) < 2:
+                return
+            front_matter = yaml.safe_load(parts[1])
+            if not isinstance(front_matter, dict):
+                return
 
-                    image = str(front_matter.get("image", "") or "").strip()
-                    image_alt = str(front_matter.get("image_alt", "") or "").strip()
-                    image_caption = str(
-                        front_matter.get("image_caption", "") or "",
-                    ).strip()
+            image = str(front_matter.get("image", "") or "").strip()
 
-                    if not image:
-                        self.issues.append(
-                            {
-                                "check": "missing_image",
-                                "severity": "CRITICAL",
-                                "message": "Article missing hero image",
-                                "details": "Production blog posts require article-specific hero imagery",
-                                "fix": "Set image to a real article asset path",
-                            },
-                        )
-                    elif "blog-default.svg" in image:
-                        self.issues.append(
-                            {
-                                "check": "default_image_fallback",
-                                "severity": "CRITICAL",
-                                "message": "Article still uses blog-default.svg fallback",
-                                "details": "Default hero fallback must not pass the publication gate",
-                                "fix": "Generate or assign article-specific hero art before publishing",
-                            },
-                        )
+            # Chart-only mode: no hero, no alt/caption requirements either.
+            if not image:
+                return
 
-                    if not image_alt:
-                        self.issues.append(
-                            {
-                                "check": "missing_image_alt",
-                                "severity": "CRITICAL",
-                                "message": "Article missing image_alt",
-                                "details": "Published posts require reader-facing alt text for hero art",
-                                "fix": "Add concise image_alt describing the visible scene",
-                            },
-                        )
+            image_alt = str(front_matter.get("image_alt", "") or "").strip()
+            image_caption = str(
+                front_matter.get("image_caption", "") or "",
+            ).strip()
 
-                    if not image_caption:
-                        self.issues.append(
-                            {
-                                "check": "missing_image_caption",
-                                "severity": "CRITICAL",
-                                "message": "Article missing image_caption",
-                                "details": "Published posts require an editorial hero caption",
-                                "fix": "Add image_caption explaining the image's editorial point",
-                            },
-                        )
+            if "blog-default.svg" in image:
+                self.issues.append(
+                    {
+                        "check": "default_image_fallback",
+                        "severity": "CRITICAL",
+                        "message": "Article still uses blog-default.svg fallback",
+                        "details": "Default hero fallback must not pass the publication gate",
+                        "fix": "Generate or assign article-specific hero art before publishing",
+                    },
+                )
+            elif self.require_image_file:
+                # Resolve /assets/images/X.png to the local working copy.
+                # Pre-deploy that's output/posts/images/X.png; during deploy
+                # the script CDs into the blog repo, so a relative path also
+                # picks up the just-copied file there.
+                resolved = self._resolve_image_path(image)
+                if resolved is not None and not resolved.exists():
+                    self.issues.append(
+                        {
+                            "check": "missing_image_file",
+                            "severity": "CRITICAL",
+                            "message": (
+                                f"Article references hero image {image!r} "
+                                f"but no file exists at {resolved}"
+                            ),
+                            "details": (
+                                "image: must point to a real PNG on disk; "
+                                "either generate the hero (run the prompt "
+                                "handshake) or remove the image: line to "
+                                "ship chart-only."
+                            ),
+                            "fix": (
+                                f"Drop the file at {resolved}, "
+                                f"or remove the image: line from frontmatter"
+                            ),
+                        },
+                    )
+
+            if not image_alt:
+                self.issues.append(
+                    {
+                        "check": "missing_image_alt",
+                        "severity": "CRITICAL",
+                        "message": "Article missing image_alt",
+                        "details": "Published posts require reader-facing alt text for hero art",
+                        "fix": "Add concise image_alt describing the visible scene",
+                    },
+                )
+
+            if not image_caption:
+                self.issues.append(
+                    {
+                        "check": "missing_image_caption",
+                        "severity": "CRITICAL",
+                        "message": "Article missing image_caption",
+                        "details": "Published posts require an editorial hero caption",
+                        "fix": "Add image_caption explaining the image's editorial point",
+                    },
+                )
         except Exception:
             pass
+
+    @staticmethod
+    def _resolve_image_path(image: str) -> Path | None:
+        """Map a Jekyll-style image: path to a local working-copy path.
+
+        ``/assets/images/X.png`` -> ``output/posts/images/X.png`` (the
+        location the human drops the file at after the prompt handshake
+        and the location deploy_to_blog.py copies from).
+
+        Returns None for paths that don't match the expected /assets/images/
+        prefix (covers absolute URLs and any other shapes we shouldn't
+        spuriously fail on)."""
+        if not image.startswith("/assets/images/"):
+            return None
+        return Path("output/posts/images") / Path(image).name
 
     def _check_heading_structure(self, content: str) -> None:
         """Reject inline markdown headings embedded inside paragraphs."""

--- a/src/agent_sdk/chart_renderer.py
+++ b/src/agent_sdk/chart_renderer.py
@@ -1,0 +1,191 @@
+"""Render Economist-style charts from Stage 3 chart specs.
+
+The Stage 3 graphics LLM produces a JSON spec describing a chart;
+this module turns that spec into a PNG. Deterministic, matplotlib-only —
+no LLM call, no API key, no per-run cost.
+
+Public surface
+--------------
+ChartRenderError
+    Raised when the spec is malformed or matplotlib fails.
+
+render_chart(spec: dict, output_path: Path) -> Path
+    Render a horizontal-bar chart to *output_path*. Returns the
+    written path. Auto-creates parent directories.
+
+Spec contract
+-------------
+::
+
+    {
+        "title": str,                 # required, non-empty
+        "subtitle": str,              # optional
+        "data": [                     # required, non-empty list
+            {
+                "metric": str,        # required per item
+                "value": float|int,   # required per item, numeric
+                "unit": str,          # optional (rendered in label)
+                "color": str,         # optional: "navy" | "red" | hex
+            }, ...
+        ],
+        "source": str,                # optional, shown bottom-left
+    }
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+# Lazy matplotlib import — matplotlib pulls in numpy + tk and adds ~1s to
+# every module import. Push that cost to render-time so tests that don't
+# render don't pay it.
+
+# Economist palette (matches scripts/generate_chart.py).
+_NAVY = "#17648d"
+_RED = "#e3120b"
+_BURGUNDY = "#843844"
+_BG_COLOR = "#f1f0e9"
+_GRAY_TEXT = "#666666"
+_GRID_COLOR = "#cccccc"
+
+_NAMED_COLORS: dict[str, str] = {
+    "navy": _NAVY,
+    "red": _RED,
+    "burgundy": _BURGUNDY,
+    "gray": _GRAY_TEXT,
+    "grey": _GRAY_TEXT,
+}
+
+
+class ChartRenderError(ValueError):
+    """Spec is malformed, or matplotlib failed to render."""
+
+
+def _resolve_color(name: str | None) -> str:
+    """Map spec color name to a hex value; passthrough if already hex."""
+    if not name:
+        return _NAVY
+    if name.startswith("#"):
+        return name
+    return _NAMED_COLORS.get(name.lower(), _NAVY)
+
+
+def _validate_spec(spec: Any) -> None:
+    """Reject any spec that would crash matplotlib partway through render."""
+    if not isinstance(spec, dict):
+        raise ChartRenderError(f"spec must be a dict, got {type(spec).__name__}")
+    title = spec.get("title")
+    if not isinstance(title, str) or not title.strip():
+        raise ChartRenderError("spec.title is required and must be a non-empty string")
+    data = spec.get("data")
+    if not isinstance(data, list) or not data:
+        raise ChartRenderError("spec.data is required and must be a non-empty list")
+    for i, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise ChartRenderError(f"spec.data[{i}] must be a dict")
+        if not isinstance(item.get("metric"), str) or not item["metric"].strip():
+            raise ChartRenderError(f"spec.data[{i}].metric is required")
+        value = item.get("value")
+        if not isinstance(value, (int, float)) or isinstance(value, bool):
+            raise ChartRenderError(
+                f"spec.data[{i}].value must be numeric, got {type(value).__name__}"
+            )
+
+
+def render_chart(spec: dict, output_path: Path) -> Path:
+    """Render *spec* to a PNG at *output_path*.
+
+    Args:
+        spec: Chart spec matching the contract documented at module top.
+        output_path: Destination PNG path. Parent directories are created
+            if missing.
+
+    Returns:
+        The resolved output path.
+
+    Raises:
+        ChartRenderError: spec is malformed or matplotlib raises.
+    """
+    _validate_spec(spec)
+
+    import matplotlib
+
+    matplotlib.use("Agg")  # headless backend
+    import matplotlib.pyplot as plt
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    title = spec["title"]
+    subtitle = spec.get("subtitle", "")
+    source = spec.get("source", "")
+    data = spec["data"]
+
+    metrics = [item["metric"] for item in data]
+    values = [float(item["value"]) for item in data]
+    colors = [_resolve_color(item.get("color")) for item in data]
+    unit = data[0].get("unit", "")  # use first item's unit for axis label
+
+    # 1200×800 PNG — figsize 12×8 inches at 100 dpi gives exactly that.
+    fig, ax = plt.subplots(figsize=(12, 8), dpi=100)
+    try:
+        fig.patch.set_facecolor(_BG_COLOR)
+        ax.set_facecolor(_BG_COLOR)
+
+        # Economist top-of-chart red rule (signature visual).
+        fig.add_artist(
+            plt.Rectangle(
+                (0.06, 0.93), 0.04, 0.012, color=_RED, transform=fig.transFigure
+            )
+        )
+
+        y_pos = list(range(len(metrics)))
+        ax.barh(y_pos, values, color=colors, height=0.6, edgecolor=_BG_COLOR)
+
+        # Inline value labels at end of each bar.
+        max_val = max(values) if values else 0
+        label_offset = max_val * 0.01 if max_val else 0.1
+        for y, v in zip(y_pos, values, strict=True):
+            label = f"{v:g}{(' ' + unit) if unit else ''}"
+            ax.text(
+                v + label_offset,
+                y,
+                label,
+                va="center",
+                ha="left",
+                fontsize=10,
+                color=_GRAY_TEXT,
+            )
+
+        ax.set_yticks(y_pos)
+        ax.set_yticklabels(metrics, fontsize=11, color="black")
+        ax.invert_yaxis()  # first metric on top — newspaper convention
+
+        # X axis: minimal — just a baseline grid for reference.
+        ax.tick_params(axis="x", colors=_GRAY_TEXT, labelsize=9)
+        ax.grid(axis="x", color=_GRID_COLOR, linewidth=0.5, alpha=0.6)
+        ax.set_axisbelow(True)
+
+        # Strip the chart-area frame; keep only the bottom rule.
+        for side in ("top", "right", "left"):
+            ax.spines[side].set_visible(False)
+        ax.spines["bottom"].set_color(_GRID_COLOR)
+
+        # Title + subtitle stacked above the chart, aligned with the red rule.
+        fig.text(0.06, 0.88, title, fontsize=18, fontweight="bold", color="black")
+        if subtitle:
+            fig.text(0.06, 0.84, subtitle, fontsize=11, color=_GRAY_TEXT)
+
+        # Source line at bottom-left, also aligned with the red rule.
+        if source:
+            fig.text(0.06, 0.03, f"Source: {source}", fontsize=9, color=_GRAY_TEXT)
+
+        plt.subplots_adjust(left=0.22, right=0.95, top=0.78, bottom=0.10)
+        fig.savefig(output_path, dpi=100, facecolor=_BG_COLOR)
+    except Exception as exc:
+        raise ChartRenderError(f"matplotlib render failed: {exc}") from exc
+    finally:
+        plt.close(fig)
+
+    return output_path

--- a/src/agent_sdk/image_gate.py
+++ b/src/agent_sdk/image_gate.py
@@ -1,0 +1,99 @@
+"""Deterministic image-quality gate for the --resume handshake (#403 slice 4).
+
+The visual-quality grade (mood matches the article, no awkward composition,
+etc.) is *not* attempted here — that is human-orchestrated, done by the
+operator reading the file via the Read tool before deploy. This module
+only enforces the things a computer can check reliably and quickly:
+
+- The file exists.
+- It is a real PNG (magic bytes match).
+- It is at least ``MIN_BYTES`` (50 KB) — guards against accidental
+  saves of empty/cropped/placeholder files.
+- It is approximately the expected aspect ratio (1792×1024 ±5% per
+  dimension) — matches the prompt's hard constraint.
+
+When any check fails, ``check_hero_image`` raises ``ImageGateError`` with
+a single human-readable message naming the specific failure. Callers
+(pipeline.py --resume) translate to exit code 11.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+EXPECTED_WIDTH = 1792
+EXPECTED_HEIGHT = 1024
+DIM_TOLERANCE_PCT = 5
+MIN_BYTES = 50 * 1024  # 50 KB
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+
+
+class ImageGateError(ValueError):
+    """Hero image failed one of the deterministic gate checks."""
+
+
+def _read_png_dimensions(path: Path) -> tuple[int, int]:
+    """Return (width, height) from a PNG IHDR chunk.
+
+    PNG byte layout (per RFC 2083):
+      bytes 0-7   = signature
+      bytes 8-15  = IHDR chunk length + type
+      bytes 16-23 = width (big-endian uint32), height (big-endian uint32)
+
+    Raises ImageGateError if the file is too short to contain the IHDR
+    or the magic bytes don't match.
+    """
+    try:
+        with path.open("rb") as f:
+            header = f.read(24)
+    except OSError as exc:
+        raise ImageGateError(f"could not open {path}: {exc}") from exc
+    if len(header) < 24 or header[:8] != PNG_MAGIC:
+        raise ImageGateError(f"{path} is not a valid PNG (magic bytes mismatch)")
+    width, height = struct.unpack(">II", header[16:24])
+    return width, height
+
+
+def _within_tolerance(actual: int, expected: int, pct: int) -> bool:
+    """True when ``actual`` is within ``pct%`` of ``expected``."""
+    if expected == 0:
+        return actual == 0
+    diff = abs(actual - expected)
+    return (diff * 100) <= (expected * pct)
+
+
+def check_hero_image(path: Path) -> None:
+    """Run all deterministic checks on the hero PNG at ``path``.
+
+    Raises:
+        ImageGateError: with a single human-readable message naming
+        the first failing check. (We stop at the first failure rather
+        than aggregating because each check is a prerequisite for the
+        next — there's no point measuring dimensions of a non-PNG.)
+    """
+    if not path.exists():
+        raise ImageGateError(
+            f"hero image not found at {path}. "
+            "Drop the PNG generated from the image prompt and re-run "
+            "`--resume`, or re-run with `--no-image` to ship chart-only."
+        )
+
+    size = path.stat().st_size
+    if size < MIN_BYTES:
+        raise ImageGateError(
+            f"hero image at {path} is {size} bytes (<{MIN_BYTES} byte "
+            "minimum). Looks like a placeholder or truncated download — "
+            "re-export from the image tool."
+        )
+
+    width, height = _read_png_dimensions(path)
+    width_ok = _within_tolerance(width, EXPECTED_WIDTH, DIM_TOLERANCE_PCT)
+    height_ok = _within_tolerance(height, EXPECTED_HEIGHT, DIM_TOLERANCE_PCT)
+    if not (width_ok and height_ok):
+        raise ImageGateError(
+            f"hero image dimensions {width}x{height} not within "
+            f"{DIM_TOLERANCE_PCT}% of expected "
+            f"{EXPECTED_WIDTH}x{EXPECTED_HEIGHT}. Re-generate at the "
+            "correct aspect ratio (1792x1024 landscape hero) or resize."
+        )

--- a/src/agent_sdk/image_prompt_synth.py
+++ b/src/agent_sdk/image_prompt_synth.py
@@ -1,0 +1,99 @@
+"""Compose the ChatGPT-handoff prompt for the featured image (#403 slice 3).
+
+The writer LLM already emits a strong ``image_alt`` line in the article
+frontmatter — a one-sentence visual concept (e.g. "An Economist-style
+editorial illustration of a lone product manager directing a swarm of
+robotic agents..."). This module wraps that concept in the hard
+constraints the image tool needs (aspect ratio, no-text, palette) and
+returns a paste-ready string for the human to drop into chat.openai.com
+or any other web-based image tool.
+
+This is deliberately a pure-Python template — no LLM call, no API key,
+no cost. The whole point of the handshake spec is to keep the image
+step zero-spend and human-paced.
+
+Signature change vs the plan
+----------------------------
+The plan listed ``compose_prompt(title, summary, themes)``. Switched to
+``compose_prompt(title, image_alt, image_caption)`` after looking at the
+writer's actual output: image_alt is already a fully-formed visual
+concept the LLM generated; image_caption is the editorial frame. That
+is strictly better than asking the writer for a summary + themes and
+then synthesising a visual concept from those (we'd be redoing work
+the writer already did).
+"""
+
+from __future__ import annotations
+
+# Hard constraints that every prompt must end with. Kept as a module
+# constant so tests can assert their presence and so the operator can
+# eyeball them when reviewing the artefact.
+_HARD_CONSTRAINTS: tuple[str, ...] = (
+    "Palette: Economist red #E3120B, deep navy, off-white, one accent",
+    "Aspect ratio: 1792x1024 (landscape hero)",
+    "Constraints: no text, no words, no captions, no logos in the image itself",
+    "Style: bold, high-contrast graphic editorial illustration "
+    "(not painterly, not photorealistic)",
+)
+
+# Cap on inputs we drop into the prompt. Generous enough to keep the
+# writer's full image_alt but short enough that a typo or stray HTML
+# from a copy-paste can't bloat the output into something unwieldy.
+_MAX_FIELD_LEN = 600
+
+
+class PromptSynthError(ValueError):
+    """Raised when required inputs are missing or empty."""
+
+
+def _clean(s: str) -> str:
+    """Trim, collapse internal whitespace, cap length."""
+    cleaned = " ".join(s.split())
+    return cleaned[:_MAX_FIELD_LEN]
+
+
+def compose_prompt(
+    title: str,
+    image_alt: str,
+    image_caption: str = "",
+) -> str:
+    """Return the ChatGPT-handoff prompt string for ``title``.
+
+    Args:
+        title: Article title (used for human-orientation only — the image
+            tool does not see it as a directive).
+        image_alt: The visual concept the writer LLM emitted in the
+            frontmatter ``image_alt`` field. This is the actual instruction
+            to the image tool.
+        image_caption: Optional editorial caption from the frontmatter.
+            When provided, surfaces as ``Editorial framing:`` so the
+            image tool understands the tone the article sets.
+
+    Returns:
+        A plain-text prompt ready to paste verbatim into the ChatGPT
+        web UI. No markdown, no code fences — image tools generally
+        ignore those anyway and they make the artefact harder to read.
+
+    Raises:
+        PromptSynthError: ``title`` or ``image_alt`` is empty/whitespace.
+    """
+    if not title or not title.strip():
+        raise PromptSynthError("title is required")
+    if not image_alt or not image_alt.strip():
+        raise PromptSynthError("image_alt is required")
+
+    title_c = _clean(title)
+    alt_c = _clean(image_alt)
+    caption_c = _clean(image_caption)
+
+    lines: list[str] = [
+        f'Generate an editorial illustration for the article "{title_c}".',
+        "",
+        f"Subject: {alt_c}",
+    ]
+    if caption_c:
+        lines.append(f"Editorial framing: {caption_c}")
+    lines.append("")
+    lines.extend(_HARD_CONSTRAINTS)
+
+    return "\n".join(lines)

--- a/src/agent_sdk/pipeline.py
+++ b/src/agent_sdk/pipeline.py
@@ -23,6 +23,7 @@ from src.agent_sdk._shared import (
     SearchProvidersEmptyError,
     SearchProvidersFailedError,
 )
+from src.agent_sdk.image_gate import ImageGateError, check_hero_image
 from src.agent_sdk.stage3_runner import (
     DEFAULT_GRAPHICS_MODEL,
     DEFAULT_WRITER_MODEL,
@@ -36,12 +37,16 @@ logger = logging.getLogger(__name__)
 
 COST_LOG_PATH = Path("logs/agent_sdk_costs.jsonl")
 
-# #403 slice 3: distinct exit codes so callers can branch on outcome.
+# Distinct exit codes so callers (CI, scripts, the operator) can branch
+# on outcome without parsing stderr.
 # 0  = full pipeline complete (Stage 3 + Stage 4 ran)
+# 1  = operator error (unknown slug, missing article)
 # 2  = SearchProvidersFailedError (transient/environmental)
 # 3  = SearchProvidersEmptyError (topic too narrow)
-# 10 = Stage 3 complete, awaiting image-prompt handshake
+# 10 = Stage 3 complete, awaiting image-prompt handshake (#403 slice 3)
+# 11 = --resume image-gate failure (missing/wrong-size/wrong-dims PNG) (#403 slice 4)
 EXIT_HANDSHAKE_PENDING = 10
+EXIT_IMAGE_GATE_FAILED = 11
 
 # #403 slice 3: slug-keyed canonical artefacts. logs/spike/* stays as
 # telemetry only (gitignored at the project level for the spike dir).
@@ -523,6 +528,16 @@ def _run_resume(slug: str, *, no_image: bool) -> None:
         logger.info(
             "Stripped image: / image_alt: / image_caption: from %s", article_path
         )
+    else:
+        # #403 slice 4: deterministic gate before Stage 4 — the dropped hero
+        # PNG must exist, be a real PNG, and match the expected aspect ratio.
+        # Visual-quality grade is human-orchestrated post-resume.
+        hero_path = IMAGE_DROP_DIR / f"{slug}.png"
+        try:
+            check_hero_image(hero_path)
+        except ImageGateError as exc:
+            print(f"\nImage gate failed: {exc}", file=sys.stderr)
+            sys.exit(EXIT_IMAGE_GATE_FAILED)
 
     start = time.perf_counter()
     stage4 = run_stage4(article, state["chart_data"])

--- a/src/agent_sdk/pipeline.py
+++ b/src/agent_sdk/pipeline.py
@@ -22,6 +22,7 @@ import orjson
 from src.agent_sdk._shared import (
     SearchProvidersEmptyError,
     SearchProvidersFailedError,
+    _auto_embed_chart,
 )
 from src.agent_sdk.image_gate import ImageGateError, check_hero_image
 from src.agent_sdk.stage3_runner import (
@@ -522,6 +523,10 @@ def _run_resume(slug: str, *, no_image: bool) -> None:
 
     article = article_path.read_text()
     if no_image:
+        # Stage 4 normally inserts the chart embed using the hero-image
+        # slug. Preserve that derivation before chart-only mode removes
+        # the hero metadata.
+        article = _auto_embed_chart(article)
         article = _strip_image_frontmatter(article)
         # Persist the stripped version so Stage 4 + deploy see the same shape
         article_path.write_text(article)

--- a/src/agent_sdk/pipeline.py
+++ b/src/agent_sdk/pipeline.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import re
 import sys
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -25,6 +26,7 @@ from src.agent_sdk._shared import (
 from src.agent_sdk.stage3_runner import (
     DEFAULT_GRAPHICS_MODEL,
     DEFAULT_WRITER_MODEL,
+    Stage3Result,
     run_stage3,
 )
 from src.agent_sdk.stage4_runner import run_stage4
@@ -33,6 +35,32 @@ from src.telemetry.roi_tracker import ROITracker, get_tracker
 logger = logging.getLogger(__name__)
 
 COST_LOG_PATH = Path("logs/agent_sdk_costs.jsonl")
+
+# #403 slice 3: distinct exit codes so callers can branch on outcome.
+# 0  = full pipeline complete (Stage 3 + Stage 4 ran)
+# 2  = SearchProvidersFailedError (transient/environmental)
+# 3  = SearchProvidersEmptyError (topic too narrow)
+# 10 = Stage 3 complete, awaiting image-prompt handshake
+EXIT_HANDSHAKE_PENDING = 10
+
+# #403 slice 3: slug-keyed canonical artefacts. logs/spike/* stays as
+# telemetry only (gitignored at the project level for the spike dir).
+POSTS_DIR = Path("output/posts")
+STATE_DIR = Path("output/state")
+IMAGE_DROP_DIR = Path("output/posts/images")
+
+
+@dataclass
+class HandshakeArtefacts:
+    """Paths emitted by Stage 3 when running in default (pause-for-image) mode."""
+
+    slug: str
+    article_path: Path
+    chart_path: Path | None
+    prompt_path: Path | None
+    state_path: Path
+    image_drop_path: Path  # where the human must drop the file
+
 
 # Logical agent name used when recording pipeline runs in the ROI tracker.
 ROI_PIPELINE_AGENT = "pipeline"
@@ -138,6 +166,103 @@ def _record_roi(result: PipelineResult) -> None:
     tracker.end_execution(execution_id)
 
 
+# ---------------------------------------------------------------------------
+# #403 slice 3: handshake state persistence + article-mutation helpers
+# ---------------------------------------------------------------------------
+
+
+def _state_path(slug: str) -> Path:
+    return STATE_DIR / f"{slug}.json"
+
+
+def _persist_stage3_artefacts(stage3: Stage3Result) -> HandshakeArtefacts:
+    """Write the slug-keyed canonical artefacts + state file after Stage 3.
+
+    The state file is the contract that ``--resume <slug>`` reads to pick
+    up where Stage 3 left off. chart_data is embedded directly because
+    Stage 4 needs the parsed dict (not a re-read of the chart JSON).
+    """
+    slug = stage3.slug
+    POSTS_DIR.mkdir(parents=True, exist_ok=True)
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+
+    article_path = POSTS_DIR / f"{slug}.md"
+    article_path.write_text(stage3.article)
+
+    state_path = _state_path(slug)
+    state = {
+        "schema_version": 1,
+        "slug": slug,
+        "topic": stage3.topic,
+        "stage3_completed_at": datetime.now(UTC).isoformat(),
+        "article_path": str(article_path),
+        "chart_path": str(stage3.chart_path) if stage3.chart_path else None,
+        "prompt_path": str(stage3.prompt_path) if stage3.prompt_path else None,
+        "chart_data": stage3.chart_data,
+        "metrics": {
+            "writer_cost_usd": stage3.writer_cost_usd,
+            "graphics_cost_usd": stage3.graphics_cost_usd,
+            "writer_model": stage3.writer_model,
+            "graphics_model": stage3.graphics_model,
+            "wall_seconds": stage3.wall_seconds,
+            "article_chars": stage3.article_chars,
+            "stat_audit_removed": stage3.stat_audit_removed,
+        },
+    }
+    state_path.write_bytes(orjson.dumps(state, option=orjson.OPT_INDENT_2))
+
+    return HandshakeArtefacts(
+        slug=slug,
+        article_path=article_path,
+        chart_path=stage3.chart_path,
+        prompt_path=stage3.prompt_path,
+        state_path=state_path,
+        image_drop_path=IMAGE_DROP_DIR / f"{slug}.png",
+    )
+
+
+def _load_state(slug: str) -> dict:
+    """Read the Stage 3 state file for ``slug``.
+
+    Raises ``FileNotFoundError`` with an operator-friendly message when
+    no state exists (user ran ``--resume`` against a slug that was never
+    generated)."""
+    path = _state_path(slug)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"No Stage 3 state for slug {slug!r} at {path}. "
+            f"Run `python -m src.agent_sdk.pipeline '<topic>'` first."
+        )
+    return orjson.loads(path.read_bytes())
+
+
+_FRONTMATTER_IMAGE_LINE = re.compile(r"^image(?:_alt|_caption)?:[^\n]*\n", re.MULTILINE)
+
+
+def _strip_image_frontmatter(article: str) -> str:
+    """Remove image:, image_alt:, image_caption: lines from frontmatter.
+
+    For ``--no-image`` mode: the article shipped chart-only. Stripping
+    these three fields satisfies the publication validator's "image:
+    optional, file must exist when present" contract (slice 2) without
+    leaving dangling alt/caption fields that reference an absent image.
+    Only the frontmatter (between the first two ``---`` lines) is
+    touched; body image syntax (chart embed) is left alone.
+    """
+    if not article.startswith("---"):
+        return article
+    parts = article.split("---", 2)
+    if len(parts) < 3:
+        return article
+    fm = _FRONTMATTER_IMAGE_LINE.sub("", parts[1])
+    return f"---{fm}---{parts[2]}"
+
+
+# ---------------------------------------------------------------------------
+# Existing cost-log + ROI helpers
+# ---------------------------------------------------------------------------
+
+
 def _append_cost_log(result: PipelineResult, total_wall_seconds: float) -> None:
     """Append a single JSON line summarising this run for spend tracking."""
     COST_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -198,57 +323,110 @@ def main() -> None:
             "exit. No LLM calls. Useful for iterating on topic phrasing."
         ),
     )
+    parser.add_argument(
+        "--resume",
+        metavar="SLUG",
+        help=(
+            "Resume after the image handshake. Reads Stage 3 state from "
+            "output/state/<slug>.json, runs Stage 4. Requires the human to "
+            "have dropped the hero PNG at output/posts/images/<slug>.png "
+            "first, unless --no-image is also set."
+        ),
+    )
+    parser.add_argument(
+        "--no-image",
+        action="store_true",
+        help=(
+            "With --resume: strip image: / image_alt: / image_caption: from "
+            "the article frontmatter before Stage 4. Ships chart-only."
+        ),
+    )
     args = parser.parse_args()
     topic = (
         " ".join(args.topic)
         if args.topic
         else "the productivity paradox of AI coding assistants"
     )
+
+    # --research-only path (Stage 0 only) — unchanged
+    if args.research_only:
+        _run_research_only(topic)
+        return
+
+    # --resume path (Stage 4 only) — #403 slice 3
+    if args.resume:
+        _run_resume(args.resume, no_image=args.no_image)
+        return
+
+    # Default path (Stage 3 only, then pause for image handshake) — #403 slice 3
     print(f"Running Agent SDK pipeline on: {topic}")
     print(f"  Models: writer={args.writer_model}, graphics={args.graphics_model}")
     print(
         f"  Budgets: writer ${args.writer_budget:.2f}, "
         f"graphics ${args.graphics_budget:.2f}",
     )
+    _run_stage3_with_handshake(
+        topic,
+        writer_budget=args.writer_budget,
+        graphics_budget=args.graphics_budget,
+        writer_model=args.writer_model,
+        graphics_model=args.graphics_model,
+    )
 
-    if args.research_only:
-        from src.agent_sdk._shared import build_research_brief
 
-        try:
-            brief = build_research_brief(topic)
-        except SearchProvidersFailedError as exc:
-            print(
-                "\nResearch aborted: providers failed.\n"
-                f"  {exc}\n"
-                "  Likely causes: provider outage, missing/invalid "
-                "SERPER_API_KEY, or query rejected by provider (HTTP 4xx). "
-                "Retry in a few minutes or rephrase the topic.",
-                file=sys.stderr,
-            )
-            sys.exit(2)
-        except SearchProvidersEmptyError as exc:
-            print(
-                "\nResearch aborted: providers ran but returned zero sources.\n"
-                f"  {exc}\n"
-                "  Likely cause: topic too narrow, too recent, or phrased in "
-                "a way that matches nothing. Try broadening or rephrasing.",
-                file=sys.stderr,
-            )
-            sys.exit(3)
-        print("\n--- Research brief ---\n")
-        print(brief)
-        return
+def _run_research_only(topic: str) -> None:
+    """Stage 0 only — print the assembled brief, no LLM calls."""
+    from src.agent_sdk._shared import build_research_brief
 
+    try:
+        brief = build_research_brief(topic)
+    except SearchProvidersFailedError as exc:
+        print(
+            "\nResearch aborted: providers failed.\n"
+            f"  {exc}\n"
+            "  Likely causes: provider outage, missing/invalid "
+            "SERPER_API_KEY, or query rejected by provider (HTTP 4xx). "
+            "Retry in a few minutes or rephrase the topic.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    except SearchProvidersEmptyError as exc:
+        print(
+            "\nResearch aborted: providers ran but returned zero sources.\n"
+            f"  {exc}\n"
+            "  Likely cause: topic too narrow, too recent, or phrased in "
+            "a way that matches nothing. Try broadening or rephrasing.",
+            file=sys.stderr,
+        )
+        sys.exit(3)
+    print("\n--- Research brief ---\n")
+    print(brief)
+
+
+def _run_stage3_with_handshake(
+    topic: str,
+    *,
+    writer_budget: float | None,
+    graphics_budget: float | None,
+    writer_model: str,
+    graphics_model: str,
+) -> None:
+    """Run Stage 3, persist artefacts, print the handshake message, exit 10.
+
+    The pause-for-image step is the heart of Path A (#403): the pipeline
+    does NOT auto-call a paid image API. Instead it produces a paste-ready
+    prompt and waits for the human to drop the PNG. Resume via --resume.
+    """
     start = time.perf_counter()
     try:
-        result = asyncio.run(
-            run_pipeline(
+        stage3 = asyncio.run(
+            run_stage3(
                 topic,
-                writer_budget_usd=args.writer_budget,
-                graphics_budget_usd=args.graphics_budget,
-                writer_model=args.writer_model,
-                graphics_model=args.graphics_model,
-            ),
+                writer_budget_usd=writer_budget,
+                graphics_budget_usd=graphics_budget,
+                writer_model=writer_model,
+                graphics_model=graphics_model,
+            )
         )
     except SearchProvidersFailedError as exc:
         print(
@@ -270,39 +448,105 @@ def main() -> None:
             file=sys.stderr,
         )
         sys.exit(3)
-    total = time.perf_counter() - start
+    elapsed = time.perf_counter() - start
 
-    out_dir = Path("logs/spike")
-    out_dir.mkdir(parents=True, exist_ok=True)
-    (out_dir / "pipeline_article.md").write_text(result.article)
-    (out_dir / "pipeline_chart.json").write_bytes(
-        orjson.dumps(result.chart_data, option=orjson.OPT_INDENT_2),
-    )
-    metrics = {
-        k: v for k, v in asdict(result).items() if k not in ("article", "chart_data")
-    }
-    metrics["total_wall_seconds"] = total
-    (out_dir / "pipeline_metrics.json").write_bytes(
-        orjson.dumps(metrics, option=orjson.OPT_INDENT_2),
-    )
+    artefacts = _persist_stage3_artefacts(stage3)
+    _print_handshake_message(stage3, artefacts, elapsed)
+    sys.exit(EXIT_HANDSHAKE_PENDING)
 
+
+def _print_handshake_message(
+    stage3: Stage3Result,
+    artefacts: HandshakeArtefacts,
+    wall_seconds: float,
+) -> None:
+    """Verbose, paste-ready operator instructions per spec Q2 lock-in."""
     print(
-        f"Pipeline complete: ${result.total_cost_usd:.4f} "
-        f"(writer ${result.writer_cost_usd:.4f} via {result.writer_model}, "
-        f"graphics ${result.graphics_cost_usd:.4f} via {result.graphics_model}), "
-        f"{total:.1f}s total (S3 {result.stage3_seconds:.1f}s + "
-        f"S4 {result.stage4_seconds:.2f}s), "
-        f"score={result.editorial_score}%, "
-        f"gates={result.gates_passed}/5, "
-        f"validator={'PASS' if result.publication_validator_passed else 'FAIL'}, "
-        f"ready={result.publication_ready}, "
-        f"{result.article_chars} chars.",
+        f"\nStage 3 complete: ${stage3.total_cost_usd:.4f} "
+        f"(writer ${stage3.writer_cost_usd:.4f} via {stage3.writer_model}, "
+        f"graphics ${stage3.graphics_cost_usd:.4f} via {stage3.graphics_model}), "
+        f"{wall_seconds:.1f}s, {stage3.article_chars} chars."
     )
-    if not result.publication_validator_passed:
+    print(f"\nSlug: {artefacts.slug}")
+    print("\nArtefacts:")
+    print(f"  Article: {artefacts.article_path}")
+    if artefacts.chart_path:
+        print(f"  Chart:   {artefacts.chart_path}")
+    if artefacts.prompt_path:
+        print(f"  Prompt:  {artefacts.prompt_path}")
+    print(f"  State:   {artefacts.state_path}")
+
+    print("\n" + "=" * 70)
+    if stage3.image_prompt:
+        print("HANDOFF — paste this prompt into chat.openai.com (image tool):")
+        print("=" * 70)
+        print(stage3.image_prompt)
+        print("=" * 70)
+        print(f"\nDrop the generated PNG here: {artefacts.image_drop_path}")
+        print(
+            "\nThen resume with:\n"
+            f"  python -m src.agent_sdk.pipeline --resume {artefacts.slug}\n"
+            "\nOr ship chart-only (no hero image) with:\n"
+            f"  python -m src.agent_sdk.pipeline --resume {artefacts.slug} --no-image"
+        )
+    else:
+        print(
+            "No image prompt was generated (writer omitted image_alt). "
+            "Resume in chart-only mode with:\n"
+            f"  python -m src.agent_sdk.pipeline --resume {artefacts.slug} --no-image"
+        )
+    print("=" * 70 + "\n")
+
+
+def _run_resume(slug: str, *, no_image: bool) -> None:
+    """Stage 4 only — load state, validate, optionally strip image fields."""
+    try:
+        state = _load_state(slug)
+    except FileNotFoundError as exc:
+        print(f"\n{exc}", file=sys.stderr)
+        sys.exit(1)
+
+    article_path = Path(state["article_path"])
+    if not article_path.exists():
+        print(
+            f"\nState references article at {article_path} but the file is "
+            "missing. Re-run Stage 3.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    article = article_path.read_text()
+    if no_image:
+        article = _strip_image_frontmatter(article)
+        # Persist the stripped version so Stage 4 + deploy see the same shape
+        article_path.write_text(article)
+        logger.info(
+            "Stripped image: / image_alt: / image_caption: from %s", article_path
+        )
+
+    start = time.perf_counter()
+    stage4 = run_stage4(article, state["chart_data"])
+    elapsed = time.perf_counter() - start
+
+    # Write back the polished article (Stage 4 may auto-fix British spelling etc.)
+    article_path.write_text(stage4.article)
+
+    s3_metrics = state.get("metrics", {})
+    total_cost = s3_metrics.get("writer_cost_usd", 0.0) + s3_metrics.get(
+        "graphics_cost_usd", 0.0
+    )
+    print(
+        f"\nStage 4 complete: ${total_cost:.4f} pipeline cost, "
+        f"{elapsed:.2f}s, score={stage4.editorial_score}%, "
+        f"gates={stage4.gates_passed}/5, "
+        f"validator={'PASS' if stage4.publication_validator_passed else 'FAIL'}, "
+        f"ready={stage4.publication_ready}."
+    )
+    if not stage4.publication_validator_passed:
         print("Validator issues:")
-        for issue in result.publication_validator_issues:
+        for issue in stage4.publication_validator_issues:
             print(f"  - {issue.get('check', '?')}: {issue.get('message', '?')}")
-    print("Artefacts: logs/spike/pipeline_{article.md,chart.json,metrics.json}")
+    print(f"Article: {article_path}")
 
 
 if __name__ == "__main__":

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -48,6 +48,7 @@ from src.agent_sdk._shared import (
     audit_article_stats as _audit_article_stats,
 )
 from src.agent_sdk.chart_renderer import ChartRenderError, render_chart
+from src.agent_sdk.image_prompt_synth import PromptSynthError, compose_prompt
 
 logger = logging.getLogger(__name__)
 
@@ -159,9 +160,30 @@ class Stage3Result:
     article_chars: int
     stat_audit_removed: int
     chart_path: Path | None = None  # #403 slice 1: rendered chart PNG
+    prompt_path: Path | None = None  # #403 slice 3: image-prompt artefact
+    slug: str = ""  # #403 slice 3: canonical slug for downstream resume
+    image_prompt: str = ""  # #403 slice 3: the prompt text itself
 
 
 _IMAGE_FIELD_PATTERN = re.compile(r"^image:\s*[^\n]*?/([^/\s]+)\.png", re.MULTILINE)
+_TITLE_FIELD_PATTERN = re.compile(r'^title:\s*["\']?(.*?)["\']?\s*$', re.MULTILINE)
+_IMAGE_ALT_PATTERN = re.compile(r'^image_alt:\s*["\']?(.*?)["\']?\s*$', re.MULTILINE)
+_IMAGE_CAPTION_PATTERN = re.compile(
+    r'^image_caption:\s*["\']?(.*?)["\']?\s*$', re.MULTILINE
+)
+
+
+def _extract_frontmatter_field(article: str, pattern: re.Pattern[str]) -> str:
+    """Return the first capture from ``pattern`` in the article's
+    frontmatter, or ``''`` if not found. Frontmatter is the block
+    between the first two ``---`` lines."""
+    if not article.startswith("---"):
+        return ""
+    parts = article.split("---", 2)
+    if len(parts) < 3:
+        return ""
+    match = pattern.search(parts[1])
+    return match.group(1).strip() if match else ""
 
 
 def _slug_for_chart(article: str, topic: str) -> str:
@@ -416,6 +438,33 @@ async def run_stage3(
     except ChartRenderError as exc:
         logger.warning("Chart render skipped (%s); proceeding without PNG", exc)
 
+    # #403 slice 3: synthesise the ChatGPT-handoff prompt and persist it
+    # as a sibling artefact. The prompt is built from the article's own
+    # image_alt + image_caption fields (already LLM-generated visual
+    # concepts) wrapped in the Economist hard constraints. Failure is
+    # non-fatal — the operator can still ship chart-only via --no-image.
+    image_prompt = ""
+    prompt_path: Path | None = None
+    try:
+        title = _extract_frontmatter_field(article, _TITLE_FIELD_PATTERN) or topic
+        image_alt = _extract_frontmatter_field(article, _IMAGE_ALT_PATTERN)
+        image_caption = _extract_frontmatter_field(article, _IMAGE_CAPTION_PATTERN)
+        if image_alt:
+            image_prompt = compose_prompt(
+                title=title, image_alt=image_alt, image_caption=image_caption
+            )
+            prompt_path = Path("output/posts") / f"{slug}.image_prompt.md"
+            prompt_path.parent.mkdir(parents=True, exist_ok=True)
+            prompt_path.write_text(image_prompt)
+            logger.info("Wrote image prompt artefact: %s", prompt_path)
+        else:
+            logger.info(
+                "No image_alt in frontmatter — skipping prompt artefact "
+                "(article will need --no-image at resume time)"
+            )
+    except PromptSynthError as exc:
+        logger.warning("Image prompt synthesis skipped (%s)", exc)
+
     elapsed = time.perf_counter() - start
 
     return Stage3Result(
@@ -432,6 +481,9 @@ async def run_stage3(
         article_chars=len(article),
         stat_audit_removed=max(stat_audit_removed, 0),
         chart_path=chart_path,
+        prompt_path=prompt_path,
+        slug=slug,
+        image_prompt=image_prompt,
     )
 
 

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -47,7 +47,7 @@ from src.agent_sdk._shared import (
 from src.agent_sdk._shared import (
     audit_article_stats as _audit_article_stats,
 )
-from src.agent_sdk.chart_renderer import ChartRenderError, render_chart
+from src.agent_sdk.chart_renderer import render_chart
 from src.agent_sdk.image_prompt_synth import PromptSynthError, compose_prompt
 
 logger = logging.getLogger(__name__)
@@ -427,16 +427,11 @@ async def run_stage3(
     )
     chart_data = _parse_chart_json(graphics_text)
 
-    # #403 slice 1: render the chart spec to a real PNG. A render failure
-    # is not fatal — articles can still ship chart-only or text-only;
-    # the deploy + validator slices handle missing PNGs gracefully.
+    # #403 slice 1: render the chart spec to a real PNG. Render failures
+    # are fatal because a missing chart would leave a broken body embed.
     slug = _slug_for_chart(article, topic)
-    chart_path: Path | None = None
-    try:
-        chart_path = render_chart(chart_data, Path("output/charts") / f"{slug}.png")
-        logger.info("Rendered chart: %s", chart_path)
-    except ChartRenderError as exc:
-        logger.warning("Chart render skipped (%s); proceeding without PNG", exc)
+    chart_path = render_chart(chart_data, Path("output/charts") / f"{slug}.png")
+    logger.info("Rendered chart: %s", chart_path)
 
     # #403 slice 3: synthesise the ChatGPT-handoff prompt and persist it
     # as a sibling artefact. The prompt is built from the article's own

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -47,6 +47,7 @@ from src.agent_sdk._shared import (
 from src.agent_sdk._shared import (
     audit_article_stats as _audit_article_stats,
 )
+from src.agent_sdk.chart_renderer import ChartRenderError, render_chart
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +158,26 @@ class Stage3Result:
     research_brief_chars: int
     article_chars: int
     stat_audit_removed: int
+    chart_path: Path | None = None  # #403 slice 1: rendered chart PNG
+
+
+_IMAGE_FIELD_PATTERN = re.compile(r"^image:\s*[^\n]*?/([^/\s]+)\.png", re.MULTILINE)
+
+
+def _slug_for_chart(article: str, topic: str) -> str:
+    """Derive the slug to use when naming the chart PNG.
+
+    Preferred source is the article's frontmatter ``image:`` line, since
+    that's what the deploy script and the in-article chart reference both
+    point at. Falls back to a kebab-cased topic when the writer omitted
+    the image field (slice 2 makes that optional). Slice 3 will replace
+    this with a single canonical slug derivation."""
+    match = _IMAGE_FIELD_PATTERN.search(article)
+    if match:
+        return match.group(1)
+    # Conservative kebab-case: lowercase, ASCII alnum + hyphens only.
+    safe = re.sub(r"[^a-z0-9]+", "-", topic.lower()).strip("-")
+    return safe or "untitled"
 
 
 _INLINE_HEADING_PATTERN = re.compile(r"[ \t]+(##+ +[A-Z][^\n]*)")
@@ -384,6 +405,17 @@ async def run_stage3(
     )
     chart_data = _parse_chart_json(graphics_text)
 
+    # #403 slice 1: render the chart spec to a real PNG. A render failure
+    # is not fatal — articles can still ship chart-only or text-only;
+    # the deploy + validator slices handle missing PNGs gracefully.
+    slug = _slug_for_chart(article, topic)
+    chart_path: Path | None = None
+    try:
+        chart_path = render_chart(chart_data, Path("output/charts") / f"{slug}.png")
+        logger.info("Rendered chart: %s", chart_path)
+    except ChartRenderError as exc:
+        logger.warning("Chart render skipped (%s); proceeding without PNG", exc)
+
     elapsed = time.perf_counter() - start
 
     return Stage3Result(
@@ -399,6 +431,7 @@ async def run_stage3(
         research_brief_chars=len(research_brief),
         article_chars=len(article),
         stat_audit_removed=max(stat_audit_removed, 0),
+        chart_path=chart_path,
     )
 
 

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -51,7 +51,7 @@ Task 4.1: deterministic image gate (dims, format, size, exists)
 
                 ▼ Slice 4 prereq
 
-Task 5.1: docs/CONTRIBUTING.md update — handoff workflow
+Task 5.1: CONTRIBUTING.md update — handoff workflow
 Task 5.2: full end-to-end smoke against last-merged main
 ```
 
@@ -141,10 +141,10 @@ Task 5.2: full end-to-end smoke against last-merged main
 
 ### Phase 5: Docs + smoke (slice 5)
 
-- **Task 5.1**: `docs/CONTRIBUTING.md` — handoff workflow section (3-paragraph + example commands)
+- **Task 5.1**: `CONTRIBUTING.md` — handoff workflow section (3-paragraph + example commands)
   - Acceptance: section "Generating a featured image" with the exact paste-prompt-into-ChatGPT workflow, drop path, and resume command
   - Verify: manual review
-  - Files: `docs/CONTRIBUTING.md`
+  - Files: `CONTRIBUTING.md`
   - Estimated scope: **XS**
 
 - **Task 5.2**: End-to-end smoke against last-merged main

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,104 +1,179 @@
-# Plan: Migrate domain modules from scripts/ to src/ (issue #344)
+# Plan: Path A — chart-rendered hero, human-in-the-loop featured image
 
-**Spec**: SPEC.md
-**ADR**: docs/adr/0010-scripts-to-src-migration.md
-**Date**: 2026-05-15
+**Spec**: [`docs/specs/featured-image-handshake.md`](../docs/specs/featured-image-handshake.md)
+**GitHub issue**: oviney/economist-agents#403
+**Date**: 2026-05-19
+
+## Decisions locked in from spec open questions
+
+- **Q1 (multimodal validation):** pipeline.py runs deterministic checks only (dimensions = 1792×1024 ±5%, file exists, file is PNG, file size > 50 KB). The visual-quality grade is done by the operator reading the file via the Read tool after `--resume` returns, before deploy is called. Keeps pipeline non-interactive.
+- **Q2 (handoff message):** verbose — full prompt embedded inline + exact drop-path + next command, so the user can copy-paste without context-switching back to chat.
+- **Q3 (timeout):** none. `--resume <slug>` is open-ended. State lives on disk; multiple pipelines can coexist identified by slug.
+
+## Structural change
+
+Articles move from `logs/spike/pipeline_article.md` (singleton) to `output/posts/<slug>.md` (slug-keyed). `logs/spike/pipeline_*` becomes telemetry-only. Enables `--resume <slug>` to address a specific in-flight article and matches `deploy_to_blog.py`'s mental model.
 
 ## Dependency graph
 
 ```
-T0 (create src/quality/, src/backlog/ packages)
-  │
-  ├──► T1..T8 (migrate Group A — 8 modules, one per slice)
-  │       ├── T1: agent_reviewer (callers: writer_agent, research_agent, test_quality_system)
-  │       ├── T2: governance (callers: writer_agent, research_agent, economist_agent)
-  │       ├── T3: chart_metrics (callers: graphics_agent, economist_agent)
-  │       ├── T4: schema_validator (callers: test_quality_system)
-  │       ├── T5: agent_metrics (callers: economist_agent, quality_dashboard, test_quality_dashboard mocks)
-  │       ├── T6: defect_tracker (callers: quality_dashboard, test_quality_dashboard mocks)
-  │       ├── T7: validate_closed_loop (callers: test_closed_loop_validation subprocess)
-  │       └── T8: visual_qa_zones (callers: economist_agent)
-  │
-  ├──► T9..T12 (migrate Group B — 4 modules, one per slice)
-  │       ├── T9:  backlog_groomer
-  │       ├── T10: ci_health_monitor
-  │       ├── T11: migrate_backlog_to_github
-  │       └── T12: validate_documentation_accuracy
-  │       (all four callers in scripts/continuous_burndown.py)
-  │
-  ├──► T13 (skills_manager: convert to fully-qualified imports)
-  │
-  ├──► T14 (remove sys.path hack from tests/test_architecture_compliance.py)
-  │
-  ├──► T15 (move 12 originals to scripts/archived/)
-  │
-  └──► T16 (update SPEC.md §2 - mark †-rows as MIGRATED; final verification)
+Task 1.1: chart_renderer module ──┐
+                                  │
+Task 1.2: wire chart_renderer ────┼──► Slice 1 done
+into stage3                       │     (chart PNGs render)
+                                  │
+Task 2.1: validator image:        │
+optional + file-must-exist        ├──► Slice 2 done
+                                  │     (text-only / chart-only articles ship)
+Task 2.2: BUG-017 false-pos fix ──┘
+(#402 root-cause)
+
+                ▼ Slice 1+2 prereq
+
+Task 3.1: image_prompt_synth module
+        │
+        ▼
+Task 3.2: slug-keyed output dirs + state file
+        │
+        ▼
+Task 3.3: pipeline --resume / --no-image / exit code 10
+        │
+        ▼
+Task 3.4: stage3_runner emits prompt artefact + handshake docs
+        │
+        └──► Slice 3 done (handshake works end-to-end)
+
+                ▼ Slice 3 prereq
+
+Task 4.1: deterministic image gate (dims, format, size, exists)
+        │
+        └──► Slice 4 done (--resume rejects malformed images)
+
+                ▼ Slice 4 prereq
+
+Task 5.1: docs/CONTRIBUTING.md update — handoff workflow
+Task 5.2: full end-to-end smoke against last-merged main
 ```
 
-Each task is one commit. Verification after every task:
-- `pytest tests/ -q` shows same pass/skip count as baseline
-- `ruff check --no-fix` and `ruff format --check` clean
+## Task list
 
-## Baseline
+### Phase 1: Chart actually renders (no API path; slice 1)
 
-Before starting, capture baseline test count: `pytest tests/ -q`.
-Expected: 1741 passed, 84 skipped (per worker brief).
+- **Task 1.1**: Create `src/agent_sdk/chart_renderer.py` with `render_chart(spec: dict, output_path: Path) -> Path`
+  - Acceptance: malformed spec raises `ChartRenderError`; valid spec produces a 1200×800 PNG matching Economist style (navy + accent red, single horizontal-bar layout)
+  - Verify: `pytest tests/test_chart_renderer.py -v` (new file), 5+ tests covering: valid render, dimensions, malformed spec, missing data field, output dir auto-created
+  - Files: `src/agent_sdk/chart_renderer.py` (new), `tests/test_chart_renderer.py` (new)
+  - Estimated scope: **S** (1-2 files, ~150 LOC + ~80 LOC tests)
 
-## Tasks
+- **Task 1.2**: Wire `chart_renderer` into `stage3_runner.run_stage3`
+  - Acceptance: after Stage 3, `output/charts/<slug>.png` exists. `Stage3Result` exposes `chart_path: Path`.
+  - Verify: existing `tests/test_stage3_*.py` still pass; new integration test asserts PNG file presence after run
+  - Files: `src/agent_sdk/stage3_runner.py`, `tests/test_stage3_runner.py` (new or extended)
+  - Estimated scope: **S** (1 file modified, 1 test file touched)
 
-### T0 — Create empty src/quality/ and src/backlog/ packages
+### Checkpoint A — after Slice 1
+- [ ] `pytest tests/ -q` green
+- [ ] Manual: run pipeline on a topic, confirm `output/charts/<slug>.png` exists and looks reasonable (eyeball chart visual)
+- [ ] Human reviews
 
-- Create `src/quality/__init__.py` (empty)
-- Create `src/backlog/__init__.py` (empty)
-- Verify: `pytest tests/ -q` unchanged
+### Phase 2: Validator accepts chart-only articles (slice 2)
 
-### T1..T8 — Group A migrations (one module per commit)
+- **Task 2.1**: `scripts/publication_validator.py` — `image:` becomes optional; when present, file must exist on disk
+  - Acceptance: article without `image:` line passes; article with `image: /assets/images/X.png` passes IFF file at expected resolved path exists; missing file → CRITICAL FAIL with file path in message
+  - Verify: new test file `tests/test_publication_validator_image_optional.py` with 4 cases (no-image-line, image-line-file-exists, image-line-file-missing, image-line-malformed-path); existing validator tests still pass
+  - Files: `scripts/publication_validator.py`, `tests/test_publication_validator_image_optional.py` (new)
+  - Estimated scope: **S**
 
-For each module M (in T1..T8):
-1. `git mv scripts/M.py src/quality/M.py`
-2. Update bare-name imports in all callers to `from src.quality.M import …`
-3. Run `pytest tests/ -q` — must show baseline count
-4. Run ruff — must be clean
-5. Commit: `refactor: migrate scripts/M.py to src/quality/M.py (#344)`
+- **Task 2.2**: Fix BUG-017 false positive (closes #402)
+  - Acceptance: rule only fires when `image:` path and chart embed path resolve to the same basename; rule does NOT fire when hero is `/assets/images/X.png` and chart is `/assets/charts/X.png`
+  - Verify: new test `tests/test_defect_prevention_bug017.py` (or extend existing), 3 cases: same-basename (fires), different-dir-same-name (does not fire), different-name (does not fire)
+  - Files: `scripts/defect_prevention_rules.py`, test file
+  - Estimated scope: **S**
 
-### T9..T12 — Group B migrations (one module per commit)
+### Checkpoint B — after Slice 2
+- [ ] `pytest tests/ -q` green
+- [ ] Manual: re-run validator on `logs/spike/pipeline_article.md` from yesterday with image: REMOVED — should pass cleanly (no BUG-017 false positive, no MISSING_IMAGE)
+- [ ] Human reviews
 
-For each module M (in T9..T12):
-1. `git mv scripts/M.py src/backlog/M.py`
-2. Update `scripts/continuous_burndown.py` to `from src.backlog.M import …`
-3. Run tests + ruff
-4. Commit: `refactor: migrate scripts/M.py to src/backlog/M.py (#344)`
+### Phase 3: Image prompt handshake (slice 3)
 
-### T13 — Convert skills_manager bare imports to fully-qualified
+- **Task 3.1**: Create `src/agent_sdk/image_prompt_synth.py` with `compose_prompt(title: str, summary: str, themes: list[str]) -> str`
+  - Acceptance: returned prompt is non-empty; includes hard constraints (no-text, aspect ratio 1792×1024, Economist palette); does not include code-fence or markdown
+  - Verify: `tests/test_image_prompt_synth.py`, 4 tests (constraints present, no markdown, empty inputs raise, long titles truncated)
+  - Files: new module + new test file
+  - Estimated scope: **S**
 
-Files: `tests/test_quality_system.py`, `tests/test_closed_loop_validation.py`.
-Change `from skills_manager import SkillsManager`
-to `from scripts.skills_manager import SkillsManager`.
+- **Task 3.2**: Slug-keyed output dirs + state file
+  - Acceptance: pipeline writes article to `output/posts/<slug>.md`, chart to `output/charts/<slug>.png`, state JSON to `output/state/<slug>.json` (contains topic, stage-3 timestamp, chart path, prompt path)
+  - Verify: integration test confirms file layout; existing tests that read `logs/spike/pipeline_article.md` updated
+  - Files: `src/agent_sdk/pipeline.py`, `src/agent_sdk/stage3_runner.py`, several test files
+  - Estimated scope: **M** (3-5 files)
 
-Verify pytest unchanged, commit.
+- **Task 3.3**: `pipeline.py` flags `--resume <slug>` and `--no-image`; exit code 10 from default Stage 3 completion
+  - Acceptance: bare `pipeline "topic"` does Stage 3, writes artefacts, prints handoff message, exits 10. `--resume <slug>` reads state, runs Stage 4. `--no-image` strips `image:` from frontmatter and runs Stage 4 without expecting a file.
+  - Verify: `tests/test_pipeline_handshake.py` with 3 cases (default-exits-10, resume-with-image, resume-no-image)
+  - Files: `src/agent_sdk/pipeline.py`, new test file
+  - Estimated scope: **M**
 
-### T14 — Remove sys.path hack
+- **Task 3.4**: stage3_runner writes prompt artefact + handoff message text
+  - Acceptance: after Stage 3, `output/posts/<slug>.image_prompt.md` exists with the full prompt; handoff message printed to stdout contains the prompt, the drop path, and the resume command
+  - Verify: existing tests still pass; new assertion checks file presence + content
+  - Files: `src/agent_sdk/stage3_runner.py`
+  - Estimated scope: **S**
 
-`tests/test_architecture_compliance.py:22`: remove
-`sys.path.insert(0, str(SCRIPTS_DIR))`. Keep `import sys` only if still
-used; otherwise remove that too. Keep `SCRIPTS_DIR` (used for file scan).
+### Checkpoint C — after Slice 3
+- [ ] `pytest tests/ -q` green
+- [ ] Manual: run pipeline on a topic. Confirm exit 10. Confirm prompt artefact exists. Run `--resume <slug> --no-image`. Confirm article finalised without `image:`.
+- [ ] Human reviews
 
-Verify pytest unchanged, commit.
+### Phase 4: Deterministic image gate (slice 4)
 
-### T15 — Move 12 originals to scripts/archived/
+- **Task 4.1**: Deterministic image validation in `--resume <slug>` (no `--no-image`)
+  - Acceptance: when image at `output/posts/images/<slug>.png` is missing or not 1792×1024 (±5%) or not PNG or <50 KB, `--resume` exits with code 11 and a clear message (separate from research errors 2/3 and handoff 10)
+  - Verify: `tests/test_image_gate.py` with 4 cases (passes, missing, wrong-dims, wrong-format)
+  - Files: `src/agent_sdk/pipeline.py` (or new `image_gate.py`), test file
+  - Estimated scope: **S**
 
-Single commit: `git mv` all 12 to `scripts/archived/`. Run full test
-suite + ruff. Commit.
+### Checkpoint D — after Slice 4
+- [ ] `pytest tests/ -q` green
+- [ ] Manual: drop a non-1792×1024 image, confirm exit 11. Drop a correct one, confirm Stage 4 completes.
+- [ ] Human reviews
 
-### T16 — Update SPEC.md §2 and final verification
+### Phase 5: Docs + smoke (slice 5)
 
-Update the 12 KEEP entries marked `†` in SPEC.md §2 — they now
-classify as MIGRATED rather than KEEP. Add a note at the top of §2
-linking to this issue's PR.
+- **Task 5.1**: `docs/CONTRIBUTING.md` — handoff workflow section (3-paragraph + example commands)
+  - Acceptance: section "Generating a featured image" with the exact paste-prompt-into-ChatGPT workflow, drop path, and resume command
+  - Verify: manual review
+  - Files: `docs/CONTRIBUTING.md`
+  - Estimated scope: **XS**
 
-Final checks:
-- `pytest tests/ -q` shows baseline count
-- `ruff check --no-fix && ruff format --check` clean
-- `grep -rEn '^(from|import) (agent_reviewer|governance|chart_metrics|schema_validator|agent_metrics|defect_tracker|validate_closed_loop|backlog_groomer|ci_health_monitor|migrate_backlog_to_github|validate_documentation_accuracy|visual_qa_zones)\b' agents/ src/ tests/ mcp_servers/` returns ZERO results
+- **Task 5.2**: End-to-end smoke against last-merged main
+  - Acceptance: run pipeline on a topic; do handshake; deploy to blog repo (dry-run); confirm no broken-image regressions
+  - Verify: deploy `--dry-run` exits 0 and the validation report inside it shows no MISSING_IMAGE or BUG-017
+  - Files: none — orchestration step
+  - Estimated scope: **XS**
 
-Commit and open PR.
+### Checkpoint E — done
+- [ ] All slices verified
+- [ ] PR opened (one branch, multiple commits per slice — matches the #388 / #395 pattern from this session)
+- [ ] Issue #402 closed in same PR
+- [ ] Human approves merge
+
+## Risks and mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Chart spec schema varies across topics | Medium | Task 1.1 raises `ChartRenderError` with clear field-by-field validation; test with 3 real captured spec JSONs |
+| Slug derivation differs from existing deploy script | High | Verify existing slug logic before Task 3.2; reuse the same function |
+| `output/posts/<slug>.md` collides across runs | Low | State file includes timestamp; same slug overwrites (current single-pipeline behaviour) |
+| Image-gate `±5% dimension tolerance` is wrong target | Low | Make tolerance configurable via env var; default 5% |
+| User runs `--resume` without ever running default | Low | State file absent → clear error: "no state for slug X; run pipeline 'topic' first" |
+
+## Parallelization
+
+- Tasks 1.1 + 2.1 + 2.2 + 3.1 are **independent** — could run in parallel if the workforce allowed. I will do them sequentially since I am the workforce.
+- Tasks 1.2 and 3.2 both touch `stage3_runner.py` — must be sequential.
+
+## Open questions
+
+None — Q1/Q2/Q3 from the spec are now locked. Will surface anything new in implementation.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -5,13 +5,27 @@
 
 ## In Progress
 
-_(none — awaiting human "go" before Phase 4 implementation)_
+- **Slice 4** — deterministic image gate
 
-## Slice 1 — chart actually renders
+## Slice 1 — chart actually renders ✅ (commit aaf56f3)
 
-- [ ] **Task 1.1**: create `src/agent_sdk/chart_renderer.py` + `tests/test_chart_renderer.py` (≥5 tests)
-- [ ] **Task 1.2**: wire `chart_renderer` into `stage3_runner.run_stage3`; `Stage3Result.chart_path` exposed
-- [ ] **Checkpoint A**: pytest green; manual eyeball of `output/charts/<slug>.png`
+- [x] **Task 1.1**: create `src/agent_sdk/chart_renderer.py` + `tests/test_chart_renderer.py` (15 tests)
+- [x] **Task 1.2**: wire `chart_renderer` into `stage3_runner.run_stage3`; `Stage3Result.chart_path` exposed (+6 wire-up tests)
+- [x] **Checkpoint A**: pytest 2166 green; manual eyeball confirms Economist-style chart on real spec
+
+## Slice 2 — validator accepts chart-only articles ✅ (commit 0f36289)
+
+- [x] **Task 2.1**: `publication_validator.py` — `image:` optional, file-must-exist via `require_image_file=True`
+- [x] **Task 2.2**: BUG-017 false-positive fix (path comparison); closes #402
+- [x] **Checkpoint B**: pytest 2183 green; yesterday's article minus image: validates cleanly
+
+## Slice 3 — image prompt handshake ✅
+
+- [x] **Task 3.1**: `src/agent_sdk/image_prompt_synth.py` + 12 tests
+- [x] **Task 3.2**: slug-keyed output dirs (`output/posts/<slug>.md`, `output/charts/<slug>.png`, `output/state/<slug>.json`)
+- [x] **Task 3.3**: `pipeline.py` `--resume <slug>` + `--no-image` + exit code 10
+- [x] **Task 3.4**: `stage3_runner` writes `output/posts/<slug>.image_prompt.md` + verbose handoff message
+- [x] **Checkpoint C**: pytest 2207 green (+12 handshake tests, +12 prompt synth tests)
 
 ## Slice 2 — validator accepts chart-only articles
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,43 +1,47 @@
-# TODO: Migrate domain modules from scripts/ to src/ (#344)
+# TODO: Path A — chart-rendered hero, human-in-the-loop featured image
+
+**Plan**: [`tasks/plan.md`](./plan.md)
+**Spec**: [`docs/specs/featured-image-handshake.md`](../docs/specs/featured-image-handshake.md)
 
 ## In Progress
 
-- [ ] T16 — Open PR + close #344
+_(none — awaiting human "go" before Phase 4 implementation)_
+
+## Slice 1 — chart actually renders
+
+- [ ] **Task 1.1**: create `src/agent_sdk/chart_renderer.py` + `tests/test_chart_renderer.py` (≥5 tests)
+- [ ] **Task 1.2**: wire `chart_renderer` into `stage3_runner.run_stage3`; `Stage3Result.chart_path` exposed
+- [ ] **Checkpoint A**: pytest green; manual eyeball of `output/charts/<slug>.png`
+
+## Slice 2 — validator accepts chart-only articles
+
+- [ ] **Task 2.1**: `publication_validator.py` — `image:` becomes optional, file-must-exist when present
+- [ ] **Task 2.2**: BUG-017 false-positive fix (path comparison; closes #402)
+- [ ] **Checkpoint B**: pytest green; manual re-validate yesterday's article
+
+## Slice 3 — image prompt handshake
+
+- [ ] **Task 3.1**: `src/agent_sdk/image_prompt_synth.py` + tests
+- [ ] **Task 3.2**: slug-keyed output dirs (`output/posts/<slug>.md`, `output/charts/<slug>.png`, `output/state/<slug>.json`)
+- [ ] **Task 3.3**: `pipeline.py` `--resume <slug>` + `--no-image` + exit code 10
+- [ ] **Task 3.4**: `stage3_runner` writes `output/posts/<slug>.image_prompt.md` + verbose handoff message
+- [ ] **Checkpoint C**: pytest green; manual run-pipeline → exit 10 → resume --no-image → article finalised
+
+## Slice 4 — deterministic image gate
+
+- [ ] **Task 4.1**: dims/format/size/exists check in `--resume`; exit 11 on fail
+- [ ] **Checkpoint D**: pytest green; manual wrong-dims rejection + correct-image acceptance
+
+## Slice 5 — docs + smoke
+
+- [ ] **Task 5.1**: `docs/CONTRIBUTING.md` — "Generating a featured image" section
+- [ ] **Task 5.2**: end-to-end smoke via deploy `--dry-run`
+- [ ] **Checkpoint E**: PR opened, #402 closed in same PR, human approves merge
 
 ## Done
 
-- [x] T0  — Scaffold src/quality/ and src/backlog/ packages
-- [x] T1  — Migrate agent_reviewer.py to src/quality/
-- [x] T2  — Migrate governance.py to src/quality/
-- [x] T3  — Migrate chart_metrics.py to src/quality/
-- [x] T4  — Migrate schema_validator.py to src/quality/
-- [x] T5  — Migrate agent_metrics.py to src/quality/
-- [x] T6  — Migrate defect_tracker.py to src/quality/ (+ fix latent test mock bug)
-- [x] T7  — Migrate validate_closed_loop.py to src/quality/
-- [x] T8  — Migrate visual_qa_zones.py to src/quality/
-- [x] T9–T12 — Migrate backlog modules to src/backlog/ (single commit;
-       scripts/continuous_burndown.py imports all four atomically)
-- [x] T13 — Convert skills_manager bare imports to scripts.skills_manager
-- [x] T14 — Remove sys.path.insert from tests/test_architecture_compliance.py
-- [x] T15 — Originals removed from scripts/ via git mv (AC6 satisfied —
-       no empty stubs left to archive)
-- [x] T16 — Update SPEC.md §2 (12 †-rows moved to new MIGRATED section)
+_(none yet — implementation has not started)_
 
-## Verification
+## Blocked / Deferred
 
-- Pytest: 1756 passed, 84 skipped (matches baseline ±0)
-- Ruff check: All checks passed!
-- Ruff format: 229 files already formatted
-- No bare-name imports of any of the 12 migrated modules remain in
-  agents/, src/, tests/, or mcp_servers/
-- sys.path.insert(0, str(SCRIPTS_DIR)) removed from test_architecture_compliance.py:22
-
-## Acceptance criteria
-
-- AC1 (12 modules to src/): ✓
-- AC2 (callers updated): ✓ (agents/* + tests + scripts/continuous_burndown.py
-  + scripts/economist_agent.py + scripts/quality_dashboard.py)
-- AC3 (sys.path hack removed): ✓
-- AC4 (pytest same count): ✓ (1756 + 84 vs 1756 + 84 baseline)
-- AC5 (mock patch paths updated): ✓ (4× agent_metrics, 3× defect_tracker)
-- AC6 (originals archived/removed): ✓ (originals removed via git mv)
+_(none)_

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -5,7 +5,7 @@
 
 ## In Progress
 
-- **Slice 5** — docs + smoke
+- **Open PR for #403** — branch ready, smoke deferred to human verification
 
 ## Slice 1 — chart actually renders ✅ (commit aaf56f3)
 
@@ -31,6 +31,12 @@
 
 - [x] **Task 4.1**: `src/agent_sdk/image_gate.py` + wired into `_run_resume` (exits 11 on fail)
 - [x] **Checkpoint D**: pytest 2218 green (+11 gate tests covering missing/too-small/wrong-magic/wrong-dims + 4 wire-up cases)
+
+## Slice 5 — docs + smoke
+
+- [x] **Task 5.1**: `CONTRIBUTING.md` — "Generating an article — the image handshake (#403)" section with exit codes table + workflow steps
+- [ ] **Task 5.2**: end-to-end smoke (deferred to human verification post-merge; requires ~$0.30 pipeline run + image generation in ChatGPT)
+- [ ] **Checkpoint E**: PR opened (next), #402 closed in same PR, human approves merge
 
 ## Slice 2 — validator accepts chart-only articles
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -5,7 +5,8 @@
 
 ## In Progress
 
-- **Open PR for #403** — branch ready, smoke deferred to human verification
+- [ ] **Task 5.2**: end-to-end smoke (deferred to human verification; requires a live pipeline run + image generation in ChatGPT)
+- [ ] **Checkpoint E**: human approves PR #404 for merge
 
 ## Slice 1 — chart actually renders ✅ (commit aaf56f3)
 
@@ -36,37 +37,14 @@
 
 - [x] **Task 5.1**: `CONTRIBUTING.md` — "Generating an article — the image handshake (#403)" section with exit codes table + workflow steps
 - [ ] **Task 5.2**: end-to-end smoke (deferred to human verification post-merge; requires ~$0.30 pipeline run + image generation in ChatGPT)
-- [ ] **Checkpoint E**: PR opened (next), #402 closed in same PR, human approves merge
-
-## Slice 2 — validator accepts chart-only articles
-
-- [ ] **Task 2.1**: `publication_validator.py` — `image:` becomes optional, file-must-exist when present
-- [ ] **Task 2.2**: BUG-017 false-positive fix (path comparison; closes #402)
-- [ ] **Checkpoint B**: pytest green; manual re-validate yesterday's article
-
-## Slice 3 — image prompt handshake
-
-- [ ] **Task 3.1**: `src/agent_sdk/image_prompt_synth.py` + tests
-- [ ] **Task 3.2**: slug-keyed output dirs (`output/posts/<slug>.md`, `output/charts/<slug>.png`, `output/state/<slug>.json`)
-- [ ] **Task 3.3**: `pipeline.py` `--resume <slug>` + `--no-image` + exit code 10
-- [ ] **Task 3.4**: `stage3_runner` writes `output/posts/<slug>.image_prompt.md` + verbose handoff message
-- [ ] **Checkpoint C**: pytest green; manual run-pipeline → exit 10 → resume --no-image → article finalised
-
-## Slice 4 — deterministic image gate
-
-- [ ] **Task 4.1**: dims/format/size/exists check in `--resume`; exit 11 on fail
-- [ ] **Checkpoint D**: pytest green; manual wrong-dims rejection + correct-image acceptance
-
-## Slice 5 — docs + smoke
-
-- [ ] **Task 5.1**: `docs/CONTRIBUTING.md` — "Generating a featured image" section
-- [ ] **Task 5.2**: end-to-end smoke via deploy `--dry-run`
-- [ ] **Checkpoint E**: PR opened, #402 closed in same PR, human approves merge
+- [x] **Checkpoint E**: PR #404 opened; closes #402 in same PR
 
 ## Done
 
-_(none yet — implementation has not started)_
+- [x] Slices 1-5 implementation complete in PR #404
+- [x] Automated regression coverage complete
 
 ## Blocked / Deferred
 
-_(none)_
+- [ ] Live end-to-end smoke: requires a paid Stage 3 run and human-generated hero image
+- [ ] `run_flow()` handshake migration: tracked separately in #410

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -5,7 +5,7 @@
 
 ## In Progress
 
-- **Slice 4** — deterministic image gate
+- **Slice 5** — docs + smoke
 
 ## Slice 1 — chart actually renders ✅ (commit aaf56f3)
 
@@ -26,6 +26,11 @@
 - [x] **Task 3.3**: `pipeline.py` `--resume <slug>` + `--no-image` + exit code 10
 - [x] **Task 3.4**: `stage3_runner` writes `output/posts/<slug>.image_prompt.md` + verbose handoff message
 - [x] **Checkpoint C**: pytest 2207 green (+12 handshake tests, +12 prompt synth tests)
+
+## Slice 4 — deterministic image gate ✅
+
+- [x] **Task 4.1**: `src/agent_sdk/image_gate.py` + wired into `_run_resume` (exits 11 on fail)
+- [x] **Checkpoint D**: pytest 2218 green (+11 gate tests covering missing/too-small/wrong-magic/wrong-dims + 4 wire-up cases)
 
 ## Slice 2 — validator accepts chart-only articles
 

--- a/tests/test_chart_renderer.py
+++ b/tests/test_chart_renderer.py
@@ -1,0 +1,158 @@
+"""Tests for src/agent_sdk/chart_renderer.py (#403 slice 1)."""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import pytest
+
+from src.agent_sdk.chart_renderer import ChartRenderError, render_chart
+
+
+def _valid_spec() -> dict:
+    """Mirrors the shape Stage 3's graphics LLM produces (see
+    logs/spike/pipeline_chart.json from the 2026-05-18 run)."""
+    return {
+        "title": "The Shrinking Squad",
+        "subtitle": "Typical product team composition, full-time human roles per squad",
+        "data": [
+            {"metric": "Product Manager", "value": 1, "unit": "role", "color": "navy"},
+            {"metric": "Designer", "value": 1, "unit": "role", "color": "navy"},
+            {"metric": "Tech Lead", "value": 1, "unit": "role", "color": "navy"},
+            {"metric": "Junior PM", "value": 0, "unit": "role", "color": "red"},
+        ],
+        "source": "Department of Product, 2025",
+    }
+
+
+def _png_dimensions(path: Path) -> tuple[int, int]:
+    """Read width, height from a PNG header without depending on Pillow.
+
+    PNG byte layout (per RFC 2083):
+      bytes 0-7   = signature
+      bytes 8-15  = IHDR chunk length + type
+      bytes 16-23 = width (big-endian uint32), height (big-endian uint32)
+    """
+    with path.open("rb") as f:
+        header = f.read(24)
+    assert header[:8] == b"\x89PNG\r\n\x1a\n", "not a PNG file"
+    width, height = struct.unpack(">II", header[16:24])
+    return width, height
+
+
+# ── valid render path ────────────────────────────────────────────────
+
+
+def test_valid_spec_writes_png_to_output_path(tmp_path: Path) -> None:
+    out = tmp_path / "chart.png"
+    result = render_chart(_valid_spec(), out)
+    assert result == out
+    assert out.exists()
+    assert out.stat().st_size > 0
+
+
+def test_rendered_png_has_expected_1200x800_dimensions(tmp_path: Path) -> None:
+    out = tmp_path / "chart.png"
+    render_chart(_valid_spec(), out)
+    w, h = _png_dimensions(out)
+    # Spec contract: 1200×800 (figsize 12×8 in @ 100 dpi).
+    assert (w, h) == (1200, 800), f"expected 1200×800, got {w}×{h}"
+
+
+def test_output_dir_auto_created(tmp_path: Path) -> None:
+    out = tmp_path / "deeply" / "nested" / "charts" / "x.png"
+    render_chart(_valid_spec(), out)
+    assert out.exists()
+
+
+def test_subtitle_and_source_are_optional(tmp_path: Path) -> None:
+    spec = _valid_spec()
+    del spec["subtitle"]
+    del spec["source"]
+    out = tmp_path / "chart.png"
+    render_chart(spec, out)
+    assert out.exists()
+
+
+def test_unit_omitted_when_missing(tmp_path: Path) -> None:
+    spec = _valid_spec()
+    for item in spec["data"]:
+        item.pop("unit", None)
+    out = tmp_path / "chart.png"
+    render_chart(spec, out)  # must not crash on missing unit
+    assert out.exists()
+
+
+def test_unknown_color_name_falls_back_to_navy(tmp_path: Path) -> None:
+    spec = _valid_spec()
+    spec["data"][0]["color"] = "chartreuse"  # not in the named palette
+    out = tmp_path / "chart.png"
+    render_chart(spec, out)
+    assert out.exists()
+
+
+def test_hex_color_passthrough(tmp_path: Path) -> None:
+    spec = _valid_spec()
+    spec["data"][0]["color"] = "#0066cc"
+    out = tmp_path / "chart.png"
+    render_chart(spec, out)
+    assert out.exists()
+
+
+# ── malformed spec rejection ─────────────────────────────────────────
+
+
+def test_non_dict_spec_raises(tmp_path: Path) -> None:
+    with pytest.raises(ChartRenderError, match="must be a dict"):
+        render_chart("not a dict", tmp_path / "x.png")  # type: ignore[arg-type]
+
+
+def test_missing_title_raises(tmp_path: Path) -> None:
+    spec = _valid_spec()
+    del spec["title"]
+    with pytest.raises(ChartRenderError, match="title"):
+        render_chart(spec, tmp_path / "x.png")
+
+
+def test_empty_title_raises(tmp_path: Path) -> None:
+    spec = _valid_spec()
+    spec["title"] = "   "
+    with pytest.raises(ChartRenderError, match="title"):
+        render_chart(spec, tmp_path / "x.png")
+
+
+def test_missing_data_raises(tmp_path: Path) -> None:
+    spec = _valid_spec()
+    del spec["data"]
+    with pytest.raises(ChartRenderError, match="data"):
+        render_chart(spec, tmp_path / "x.png")
+
+
+def test_empty_data_list_raises(tmp_path: Path) -> None:
+    spec = _valid_spec()
+    spec["data"] = []
+    with pytest.raises(ChartRenderError, match="non-empty list"):
+        render_chart(spec, tmp_path / "x.png")
+
+
+def test_non_numeric_value_raises(tmp_path: Path) -> None:
+    spec = _valid_spec()
+    spec["data"][0]["value"] = "lots"
+    with pytest.raises(ChartRenderError, match="numeric"):
+        render_chart(spec, tmp_path / "x.png")
+
+
+def test_boolean_value_raises(tmp_path: Path) -> None:
+    # bool is a subclass of int in Python — easy to misclassify as numeric.
+    spec = _valid_spec()
+    spec["data"][0]["value"] = True
+    with pytest.raises(ChartRenderError, match="numeric"):
+        render_chart(spec, tmp_path / "x.png")
+
+
+def test_missing_metric_in_data_item_raises(tmp_path: Path) -> None:
+    spec = _valid_spec()
+    del spec["data"][1]["metric"]
+    with pytest.raises(ChartRenderError, match="metric"):
+        render_chart(spec, tmp_path / "x.png")

--- a/tests/test_defect_prevention_bug017.py
+++ b/tests/test_defect_prevention_bug017.py
@@ -1,0 +1,98 @@
+"""Tests for #403 slice 2 (Task 2.2): BUG-017 false-positive fix.
+
+The old rule fired whenever an article had BOTH ``image:`` in frontmatter
+AND ANY ``![...]​(*.png)`` markdown in the body — regardless of whether
+the two paths point to the same file. Reproduced 2026-05-18 (issue #402):
+hero in ``/assets/images/X.png`` + chart in ``/assets/charts/X.png`` was
+flagged as duplicate even though they are two distinct files. Fix: only
+flag when the paths actually resolve to the same file.
+"""
+
+from __future__ import annotations
+
+from scripts.defect_prevention_rules import DefectPrevention
+
+
+def _article(image: str, body_chart_path: str | None) -> str:
+    """Build a minimal article with a frontmatter image and optional
+    body chart embed."""
+    fm = (
+        f"---\nlayout: post\ntitle: x\ndate: 2026-05-24\nimage: {image}\n---\n\nBody.\n"
+    )
+    if body_chart_path is not None:
+        fm += f"\n![Chart]({body_chart_path})\n"
+    return fm
+
+
+def _check(content: str) -> str:
+    """Run only _check_duplicate_chart and return its message ('' = clean)."""
+    return DefectPrevention()._check_duplicate_chart(content, {})
+
+
+# ── true positives — rule SHOULD fire ────────────────────────────────
+
+
+def test_fires_when_hero_and_chart_point_to_identical_path() -> None:
+    msg = _check(_article("/assets/charts/x.png", "/assets/charts/x.png"))
+    assert msg
+    assert "Duplicate chart display" in msg
+    assert "/assets/charts/x.png" in msg
+
+
+def test_fires_when_paths_differ_only_in_double_slash() -> None:
+    # Normalisation should treat /assets//charts/x.png and
+    # /assets/charts/x.png as the same path.
+    msg = _check(_article("/assets//charts/x.png", "/assets/charts/x.png"))
+    assert msg
+
+
+# ── false positives — rule MUST NOT fire (the #402 fix) ──────────────
+
+
+def test_does_not_fire_when_hero_in_images_and_chart_in_charts() -> None:
+    """The hero/chart layout that the writer prompt produces — different
+    parent dirs sharing the same slug. These are two real files; not a
+    duplicate. Reproduces #402."""
+    msg = _check(
+        _article(
+            "/assets/images/product-team-composition.png",
+            "/assets/charts/product-team-composition.png",
+        )
+    )
+    assert msg == ""
+
+
+def test_does_not_fire_when_paths_have_different_basenames() -> None:
+    msg = _check(_article("/assets/images/x.png", "/assets/charts/y.png"))
+    assert msg == ""
+
+
+def test_does_not_fire_when_no_chart_embed_in_body() -> None:
+    msg = _check(_article("/assets/images/x.png", None))
+    assert msg == ""
+
+
+def test_does_not_fire_when_no_image_field() -> None:
+    body = (
+        "---\nlayout: post\ntitle: x\ndate: 2026-05-24\n---\n\n"
+        "Body.\n\n![Chart](/assets/charts/x.png)\n"
+    )
+    assert _check(body) == ""
+
+
+def test_does_not_fire_on_article_without_frontmatter() -> None:
+    assert _check("Plain markdown, no frontmatter.\n") == ""
+
+
+# ── multiple chart embeds — fire if any matches the hero ─────────────
+
+
+def test_fires_when_any_of_multiple_chart_embeds_matches_hero() -> None:
+    body = (
+        "---\nlayout: post\ntitle: x\n"
+        "image: /assets/charts/x.png\n---\n\n"
+        "First chart: ![a](/assets/charts/other.png)\n"
+        "Second chart: ![b](/assets/charts/x.png)\n"
+    )
+    msg = _check(body)
+    assert msg

--- a/tests/test_deploy_to_blog.py
+++ b/tests/test_deploy_to_blog.py
@@ -355,7 +355,7 @@ class TestDeployCallable:
                 article_path=article_file,
                 blog_owner="test-owner",
                 blog_repo="test-blog",
-                token="fake-token",
+                token="t",
             )
 
         assert result.status == "published"
@@ -363,7 +363,7 @@ class TestDeployCallable:
         assert result.article_name.endswith("-callable-deploy.md")
         # Token must appear in the clone URL (used to push as well).
         assert any(
-            "git clone https://x-access-token:fake-token@github.com/test-owner/test-blog.git"
+            "git clone https://x-access-token:t@github.com/test-owner/test-blog.git"
             in c
             for c in commands
         ), "clone command missing or token not interpolated"
@@ -402,7 +402,7 @@ class TestDeployCallable:
                 article_path=article_file,
                 blog_owner="test-owner",
                 blog_repo="test-blog",
-                token="bad-token",
+                token="t",
             )
 
     def test_already_up_to_date_returns_status(
@@ -434,7 +434,7 @@ class TestDeployCallable:
                 article_path=article_file,
                 blog_owner="test-owner",
                 blog_repo="test-blog",
-                token="fake-token",
+                token="t",
             )
 
         assert result.status == "up_to_date"
@@ -466,7 +466,7 @@ class TestDeployCallable:
                 article_path=article_file,
                 blog_owner="test-owner",
                 blog_repo="test-blog",
-                token="fake-token",
+                token="t",
             )
 
         assert result.status == "validation_failed"
@@ -509,7 +509,7 @@ class TestDeployCallable:
                 article_path=article_file,
                 blog_owner="test-owner",
                 blog_repo="test-blog",
-                token="fake-token",
+                token="t",
                 dry_run=True,
             )
 
@@ -517,3 +517,46 @@ class TestDeployCallable:
         assert result.pushed is False
         assert not any(c.startswith("git push") for c in commands)
         assert not any("gh pr create" in c for c in commands)
+
+    def test_missing_referenced_chart_blocks_deploy(
+        self, article_file: Path, tmp_path: Path
+    ) -> None:
+        """A chart embed without a source PNG must never reach the blog."""
+        article_file.write_text(
+            article_file.read_text()
+            + f"\n![Chart](/assets/charts/{article_file.stem}.png)\n"
+        )
+
+        def fake_run_command(cmd: str, cwd=None) -> str:
+            if cmd.startswith("git clone"):
+                self._prepare_blog_clone(cwd)
+            return ""
+
+        with (
+            patch.object(dtb, "run_command", side_effect=fake_run_command),
+            patch(
+                "scripts.deploy_to_blog.validate_file",
+                return_value=(True, "All checks passed"),
+            ),
+            pytest.raises(dtb.DeployError, match="Chart asset not found"),
+        ):
+            dtb.deploy(
+                article_path=article_file,
+                blog_owner="test-owner",
+                blog_repo="test-blog",
+                token="t",
+                dry_run=True,
+            )
+
+
+def test_find_latest_article_falls_back_to_output_posts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The handshake stores canonical articles under output/posts/."""
+    monkeypatch.chdir(tmp_path)
+    posts = tmp_path / "output" / "posts"
+    posts.mkdir(parents=True)
+    article = posts / "newest.md"
+    article.write_text(_make_article())
+
+    assert dtb.find_latest_article() == Path("output/posts/newest.md")

--- a/tests/test_image_gate.py
+++ b/tests/test_image_gate.py
@@ -1,0 +1,231 @@
+"""Tests for src/agent_sdk/image_gate.py + pipeline wire-up (#403 slice 4)."""
+
+from __future__ import annotations
+
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+from src.agent_sdk import pipeline as pl
+from src.agent_sdk.image_gate import (
+    EXPECTED_HEIGHT,
+    EXPECTED_WIDTH,
+    MIN_BYTES,
+    ImageGateError,
+    check_hero_image,
+)
+from src.agent_sdk.pipeline import EXIT_IMAGE_GATE_FAILED, _persist_stage3_artefacts
+from src.agent_sdk.stage3_runner import Stage3Result
+
+
+def _fake_png(path: Path, *, width: int, height: int, body_size: int = 0) -> Path:
+    """Write a synthetic PNG with the given header dimensions.
+
+    Only the 24-byte signature + IHDR header is well-formed — body is
+    arbitrary padding bytes (the gate only inspects header + size).
+    Real matplotlib output is bigger; we pad to body_size when given.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = (
+        b"\x89PNG\r\n\x1a\n"  # signature
+        + b"\x00\x00\x00\x0dIHDR"  # IHDR chunk length + type
+        + struct.pack(">II", width, height)
+        + b"\x08\x06\x00\x00\x00"  # bit depth, color, etc.
+    )
+    body = b"\x00" * max(0, body_size - len(header))
+    path.write_bytes(header + body)
+    return path
+
+
+# ── _read + check_hero_image unit tests ──────────────────────────────
+
+
+class TestCheckHeroImage:
+    def test_passes_on_exactly_expected_dimensions_and_size(
+        self, tmp_path: Path
+    ) -> None:
+        path = _fake_png(
+            tmp_path / "hero.png",
+            width=EXPECTED_WIDTH,
+            height=EXPECTED_HEIGHT,
+            body_size=MIN_BYTES,
+        )
+        check_hero_image(path)  # must not raise
+
+    def test_passes_within_5_percent_dimension_tolerance(self, tmp_path: Path) -> None:
+        # 1700×1080 is within ±5% of 1792×1024 (well, 1080 is 5.5% over —
+        # use 1075 which is ~5%). Pick safer mid-tolerance values.
+        path = _fake_png(
+            tmp_path / "hero.png",
+            width=int(EXPECTED_WIDTH * 0.97),
+            height=int(EXPECTED_HEIGHT * 1.03),
+            body_size=MIN_BYTES,
+        )
+        check_hero_image(path)
+
+    def test_raises_when_file_missing(self, tmp_path: Path) -> None:
+        with pytest.raises(ImageGateError, match="not found"):
+            check_hero_image(tmp_path / "absent.png")
+
+    def test_raises_when_file_too_small(self, tmp_path: Path) -> None:
+        path = _fake_png(
+            tmp_path / "hero.png",
+            width=EXPECTED_WIDTH,
+            height=EXPECTED_HEIGHT,
+            body_size=0,  # only the 24-byte header
+        )
+        with pytest.raises(ImageGateError, match="byte minimum"):
+            check_hero_image(path)
+
+    def test_raises_when_magic_bytes_wrong(self, tmp_path: Path) -> None:
+        path = tmp_path / "hero.png"
+        path.write_bytes(b"\x00" * 100_000)  # not a PNG
+        with pytest.raises(ImageGateError, match="not a valid PNG"):
+            check_hero_image(path)
+
+    def test_raises_when_width_outside_tolerance(self, tmp_path: Path) -> None:
+        path = _fake_png(
+            tmp_path / "hero.png",
+            width=900,  # way too narrow
+            height=EXPECTED_HEIGHT,
+            body_size=MIN_BYTES,
+        )
+        with pytest.raises(ImageGateError, match="dimensions"):
+            check_hero_image(path)
+
+    def test_raises_when_height_outside_tolerance(self, tmp_path: Path) -> None:
+        path = _fake_png(
+            tmp_path / "hero.png",
+            width=EXPECTED_WIDTH,
+            height=2000,  # way too tall
+            body_size=MIN_BYTES,
+        )
+        with pytest.raises(ImageGateError, match="dimensions"):
+            check_hero_image(path)
+
+
+# ── pipeline wire-up: --resume exits 11 when gate fails ──────────────
+
+
+def _seed_state(tmp_path: Path) -> None:
+    """Helper: put a Stage 3 state file in place for --resume tests."""
+    s3 = Stage3Result(
+        topic="test",
+        article="---\nlayout: post\ntitle: T\nimage: /assets/images/g.png\n"
+        "image_alt: alt\nimage_caption: cap\n---\n\nBody.\n",
+        chart_data={"title": "T", "data": [{"metric": "A", "value": 1}]},
+        total_cost_usd=0.1,
+        writer_cost_usd=0.08,
+        graphics_cost_usd=0.02,
+        writer_model="claude-sonnet-4-6",
+        graphics_model="claude-sonnet-4-6",
+        wall_seconds=1.0,
+        research_brief_chars=100,
+        article_chars=80,
+        stat_audit_removed=0,
+        chart_path=None,
+        prompt_path=None,
+        slug="g",
+        image_prompt="prompt",
+    )
+    _persist_stage3_artefacts(s3)
+
+
+class TestResumeGateWireUp:
+    def test_resume_without_image_exits_11(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _seed_state(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["pipeline.py", "--resume", "g"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            pl.main()
+        assert exc_info.value.code == EXIT_IMAGE_GATE_FAILED
+        err = capsys.readouterr().err
+        assert "Image gate failed" in err
+        assert "not found" in err
+
+    def test_resume_with_valid_image_passes_gate_and_runs_stage4(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _seed_state(tmp_path)
+        _fake_png(
+            tmp_path / "output" / "posts" / "images" / "g.png",
+            width=EXPECTED_WIDTH,
+            height=EXPECTED_HEIGHT,
+            body_size=MIN_BYTES,
+        )
+        monkeypatch.setattr(sys, "argv", ["pipeline.py", "--resume", "g"])
+
+        from unittest.mock import MagicMock
+
+        fake_s4 = MagicMock(
+            article="polished",
+            editorial_score=90,
+            gates_passed=5,
+            publication_ready=True,
+            publication_validator_passed=True,
+            publication_validator_issues=[],
+        )
+        monkeypatch.setattr(
+            "src.agent_sdk.pipeline.run_stage4",
+            lambda article, chart: fake_s4,
+        )
+        pl.main()  # must not raise SystemExit
+
+    def test_no_image_mode_skips_gate_even_without_png(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--no-image is the explicit opt-out: gate is bypassed entirely."""
+        monkeypatch.chdir(tmp_path)
+        _seed_state(tmp_path)
+        # Deliberately do NOT create output/posts/images/g.png
+
+        monkeypatch.setattr(sys, "argv", ["pipeline.py", "--resume", "g", "--no-image"])
+        from unittest.mock import MagicMock
+
+        fake_s4 = MagicMock(
+            article="polished",
+            editorial_score=90,
+            gates_passed=5,
+            publication_ready=True,
+            publication_validator_passed=True,
+            publication_validator_issues=[],
+        )
+        monkeypatch.setattr(
+            "src.agent_sdk.pipeline.run_stage4",
+            lambda article, chart: fake_s4,
+        )
+        pl.main()  # must not raise SystemExit — gate was skipped
+
+    def test_resume_with_wrong_dims_exits_11_with_dim_message(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        _seed_state(tmp_path)
+        _fake_png(
+            tmp_path / "output" / "posts" / "images" / "g.png",
+            width=512,
+            height=512,
+            body_size=MIN_BYTES,
+        )
+        monkeypatch.setattr(sys, "argv", ["pipeline.py", "--resume", "g"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            pl.main()
+        assert exc_info.value.code == EXIT_IMAGE_GATE_FAILED
+        assert "dimensions 512x512" in capsys.readouterr().err

--- a/tests/test_image_prompt_synth.py
+++ b/tests/test_image_prompt_synth.py
@@ -1,0 +1,96 @@
+"""Tests for src/agent_sdk/image_prompt_synth.py (#403 slice 3, Task 3.1)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.agent_sdk.image_prompt_synth import (
+    PromptSynthError,
+    compose_prompt,
+)
+
+
+def test_contains_all_hard_constraints() -> None:
+    out = compose_prompt(title="X", image_alt="A scene description")
+    assert "Aspect ratio: 1792x1024" in out
+    assert "Economist red #E3120B" in out
+    assert "no text, no words, no captions" in out
+    assert "bold, high-contrast" in out
+
+
+def test_title_appears_for_human_orientation() -> None:
+    out = compose_prompt(
+        title="Three People and a Fleet",
+        image_alt="A scene of three figures and many small robots",
+    )
+    assert "Three People and a Fleet" in out
+
+
+def test_image_alt_appears_as_subject_directive() -> None:
+    alt = (
+        "An Economist-style editorial illustration of a lone product "
+        "manager directing a swarm of robotic agents"
+    )
+    out = compose_prompt(title="X", image_alt=alt)
+    assert alt in out
+    assert "Subject:" in out
+
+
+def test_image_caption_surfaces_as_editorial_framing_when_provided() -> None:
+    out = compose_prompt(
+        title="X",
+        image_alt="alt text",
+        image_caption="Fewer humans does not mean fewer decisions",
+    )
+    assert "Editorial framing:" in out
+    assert "Fewer humans does not mean fewer decisions" in out
+
+
+def test_image_caption_omitted_when_empty() -> None:
+    out = compose_prompt(title="X", image_alt="alt", image_caption="")
+    assert "Editorial framing:" not in out
+
+
+def test_output_contains_no_markdown_code_fences() -> None:
+    # Image tools either ignore markdown or render it literally — both
+    # are bad. The artefact must be plain text.
+    out = compose_prompt(title="X", image_alt="alt")
+    assert "```" not in out
+    assert "**" not in out
+
+
+def test_output_is_a_single_string_with_newlines() -> None:
+    out = compose_prompt(title="X", image_alt="alt")
+    assert isinstance(out, str)
+    assert "\n" in out  # multi-line, not collapsed
+
+
+def test_internal_whitespace_in_inputs_is_collapsed() -> None:
+    # Defensive: a copy-pasted alt may have stray tabs / double spaces.
+    out = compose_prompt(
+        title="X",
+        image_alt="A scene   with\tlots\n\nof   whitespace",
+    )
+    assert "A scene with lots of whitespace" in out
+
+
+def test_long_inputs_truncated_to_protect_against_bloat() -> None:
+    huge = "X" * 5000
+    out = compose_prompt(title=huge, image_alt=huge)
+    # 600 cap on each field; total output bounded.
+    assert len(out) < 3000
+
+
+def test_empty_title_raises() -> None:
+    with pytest.raises(PromptSynthError, match="title"):
+        compose_prompt(title="", image_alt="alt")
+
+
+def test_whitespace_only_title_raises() -> None:
+    with pytest.raises(PromptSynthError, match="title"):
+        compose_prompt(title="   \n\t", image_alt="alt")
+
+
+def test_empty_image_alt_raises() -> None:
+    with pytest.raises(PromptSynthError, match="image_alt"):
+        compose_prompt(title="X", image_alt="")

--- a/tests/test_malformed_article_guard.py
+++ b/tests/test_malformed_article_guard.py
@@ -10,6 +10,7 @@ Verifies that:
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -83,8 +84,15 @@ class TestMalformedArticleError:
             patch(
                 "src.agent_sdk.stage3_runner._collect_text",
                 new=AsyncMock(
-                    side_effect=[(valid, 0.01), ('{"title":"Chart","data":[]}', 0.005)]
+                    side_effect=[
+                        (valid, 0.01),
+                        ('{"title":"Chart","data":[{"metric":"A","value":1}]}', 0.005),
+                    ]
                 ),
+            ),
+            patch(
+                "src.agent_sdk.stage3_runner.render_chart",
+                return_value=Path("output/charts/test.png"),
             ),
         ):
             result = asyncio.run(run_stage3("AI Testing"))

--- a/tests/test_mcp_servers/test_blog_deployer_server.py
+++ b/tests/test_mcp_servers/test_blog_deployer_server.py
@@ -83,6 +83,19 @@ class TestListDeployableArticles:
         assert len(result) == 1
         assert "real-article" in result[0]
 
+    def test_returns_articles_from_canonical_output_posts_dir(
+        self, tmp_path: Path
+    ) -> None:
+        from mcp_servers.blog_deployer_server import list_deployable_articles
+
+        posts_dir = tmp_path / "output" / "posts"
+        posts_dir.mkdir(parents=True)
+        (posts_dir / "canonical-article.md").write_text("---\n---\n")
+
+        result = list_deployable_articles(str(tmp_path / "output"))
+
+        assert result == [str(posts_dir / "canonical-article.md")]
+
 
 class TestDeployArticle:
     """Tests for deploy_article tool."""
@@ -180,6 +193,9 @@ class TestDeployArticle:
         # Article with output/charts/ path that needs rewriting
         output_dir = tmp_path / "output"
         output_dir.mkdir()
+        charts_dir = output_dir / "charts"
+        charts_dir.mkdir()
+        (charts_dir / "my-chart.png").write_bytes(b"png")
         article = output_dir / "2026-04-05-chart-article.md"
         article.write_text(
             "---\nlayout: post\ntitle: Charts\ndate: 2026-04-05\n---\n\n"
@@ -188,6 +204,62 @@ class TestDeployArticle:
 
         result = deploy_article(str(article), "oviney/blog")
         assert result["success"] is True
+
+    @patch("mcp_servers.blog_deployer_server._run_command")
+    def test_missing_referenced_chart_blocks_canonical_deploy(
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from mcp_servers.blog_deployer_server import deploy_article
+
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        mock_run.return_value = "https://github.com/oviney/blog/pull/1"
+
+        posts_dir = tmp_path / "output" / "posts"
+        posts_dir.mkdir(parents=True)
+        article = posts_dir / "chart-article.md"
+        article.write_text(
+            "---\nlayout: post\ntitle: Charts\ndate: 2026-04-05\n---\n\n"
+            "![Chart](/assets/charts/chart-article.png)\n",
+        )
+
+        result = deploy_article(str(article), "oviney/blog")
+
+        assert result["success"] is False
+        assert "Chart asset not found" in result["error"]
+
+    @patch("mcp_servers.blog_deployer_server.shutil.copy2")
+    @patch("mcp_servers.blog_deployer_server._run_command")
+    def test_copies_referenced_chart_from_canonical_output_layout(
+        self,
+        mock_run: MagicMock,
+        mock_copy: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from mcp_servers.blog_deployer_server import deploy_article
+
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        mock_run.return_value = "https://github.com/oviney/blog/pull/1"
+
+        posts_dir = tmp_path / "output" / "posts"
+        posts_dir.mkdir(parents=True)
+        charts_dir = tmp_path / "output" / "charts"
+        charts_dir.mkdir()
+        chart = charts_dir / "chart-article.png"
+        chart.write_bytes(b"png")
+        article = posts_dir / "chart-article.md"
+        article.write_text(
+            "---\nlayout: post\ntitle: Charts\ndate: 2026-04-05\n---\n\n"
+            "![Chart](/assets/charts/chart-article.png)\n",
+        )
+
+        result = deploy_article(str(article), "oviney/blog")
+
+        assert result["success"] is True
+        assert any(call.args[0] == chart for call in mock_copy.call_args_list)
 
 
 class TestMcpServerRegistration:

--- a/tests/test_mcp_servers/test_publication_validator_server.py
+++ b/tests/test_mcp_servers/test_publication_validator_server.py
@@ -6,8 +6,13 @@ and returns the expected result structure.
 """
 
 import asyncio
+from pathlib import Path
 
-from mcp_servers.publication_validator_server import mcp, validate_for_publication
+from mcp_servers.publication_validator_server import (
+    mcp,
+    validate_for_publication,
+    validate_post,
+)
 
 # ---------------------------------------------------------------------------
 # Article helpers (mirrors test_publication_validator.py helpers)
@@ -262,3 +267,22 @@ class TestMcpToolRegistered:
         tools = asyncio.run(mcp.list_tools())
         tool = next(t for t in tools if t.name == "validate_for_publication")
         assert tool.description
+
+
+def test_validate_post_accepts_chart_only_article(tmp_path: Path) -> None:
+    """The MCP file validator must match #403's optional-hero contract."""
+    article = tmp_path / "chart-only.md"
+    article.write_text(
+        "---\n"
+        "layout: post\n"
+        'title: "Chart Only"\n'
+        "date: 2026-05-30\n"
+        'author: "Ouray Viney"\n'
+        'categories: ["software-engineering"]\n'
+        "---\n\n"
+        "Body.\n"
+    )
+
+    result = validate_post(str(article))
+
+    assert result["valid"] is True

--- a/tests/test_pipeline_handshake.py
+++ b/tests/test_pipeline_handshake.py
@@ -202,6 +202,7 @@ class TestPipelineMain:
         assert "image:" not in polished_input.split("---")[1]
         assert "image_alt:" not in polished_input.split("---")[1]
         assert "image_caption:" not in polished_input.split("---")[1]
+        assert "![Chart](/assets/charts/test-slug.png)" in polished_input
 
     def test_resume_with_unknown_slug_exits_1_with_clear_message(
         self,

--- a/tests/test_pipeline_handshake.py
+++ b/tests/test_pipeline_handshake.py
@@ -1,0 +1,242 @@
+"""Tests for #403 slice 3: pipeline.py --resume / --no-image / exit 10.
+
+Covers the three-mode CLI:
+  - default: Stage 3 only, writes artefacts, prints handshake, exits 10
+  - --resume <slug>: Stage 4 only, requires the dropped image
+  - --resume <slug> --no-image: strips image fields, Stage 4 ships chart-only
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.agent_sdk import pipeline as pl
+from src.agent_sdk.pipeline import (
+    EXIT_HANDSHAKE_PENDING,
+    _load_state,
+    _persist_stage3_artefacts,
+    _strip_image_frontmatter,
+)
+from src.agent_sdk.stage3_runner import Stage3Result
+
+
+def _fake_stage3(
+    slug: str = "test-slug", *, chart_path: Path | None = None
+) -> Stage3Result:
+    return Stage3Result(
+        topic="test topic",
+        article=(
+            "---\nlayout: post\ntitle: T\n"
+            "image: /assets/images/test-slug.png\n"
+            "image_alt: alt\nimage_caption: cap\n---\n\nBody.\n"
+        ),
+        chart_data={"title": "T", "data": [{"metric": "A", "value": 1}]},
+        total_cost_usd=0.1,
+        writer_cost_usd=0.08,
+        graphics_cost_usd=0.02,
+        writer_model="claude-sonnet-4-6",
+        graphics_model="claude-sonnet-4-6",
+        wall_seconds=10.0,
+        research_brief_chars=500,
+        article_chars=200,
+        stat_audit_removed=0,
+        chart_path=chart_path,
+        prompt_path=None,
+        slug=slug,
+        image_prompt="paste this into ChatGPT",
+    )
+
+
+# ── _strip_image_frontmatter ─────────────────────────────────────────
+
+
+class TestStripImageFrontmatter:
+    def test_removes_all_three_image_fields(self) -> None:
+        article = (
+            "---\nlayout: post\ntitle: x\n"
+            "image: /assets/images/x.png\n"
+            'image_alt: "alt text"\n'
+            "image_caption: caption text\n"
+            "---\n\nBody.\n"
+        )
+        out = _strip_image_frontmatter(article)
+        assert "image:" not in out.split("---")[1]
+        assert "image_alt:" not in out.split("---")[1]
+        assert "image_caption:" not in out.split("---")[1]
+
+    def test_preserves_other_frontmatter_fields(self) -> None:
+        article = (
+            "---\nlayout: post\ntitle: Keep Me\n"
+            "image: /assets/images/x.png\n"
+            "author: Ouray Viney\n"
+            "---\n\nBody.\n"
+        )
+        out = _strip_image_frontmatter(article)
+        assert "title: Keep Me" in out
+        assert "author: Ouray Viney" in out
+        assert "image:" not in out.split("---")[1]
+
+    def test_preserves_body_chart_embed(self) -> None:
+        # The body's ![Chart](/assets/charts/x.png) reference must NOT be
+        # touched — it's chart-only mode, the chart still ships.
+        article = (
+            "---\nlayout: post\ntitle: x\nimage: /assets/images/x.png\n---\n\n"
+            "Body.\n\n![Chart](/assets/charts/x.png)\n"
+        )
+        out = _strip_image_frontmatter(article)
+        assert "![Chart](/assets/charts/x.png)" in out
+
+    def test_noop_when_no_image_fields_present(self) -> None:
+        article = "---\nlayout: post\ntitle: x\n---\n\nBody.\n"
+        assert _strip_image_frontmatter(article) == article
+
+    def test_noop_when_no_frontmatter(self) -> None:
+        article = "Just a body, no frontmatter.\n"
+        assert _strip_image_frontmatter(article) == article
+
+
+# ── state persistence ────────────────────────────────────────────────
+
+
+class TestStatePersistence:
+    def test_persist_writes_article_and_state_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        s3 = _fake_stage3()
+        artefacts = _persist_stage3_artefacts(s3)
+
+        assert artefacts.article_path == Path("output/posts/test-slug.md")
+        assert artefacts.article_path.exists()
+        assert artefacts.article_path.read_text() == s3.article
+        assert artefacts.state_path == Path("output/state/test-slug.json")
+        assert artefacts.state_path.exists()
+
+    def test_state_round_trips_chart_data_for_stage4(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        s3 = _fake_stage3()
+        _persist_stage3_artefacts(s3)
+        state = _load_state("test-slug")
+        # chart_data must survive JSON round-trip so Stage 4 can consume it
+        # without re-reading the chart spec file.
+        assert state["chart_data"] == s3.chart_data
+        assert state["topic"] == s3.topic
+        assert state["metrics"]["writer_cost_usd"] == s3.writer_cost_usd
+
+    def test_load_state_missing_slug_raises_with_actionable_message(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(FileNotFoundError, match="No Stage 3 state"):
+            _load_state("never-generated")
+
+
+# ── CLI mode dispatch ────────────────────────────────────────────────
+
+
+class TestPipelineMain:
+    def test_default_mode_exits_with_handshake_code_after_stage3(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Bare ``pipeline 'topic'`` runs Stage 3 only, writes artefacts,
+        prints handshake message, exits 10 (does NOT run Stage 4)."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["pipeline.py", "test topic"])
+
+        fake_s3 = _fake_stage3()
+
+        async def fake_run_stage3(*args, **kwargs):
+            return fake_s3
+
+        # If Stage 4 runs in default mode we have a bug — assert it doesn't.
+        run_stage4_mock = MagicMock()
+        monkeypatch.setattr("src.agent_sdk.pipeline.run_stage4", run_stage4_mock)
+        monkeypatch.setattr("src.agent_sdk.pipeline.run_stage3", fake_run_stage3)
+
+        with pytest.raises(SystemExit) as exc_info:
+            pl.main()
+        assert exc_info.value.code == EXIT_HANDSHAKE_PENDING
+        run_stage4_mock.assert_not_called()
+        # Artefacts landed at slug-keyed paths
+        assert Path("output/posts/test-slug.md").exists()
+        assert Path("output/state/test-slug.json").exists()
+
+    def test_resume_no_image_runs_stage4_without_image_fields(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        # Pre-seed state (as Stage 3 would have)
+        _persist_stage3_artefacts(_fake_stage3())
+
+        monkeypatch.setattr(
+            sys, "argv", ["pipeline.py", "--resume", "test-slug", "--no-image"]
+        )
+
+        captured_article = []
+        fake_stage4 = MagicMock()
+        fake_stage4.return_value = MagicMock(
+            article="polished",
+            editorial_score=90,
+            gates_passed=5,
+            publication_ready=True,
+            publication_validator_passed=True,
+            publication_validator_issues=[],
+        )
+
+        def _capture(article, chart_data):
+            captured_article.append(article)
+            return fake_stage4.return_value
+
+        monkeypatch.setattr("src.agent_sdk.pipeline.run_stage4", _capture)
+        pl.main()
+        assert captured_article, "Stage 4 was not called"
+        polished_input = captured_article[0]
+        # image: / image_alt: / image_caption: must have been stripped
+        # before Stage 4 saw the article
+        assert "image:" not in polished_input.split("---")[1]
+        assert "image_alt:" not in polished_input.split("---")[1]
+        assert "image_caption:" not in polished_input.split("---")[1]
+
+    def test_resume_with_unknown_slug_exits_1_with_clear_message(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["pipeline.py", "--resume", "never-was"])
+        with pytest.raises(SystemExit) as exc_info:
+            pl.main()
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "No Stage 3 state" in err
+        assert "never-was" in err
+
+    def test_handshake_message_includes_prompt_drop_path_and_resume_command(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["pipeline.py", "test topic"])
+
+        async def fake_run_stage3(*args, **kwargs):
+            return _fake_stage3()
+
+        monkeypatch.setattr("src.agent_sdk.pipeline.run_stage3", fake_run_stage3)
+        monkeypatch.setattr("src.agent_sdk.pipeline.run_stage4", MagicMock())
+        with pytest.raises(SystemExit):
+            pl.main()
+        out = capsys.readouterr().out
+        # Verbose handoff per spec Q2: paste-ready prompt + drop path + resume cmd
+        assert "paste this into ChatGPT" in out
+        assert "output/posts/images/test-slug.png" in out
+        assert "--resume test-slug" in out
+        assert "--no-image" in out  # alternate path also shown

--- a/tests/test_publication_validator.py
+++ b/tests/test_publication_validator.py
@@ -80,7 +80,12 @@ class TestPublicationValidatorYAML:
     """YAML frontmatter validation checks."""
 
     def test_valid_article_passes(self) -> None:
-        validator = PublicationValidator(expected_date="2026-04-03")
+        # require_image_file=False: this test exercises every OTHER validator
+        # check on a known-good article; #403 added a file-must-exist gate
+        # that is verified in tests/test_publication_validator_image_optional.py.
+        validator = PublicationValidator(
+            expected_date="2026-04-03", require_image_file=False
+        )
         article = _make_article()
         is_valid, issues = validator.validate(article)
         critical = [i for i in issues if i["severity"] == "CRITICAL"]

--- a/tests/test_publication_validator_image_optional.py
+++ b/tests/test_publication_validator_image_optional.py
@@ -1,0 +1,165 @@
+"""Tests for #403 slice 2 (Task 2.1): image: optional + file-must-exist."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.publication_validator import PublicationValidator
+
+
+def _article(extra_fm: str = "", body: str = "Body paragraph.\n") -> str:
+    """Build a minimal valid article. ``extra_fm`` adds frontmatter lines."""
+    return (
+        "---\n"
+        "layout: post\n"
+        'title: "Test"\n'
+        "date: 2026-05-24\n"
+        "author: Ouray Viney\n"
+        "categories:\n - Software Engineering\n"
+        'description: "A description that is the right size for SEO."\n'
+        f"{extra_fm}"
+        "---\n\n"
+        f"{body}"
+    )
+
+
+def _v() -> PublicationValidator:
+    return PublicationValidator(expected_date="2026-05-24")
+
+
+# ── chart-only mode (no image: line) — should NOT flag image-related issues ──
+
+
+def test_no_image_line_does_not_emit_missing_image() -> None:
+    v = _v()
+    v._check_image_contract(_article())
+    image_issues = [i for i in v.issues if "image" in i["check"]]
+    assert image_issues == []
+
+
+def test_no_image_line_does_not_require_image_alt_or_caption() -> None:
+    v = _v()
+    v._check_image_contract(_article())
+    # Pre-#403 the contract required image_alt + image_caption even when
+    # image: was missing; #403 makes the three a unit.
+    assert not any(i["check"] == "missing_image_alt" for i in v.issues)
+    assert not any(i["check"] == "missing_image_caption" for i in v.issues)
+
+
+# ── image: present + file exists — passes ──
+
+
+def test_image_present_with_file_on_disk_passes(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "output" / "posts" / "images" / "x.png"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"fake png")
+
+    v = _v()
+    v._check_image_contract(
+        _article(
+            extra_fm=(
+                "image: /assets/images/x.png\n"
+                "image_alt: an editorial illustration\n"
+                'image_caption: "A caption."\n'
+            )
+        )
+    )
+    assert not any(i["check"] == "missing_image_file" for i in v.issues)
+
+
+# ── image: present + file missing — CRITICAL fail with path in message ──
+
+
+def test_image_present_but_file_missing_emits_critical(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    v = _v()
+    v._check_image_contract(
+        _article(
+            extra_fm=(
+                "image: /assets/images/missing.png\n"
+                "image_alt: alt\n"
+                'image_caption: "cap"\n'
+            )
+        )
+    )
+    missing = [i for i in v.issues if i["check"] == "missing_image_file"]
+    assert len(missing) == 1
+    assert missing[0]["severity"] == "CRITICAL"
+    assert "missing.png" in missing[0]["message"]
+    # Operator-facing fix instructions name the exact drop path
+    assert "output/posts/images/missing.png" in missing[0]["fix"]
+
+
+# ── image: present requires alt + caption ──
+
+
+def test_image_present_without_alt_still_flags_missing_alt(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "output" / "posts" / "images").mkdir(parents=True)
+    (tmp_path / "output" / "posts" / "images" / "x.png").write_bytes(b"x")
+
+    v = _v()
+    v._check_image_contract(
+        _article(
+            extra_fm=(
+                'image: /assets/images/x.png\nimage_caption: "cap"\n'  # alt omitted
+            )
+        )
+    )
+    assert any(i["check"] == "missing_image_alt" for i in v.issues)
+
+
+def test_image_present_without_caption_flags_missing_caption(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "output" / "posts" / "images").mkdir(parents=True)
+    (tmp_path / "output" / "posts" / "images" / "x.png").write_bytes(b"x")
+
+    v = _v()
+    v._check_image_contract(
+        _article(
+            extra_fm=(
+                "image: /assets/images/x.png\nimage_alt: alt\n"  # caption omitted
+            )
+        )
+    )
+    assert any(i["check"] == "missing_image_caption" for i in v.issues)
+
+
+# ── default fallback still rejected ──
+
+
+def test_blog_default_svg_still_rejected() -> None:
+    v = _v()
+    v._check_image_contract(
+        _article(
+            extra_fm=(
+                "image: /assets/images/blog-default.svg\n"
+                "image_alt: alt\n"
+                'image_caption: "cap"\n'
+            )
+        )
+    )
+    assert any(i["check"] == "default_image_fallback" for i in v.issues)
+
+
+# ── path resolution helper ──
+
+
+def test_resolve_image_path_maps_assets_images_to_output_posts_images() -> None:
+    assert PublicationValidator._resolve_image_path("/assets/images/x.png") == Path(
+        "output/posts/images/x.png"
+    )
+
+
+def test_resolve_image_path_returns_none_for_unexpected_prefix() -> None:
+    # Absolute URLs or non-/assets/images/ paths should not be checked
+    # (the validator's job is only to enforce the standard layout).
+    assert PublicationValidator._resolve_image_path("https://cdn.x/img.png") is None
+    assert PublicationValidator._resolve_image_path("/assets/charts/x.png") is None

--- a/tests/test_references_feature.py
+++ b/tests/test_references_feature.py
@@ -254,7 +254,12 @@ This is an article.
 
     def test_references_with_three_sources_passes(self):
         """Should pass with 3+ properly formatted references"""
-        validator = PublicationValidator(expected_date="2026-01-02")
+        # require_image_file=False: this test fixture references a hero PNG
+        # that doesn't exist on disk; the #403 file-must-exist gate is
+        # covered separately in tests/test_publication_validator_image_optional.py.
+        validator = PublicationValidator(
+            expected_date="2026-01-02", require_image_file=False
+        )
 
         padding = " ".join(["word"] * 850)
         article = f"""---
@@ -467,7 +472,11 @@ IEEE research confirms these findings. Their September 2024 standards document s
 3. IEEE, ["Software Testing Standards Update"](https://www.ieee.org/testing), *IEEE Computer Society*, August 2024
 """
 
-        validator = PublicationValidator(expected_date="2026-01-02")
+        # require_image_file=False: this test fixture references a hero PNG
+        # that doesn't exist on disk; covered separately in #403 tests.
+        validator = PublicationValidator(
+            expected_date="2026-01-02", require_image_file=False
+        )
         is_valid, issues = validator.validate(article)
 
         # Should pass all checks including references

--- a/tests/test_stage3_chart_rendering.py
+++ b/tests/test_stage3_chart_rendering.py
@@ -1,0 +1,131 @@
+"""Tests for #403 slice 1: chart_renderer wired into stage3_runner."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from src.agent_sdk.stage3_runner import _slug_for_chart, run_stage3
+
+# ── slug derivation ──────────────────────────────────────────────────
+
+
+def test_slug_extracted_from_image_field_in_frontmatter() -> None:
+    article = (
+        "---\nlayout: post\ntitle: x\n"
+        "image: /assets/images/three-people-and-a-fleet.png\n"
+        "---\n\nBody."
+    )
+    assert _slug_for_chart(article, "Some topic") == "three-people-and-a-fleet"
+
+
+def test_slug_falls_back_to_kebab_topic_when_no_image_field() -> None:
+    article = "---\nlayout: post\ntitle: x\n---\n\nBody."
+    assert (
+        _slug_for_chart(article, "Product Team Composition (Agentic AI)")
+        == "product-team-composition-agentic-ai"
+    )
+
+
+def test_slug_strips_leading_and_trailing_hyphens() -> None:
+    assert _slug_for_chart("---\nlayout: post\n---\n\n", "—An idea—") == "an-idea"
+
+
+def test_slug_handles_topic_with_only_non_alnum() -> None:
+    assert _slug_for_chart("---\nlayout: post\n---\n\n", "!!!") == "untitled"
+
+
+# ── wire-up: run_stage3 produces chart_path ──────────────────────────
+
+
+def test_run_stage3_renders_chart_png_to_output_charts_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end-ish: mock the two LLM calls, assert PNG file lands on disk
+    and chart_path is populated on the Stage3Result."""
+
+    # Run from inside tmp_path so output/ doesn't pollute the repo.
+    monkeypatch.chdir(tmp_path)
+
+    article_text = (
+        "---\n"
+        "layout: post\n"
+        'title: "Test"\n'
+        "date: 2026-05-24\n"
+        "author: Ouray Viney\n"
+        "categories:\n - Software Engineering\n"
+        "image: /assets/images/test-chart-slug.png\n"
+        'description: "A test article description that is exactly the right size."\n'
+        "image_alt: alt\n"
+        "image_caption: caption\n"
+        "---\n\n"
+        "Body paragraph one. As the chart shows, things are happening.\n"
+    )
+    chart_json = (
+        '{"title": "T", "data": [{"metric": "A", "value": 1, "color": "navy"}]}'
+    )
+
+    # Two-call sequence: writer returns article, graphics returns JSON.
+    call_results = iter([(article_text, 0.0), (chart_json, 0.0)])
+
+    async def fake_collect(*args, **kwargs):
+        return next(call_results)
+
+    monkeypatch.setattr(
+        "src.agent_sdk.stage3_runner._collect_text",
+        fake_collect,
+    )
+    monkeypatch.setattr(
+        "src.agent_sdk.stage3_runner.build_research_brief",
+        lambda topic: f"# Research Brief: {topic}\n\nfake source",
+    )
+    # Disable style memory fetch (avoids ChromaDB import / network).
+    monkeypatch.setattr(
+        "src.agent_sdk.stage3_runner._fetch_style_context",
+        lambda topic: "",
+    )
+
+    result = asyncio.run(run_stage3("test topic"))
+
+    assert result.chart_path is not None
+    assert result.chart_path == Path("output/charts/test-chart-slug.png")
+    assert result.chart_path.exists()
+    assert result.chart_path.stat().st_size > 0
+
+
+def test_run_stage3_continues_without_chart_path_when_render_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A malformed chart spec must NOT crash the pipeline — render
+    failure logs a warning and Stage3Result.chart_path stays None."""
+
+    monkeypatch.chdir(tmp_path)
+
+    article_text = (
+        "---\nlayout: post\ntitle: x\nimage: /assets/images/x.png\n---\n\nbody"
+    )
+    # Empty data list — chart_renderer rejects this with ChartRenderError.
+    chart_json = '{"title": "T", "data": []}'
+
+    call_results = iter([(article_text, 0.0), (chart_json, 0.0)])
+
+    async def fake_collect(*args, **kwargs):
+        return next(call_results)
+
+    monkeypatch.setattr("src.agent_sdk.stage3_runner._collect_text", fake_collect)
+    monkeypatch.setattr(
+        "src.agent_sdk.stage3_runner.build_research_brief",
+        lambda topic: "# brief\n\nsource",
+    )
+    monkeypatch.setattr(
+        "src.agent_sdk.stage3_runner._fetch_style_context",
+        lambda topic: "",
+    )
+
+    result = asyncio.run(run_stage3("test"))
+    assert result.chart_path is None
+    assert result.article  # article itself still produced

--- a/tests/test_stage3_chart_rendering.py
+++ b/tests/test_stage3_chart_rendering.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from src.agent_sdk.chart_renderer import ChartRenderError
 from src.agent_sdk.stage3_runner import _slug_for_chart, run_stage3
 
 # ── slug derivation ──────────────────────────────────────────────────
@@ -96,12 +97,11 @@ def test_run_stage3_renders_chart_png_to_output_charts_dir(
     assert result.chart_path.stat().st_size > 0
 
 
-def test_run_stage3_continues_without_chart_path_when_render_fails(
+def test_run_stage3_fails_when_chart_render_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A malformed chart spec must NOT crash the pipeline — render
-    failure logs a warning and Stage3Result.chart_path stays None."""
+    """A malformed chart spec must block a non-shippable article."""
 
     monkeypatch.chdir(tmp_path)
 
@@ -126,6 +126,5 @@ def test_run_stage3_continues_without_chart_path_when_render_fails(
         lambda topic: "",
     )
 
-    result = asyncio.run(run_stage3("test"))
-    assert result.chart_path is None
-    assert result.article  # article itself still produced
+    with pytest.raises(ChartRenderError, match="non-empty list"):
+        asyncio.run(run_stage3("test"))

--- a/tests/test_stage3_style_memory_wiring.py
+++ b/tests/test_stage3_style_memory_wiring.py
@@ -24,13 +24,13 @@ from __future__ import annotations
 
 import asyncio
 import re
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 import src.agent_sdk.stage3_runner as stage3_runner
 from src.agent_sdk.stage3_runner import run_stage3
-
 
 VALID_ARTICLE = (
     "---\n"
@@ -73,7 +73,7 @@ def stub_pipeline(captured_prompts):
             captured_prompts["writer"] = prompt
             return VALID_ARTICLE, 0.0
         captured_prompts["graphics"] = prompt
-        return '{"title": "t", "data": []}', 0.0
+        return '{"title": "t", "data": [{"metric": "A", "value": 1}]}', 0.0
 
     with (
         patch.object(
@@ -85,6 +85,11 @@ def stub_pipeline(captured_prompts):
             stage3_runner,
             "_collect_text",
             AsyncMock(side_effect=fake_collect_text),
+        ),
+        patch.object(
+            stage3_runner,
+            "render_chart",
+            return_value=Path("output/charts/test.png"),
         ),
     ):
         yield


### PR DESCRIPTION
## Summary

Closes #403 (defect A+B: chart never rendered, featured image never generated). Closes #402 (BUG-017 false positive). Five reviewable slices on one branch.

The pipeline used to emit articles whose YAML frontmatter promised a chart PNG and a hero image PNG that **were never written to disk**. Deploy then silently shipped broken \`<img>\` tags. This PR fixes both defects via Path A from the spec ([\`docs/specs/featured-image-handshake.md\`](https://github.com/oviney/economist-agents/blob/main/docs/specs/featured-image-handshake.md)):

1. **Chart renders deterministically** in matplotlib (no API, no key, no cost).
2. **Featured image** is human-orchestrated via a paste-prompt-into-ChatGPT handshake: Stage 3 emits a paste-ready prompt + exits 10; \`--resume\` runs Stage 4 after the human drops the PNG (or \`--resume --no-image\` ships chart-only).

## Slices

| Slice | Commit | What lands | Tests |
| --- | --- | --- | --- |
| 1 | aaf56f3 | \`chart_renderer.py\` + Stage 3 wire-up | +21 |
| 2 | 0f36289 | Validator accepts chart-only + BUG-017 path comparison (#402) | +17 |
| 3 | b136827 | \`image_prompt_synth.py\` + slug-keyed output + \`--resume\`/\`--no-image\` + exit 10 | +24 |
| 4 | 26abe4e | Deterministic image gate (\`image_gate.py\`) + exit 11 | +11 |
| 5 | cf88d59 | CONTRIBUTING.md handshake workflow + exit-code table | docs only |

Each slice committed separately for reviewability; suite stayed green at every checkpoint.

## New CLI behaviour

\`\`\`
# Step 1 — produces article + chart + prompt, exits 10
python -m src.agent_sdk.pipeline "your topic"

# Step 2 — after you've dropped output/posts/images/<slug>.png from ChatGPT
python -m src.agent_sdk.pipeline --resume <slug>

# Or, skip the hero image — chart becomes the visual anchor
python -m src.agent_sdk.pipeline --resume <slug> --no-image
\`\`\`

## Exit codes

| Code | Meaning |
| ---- | ------- |
| 0    | Stage 4 complete |
| 1    | Operator error (unknown slug) |
| 2    | Research providers failed |
| 3    | Research providers returned zero sources |
| 10   | Stage 3 done — handshake pending |
| 11   | \`--resume\` image-gate failed |

## Test plan

- [x] Full suite: **2218 passed / 84 skipped** (was 2145 on main; +73 new across the 5 slices)
- [x] ruff check + ruff format clean on every touched file
- [x] AST bare-name import guard clean (53 modules scanned)
- [x] Checkpoint A: chart rendered cleanly on yesterday's real spec (eyeball)
- [x] Checkpoint B: yesterday's article minus \`image:\` validates with zero issues
- [x] Checkpoints C, D: pytest green
- [ ] **Smoke (post-merge, human)**: run \`pipeline "topic"\` → exit 10 → drop image → \`--resume\` → \`deploy --dry-run\` → confirm no broken-image regressions. ~$0.30 + a manual ChatGPT image generation. Deferred because the image-handoff loop is the operator's half.

## Out of scope

- Removing the existing \`scripts/featured_image_agent.py\` (DALL-E path). Left in repo as an opt-in alternative for anyone with \`OPENAI_API_KEY\` who wants the automated path. Not called by default.
- Issue #401 (writer hardcodes \`author: Economist Writer\`) — orthogonal; separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)