### PR TITLE
test: enforce deterministic chart layout regressions

### DIFF
--- a/.github/BACKLOG.md
+++ b/.github/BACKLOG.md
@@ -1,6 +1,6 @@
 # Project Backlog
 
-Last updated: 2025-12-31
+Last updated: 2026-05-31
 
 This file tracks architectural improvements and technical debt identified through architecture reviews and development.
 
@@ -145,11 +145,12 @@ This file tracks architectural improvements and technical debt identified throug
 
 ---
 
-### 🟢 Chart Regression Tests
-**Status**: Ready
+### ✅ Chart Regression Tests
+**Status**: Complete
 **Priority**: P2 (Medium)
 **Effort**: Large
 **Created**: 2025-12-31
+**Completed**: 2026-05-31
 
 **Problem**: Known chart bugs (5 documented in code) have no automated prevention.
 
@@ -160,18 +161,26 @@ This file tracks architectural improvements and technical debt identified throug
 4. Label-to-label overlap
 5. Clipped elements at edges
 
-**Solution Approach**:
-- Create test chart generator with known bad configurations
-- Use visual QA agent to detect issues programmatically
-- Add to CI/CD pipeline
+**Solution**:
+- Added five minimal bad-chart fixture scripts and deterministic regression
+  tests discovered by the existing CI test suite.
+- Replaced regex-only Matplotlib layout inspection with AST-backed checks for
+  figure text, annotation offsets, low-label X-axis intrusion, likely label
+  collisions, and clipped figure text.
+- Corrected pixel validation to inspect the top 4% of raster images for the
+  Economist red bar.
 
-**Files to Create**:
+**Files Changed**:
 - `tests/test_chart_layouts.py`
 - `tests/fixtures/bad_charts/` (example bad configurations)
+- `src/quality/visual_qa_zones.py`
+- `tests/test_visual_qa_zones.py`
+- `docs/STORY_CHART_REGRESSION_TESTS_SPEC.md`
+- `docs/STORY_CHART_REGRESSION_TESTS_PLAN.md`
 
-**Blocked By**: Need test data fixtures
-
-**Estimate**: 4-6 hours
+**Testing**:
+- `MPLBACKEND=Agg .venv/bin/python -m pytest tests/test_chart_layouts.py tests/test_visual_qa_zones.py tests/test_generate_chart.py -q` - 61 passed
+- `.venv/bin/ruff check src/quality/visual_qa_zones.py tests/test_chart_layouts.py tests/test_visual_qa_zones.py tests/fixtures/bad_charts/scripts` - passed
 
 ---
 

--- a/docs/STORY_CHART_REGRESSION_TESTS_PLAN.md
+++ b/docs/STORY_CHART_REGRESSION_TESTS_PLAN.md
@@ -1,0 +1,73 @@
+# Implementation Plan: Chart Layout Regression Tests
+
+## Overview
+
+Extend the deterministic chart validator so CI catches the five chart-layout
+regressions listed in `.github/BACKLOG.md`. Work proceeds in small RED/GREEN
+slices and reuses the existing `ZoneBoundaryValidator` boundary.
+
+## Architecture Decisions
+
+- Parse `fig.text()` and `ax.annotate()` calls with `ast` instead of regular
+  expressions so multiline calls and nested tuples are handled correctly.
+- Keep fixture scripts minimal and pair them with generated synthetic PNGs.
+- Correct pixel coordinates so the visual red bar is checked at the top of the
+  raster image.
+- Rely on the existing CI `pytest tests/` command for automatic discovery.
+
+## Task List
+
+### Phase 1: Regression Contract
+
+- [ ] Add five bad-layout fixture scripts and fixture-backed tests.
+  - Acceptance: every documented failure requires its own specific issue.
+  - Verify: run the new suite and record RED failures before implementation.
+  - Files: `tests/test_chart_layouts.py`, `tests/fixtures/bad_charts/scripts/*`
+
+### Checkpoint: RED
+
+- [ ] Confirm the new suite fails against the current validator for the missing
+      behaviors.
+
+### Phase 2: Deterministic Detection
+
+- [ ] Replace regex-only figure-text parsing with AST helpers.
+  - Acceptance: title/red-bar intrusion and clipped figure text are detected.
+  - Verify: run the relevant parameterized regression cases.
+  - Files: `src/quality/visual_qa_zones.py`
+
+- [ ] Add AST-backed annotation validation.
+  - Acceptance: on-line labels, low labels, and likely label collisions are
+    detected while valid multiline annotations pass.
+  - Verify: run the annotation regression cases and multiline positive case.
+  - Files: `src/quality/visual_qa_zones.py`
+
+- [ ] Correct raster red-bar coordinates and direct unit fixtures.
+  - Acceptance: a top red bar passes and a missing or misplaced red bar fails.
+  - Verify: run `tests/test_visual_qa_zones.py`.
+  - Files: `src/quality/visual_qa_zones.py`, `tests/test_visual_qa_zones.py`
+
+### Checkpoint: GREEN
+
+- [ ] Run the new suite and existing direct validator tests.
+- [ ] Run related chart tests with `MPLBACKEND=Agg`.
+
+### Phase 3: Ship
+
+- [ ] Mark the backlog item complete with files and verification evidence.
+- [ ] Run Ruff, formatting, diff hygiene, and repository quality gates.
+- [ ] Review the final diff for correctness, architecture, security, and
+      performance.
+- [ ] Commit, push, and open a PR for human review.
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+| --- | --- | --- |
+| Static checks overclaim runtime precision | Medium | Use issue text such as "likely" and scope the spec to literal script arguments. |
+| Existing pixel fixture encodes bottom-row behavior | Medium | Add top-row fixture assertions and update direct tests in the same slice. |
+| AST parser misses dynamic expressions | Low | Skip non-literal values rather than producing false positives. |
+
+## Open Questions
+
+None.

--- a/docs/STORY_CHART_REGRESSION_TESTS_SPEC.md
+++ b/docs/STORY_CHART_REGRESSION_TESTS_SPEC.md
@@ -1,0 +1,84 @@
+# Spec: Chart Layout Regression Tests
+
+## Objective
+
+Add deterministic regression coverage for the five documented Economist-style
+chart layout failures in `.github/BACKLOG.md`:
+
+1. title/red-bar overlap;
+2. inline label directly on a data line;
+3. inline label intruding into the X-axis zone;
+4. label-to-label overlap; and
+5. clipped figure text at chart edges.
+
+The checks run before LLM-based visual QA. They must stay offline, fast, and
+deterministic so CI can reject known bad chart scripts without image-model
+calls.
+
+## Tech Stack
+
+- Python 3.11+
+- Pytest
+- `ast` from the Python standard library
+- Pillow and NumPy for existing pixel-level checks
+- `src.quality.visual_qa_zones.ZoneBoundaryValidator`
+
+## Commands
+
+- Baseline: `MPLBACKEND=Agg .venv/bin/python -m pytest tests/test_visual_qa_zones.py -q`
+- RED/GREEN suite: `MPLBACKEND=Agg .venv/bin/python -m pytest tests/test_chart_layouts.py tests/test_visual_qa_zones.py -q`
+- Related chart suite: `MPLBACKEND=Agg .venv/bin/python -m pytest tests/test_chart_layouts.py tests/test_visual_qa_zones.py tests/test_generate_chart.py -q`
+- Lint: `.venv/bin/ruff check src/quality/visual_qa_zones.py tests/test_chart_layouts.py tests/test_visual_qa_zones.py tests/fixtures/bad_charts/scripts`
+- Format: `.venv/bin/ruff format --check src/quality/visual_qa_zones.py tests/test_chart_layouts.py tests/test_visual_qa_zones.py tests/fixtures/bad_charts/scripts`
+
+## Project Structure
+
+- `src/quality/visual_qa_zones.py`: deterministic chart script and pixel checks
+- `tests/test_chart_layouts.py`: fixture-backed regression suite
+- `tests/fixtures/bad_charts/scripts/`: minimal scripts for known failures
+- `tests/test_visual_qa_zones.py`: direct validator unit tests
+- `.github/BACKLOG.md`: backlog status and verification evidence
+
+## Code Style
+
+Use small AST extraction helpers and explicit issue messages:
+
+```python
+if abs(offset_x) <= 2 and abs(offset_y) <= 2:
+    issues.append(
+        f"Inline label '{label}' has near-zero xytext offset; "
+        "it will overlap data line",
+    )
+```
+
+## Testing Strategy
+
+Create synthetic top-red-bar PNGs and pair them with small fixture scripts.
+`ZoneBoundaryValidator.validate_chart()` locates the matching script and
+reports a specific issue for each documented layout failure. Keep existing
+filename, CLI, and optional pixel-validation tests passing. Add a positive
+multiline-annotation case because production chart scripts use multiline
+`ax.annotate()` calls.
+
+## Boundaries
+
+- Always: keep checks offline and deterministic; parse Python with `ast`; run
+  RED before implementation and GREEN after each slice.
+- Ask first: add dependencies, change the chart generation API, or alter CI
+  workflow configuration.
+- Never: require network credentials or image-model calls; weaken existing
+  filename, CLI, or pixel checks.
+
+## Success Criteria
+
+- Each of the five known bad layouts has a fixture-backed failing regression.
+- Each fixture produces a specific detector issue, not an incidental failure.
+- Multiline annotations with valid offsets do not produce false positives.
+- Pixel checks validate that the red bar occupies the top 4% of the image.
+- Existing direct validator and related chart tests pass.
+- Ruff, formatting, and repository quality gates pass.
+
+## Open Questions
+
+None. This slice intentionally analyzes literal Matplotlib script arguments.
+Dynamic runtime layout analysis remains outside the backlog item.

--- a/src/quality/visual_qa_zones.py
+++ b/src/quality/visual_qa_zones.py
@@ -34,6 +34,7 @@ Usage:
         print(f"Zone violations: {issues}")
 """
 
+import ast
 import re
 from pathlib import Path
 
@@ -124,37 +125,8 @@ class ZoneBoundaryValidator:
         with open(script_path) as f:
             code = f.read()
 
-        # Check 1: Title position (should be y=0.90 in figure coords)
-        title_matches = re.findall(
-            r'fig\.text\([^,]+,\s*(0\.\d+),.*?["\'].*?title',
-            code,
-            re.IGNORECASE,
-        )
-        for y_pos in title_matches:
-            y = float(y_pos)
-            if y < 0.85 or y > 0.94:
-                issues.append(f"Title y={y} outside TITLE ZONE (0.85-0.94)")
-
-        # Check 2: Subtitle position (should be y=0.85)
-        subtitle_matches = re.findall(
-            r'fig\.text\([^,]+,\s*(0\.\d+),.*?["\'].*?subtitle',
-            code,
-            re.IGNORECASE,
-        )
-        for y_pos in subtitle_matches:
-            y = float(y_pos)
-            if y < 0.85 or y > 0.94:
-                issues.append(f"Subtitle y={y} outside TITLE ZONE (0.85-0.94)")
-
-        # Check 3: Source line position (should be y=0.03 in source zone)
-        source_matches = re.findall(
-            r'fig\.text\([^,]+,\s*(0\.\d+),.*?["\'].*?[Ss]ource',
-            code,
-        )
-        for y_pos in source_matches:
-            y = float(y_pos)
-            if y < 0.01 or y > 0.06:
-                issues.append(f"Source y={y} outside SOURCE ZONE (0.01-0.06)")
+        # Check 1-3: Figure text zones
+        issues.extend(self._validate_figure_text_layout(code))
 
         # Check 4: Red bar position (should be y=0.96-1.00)
         redbar_matches = re.findall(r"Rectangle\(\(0,\s*(0\.\d+)\)", code)
@@ -163,15 +135,220 @@ class ZoneBoundaryValidator:
             if y < 0.96:
                 issues.append(f"Red bar y={y} below RED BAR ZONE (0.96-1.00)")
 
-        # Check 5: Inline labels (ax.annotate) should have appropriate offsets
-        # Look for labels without xytext offset
-        annotate_matches = re.findall(r"ax\.annotate\([^)]+\)", code)
-        for match in annotate_matches:
-            if "xytext" not in match:
+        # Check 5: Inline labels should avoid data, axis, and each other.
+        issues.extend(self._validate_annotation_layout(code))
+        return issues
+
+    def _validate_figure_text_layout(self, code: str) -> list[str]:
+        """Validate title, subtitle, source, and canvas bounds for figure text."""
+        issues: list[str] = []
+        for text_call in self._iter_figure_text_calls(code):
+            x = text_call["x"]
+            y = text_call["y"]
+            label = str(text_call["label"])
+            label_lower = label.lower()
+
+            if not isinstance(x, float) or not isinstance(y, float):
+                continue
+
+            if 0.96 <= y <= 1.0:
                 issues.append(
-                    f"Inline label missing xytext offset (will overlap data): {match[:50]}...",
+                    f"Figure text '{label}' y={y:g} intrudes into "
+                    "RED BAR ZONE (0.96-1.00)",
                 )
 
+            if (
+                "title" in label_lower
+                and "subtitle" not in label_lower
+                and (y < 0.85 or y > 0.94)
+            ):
+                issues.append(f"Title y={y:g} outside TITLE ZONE (0.85-0.94)")
+
+            if "subtitle" in label_lower and (y < 0.85 or y > 0.94):
+                issues.append(f"Subtitle y={y:g} outside TITLE ZONE (0.85-0.94)")
+
+            if "source" in label_lower and (y < 0.01 or y > 0.06):
+                issues.append(f"Source y={y:g} outside SOURCE ZONE (0.01-0.06)")
+
+            if x < 0.0 or x > 0.98 or y < 0.0 or y > 1.0:
+                issues.append(
+                    f"Figure text at ({x:g}, {y:g}) may be clipped at chart edge",
+                )
+        return issues
+
+    def _validate_annotation_layout(self, code: str) -> list[str]:
+        """Validate inline label offsets and label-to-label spacing."""
+        issues: list[str] = []
+        annotations: list[dict[str, float | str]] = []
+
+        for annotation in self._iter_annotation_calls(code):
+            label = str(annotation["label"])
+            xy = annotation["xy"]
+            xytext = annotation["xytext"]
+
+            if xytext is None:
+                if not annotation["has_xytext"]:
+                    source = str(annotation["source"])
+                    issues.append(
+                        "Inline label missing xytext offset "
+                        f"(will overlap data): {source[:50]}...",
+                    )
+                continue
+
+            offset_x, offset_y = xytext
+            if abs(offset_x) <= 2 and abs(offset_y) <= 2:
+                issues.append(
+                    f"Inline label '{label}' has near-zero xytext offset; "
+                    "it will overlap data line",
+                )
+
+            if xy is not None:
+                anchor_x, anchor_y = xy
+                annotations.append(
+                    {
+                        "label": label,
+                        "anchor_x": anchor_x,
+                        "anchor_y": anchor_y,
+                        "offset_x": offset_x,
+                        "offset_y": offset_y,
+                    },
+                )
+                if anchor_y <= 15 and offset_y < 0:
+                    issues.append(
+                        f"Inline label '{label}' uses negative offset near low data "
+                        "and may intrude into X-axis zone",
+                    )
+
+        issues.extend(self._detect_label_collisions(annotations))
+        return issues
+
+    def _iter_annotation_calls(self, code: str) -> list[dict[str, object]]:
+        """Return literal details from ``ax.annotate`` calls in chart code."""
+        try:
+            tree = ast.parse(code)
+        except SyntaxError:
+            return []
+
+        annotations: list[dict[str, object]] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute) or node.func.attr != "annotate":
+                continue
+            if not isinstance(node.func.value, ast.Name) or node.func.value.id != "ax":
+                continue
+
+            xy_node = self._find_keyword_node(node, "xy")
+            xytext_node = self._find_keyword_node(node, "xytext")
+            annotations.append(
+                {
+                    "label": self._extract_string_arg(node, 0),
+                    "xy": self._extract_numeric_tuple(xy_node),
+                    "xytext": self._extract_numeric_tuple(xytext_node),
+                    "has_xytext": xytext_node is not None,
+                    "source": ast.get_source_segment(code, node) or "ax.annotate(...)",
+                },
+            )
+        return annotations
+
+    def _iter_figure_text_calls(self, code: str) -> list[dict[str, object]]:
+        """Return literal details from ``fig.text`` calls in chart code."""
+        try:
+            tree = ast.parse(code)
+        except SyntaxError:
+            return []
+
+        text_calls: list[dict[str, object]] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute) or node.func.attr != "text":
+                continue
+            if not isinstance(node.func.value, ast.Name) or node.func.value.id != "fig":
+                continue
+
+            text_calls.append(
+                {
+                    "x": self._extract_numeric_arg(node, 0),
+                    "y": self._extract_numeric_arg(node, 1),
+                    "label": self._extract_string_arg(node, 2),
+                },
+            )
+        return text_calls
+
+    def _find_keyword_node(self, call: ast.Call, name: str) -> ast.AST | None:
+        """Find a keyword argument node in a Matplotlib call."""
+        for keyword in call.keywords:
+            if keyword.arg == name:
+                return keyword.value
+        return None
+
+    def _extract_string_arg(self, call: ast.Call, index: int) -> str:
+        """Extract a string-like positional argument from a parsed call."""
+        if len(call.args) <= index:
+            return "<unknown>"
+        arg = call.args[index]
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            return arg.value
+        if isinstance(arg, ast.JoinedStr):
+            return "<dynamic>"
+        return "<unknown>"
+
+    def _extract_numeric_arg(self, call: ast.Call, index: int) -> float | None:
+        """Extract a numeric positional argument from a parsed call."""
+        if len(call.args) <= index:
+            return None
+        return self._extract_numeric_value(call.args[index])
+
+    def _extract_numeric_tuple(
+        self,
+        node: ast.AST | None,
+    ) -> tuple[float, float] | None:
+        """Extract a literal numeric two-item tuple from parsed Python."""
+        if not isinstance(node, ast.Tuple) or len(node.elts) != 2:
+            return None
+
+        values: list[float] = []
+        for item in node.elts:
+            value = self._extract_numeric_value(item)
+            if value is None:
+                return None
+            values.append(value)
+        return (values[0], values[1])
+
+    def _extract_numeric_value(self, node: ast.AST) -> float | None:
+        """Extract a literal numeric value from parsed Python."""
+        if isinstance(node, ast.Constant) and isinstance(node.value, int | float):
+            return float(node.value)
+        if (
+            isinstance(node, ast.UnaryOp)
+            and isinstance(node.op, ast.USub)
+            and isinstance(node.operand, ast.Constant)
+            and isinstance(node.operand.value, int | float)
+        ):
+            return -float(node.operand.value)
+        return None
+
+    def _detect_label_collisions(
+        self,
+        annotations: list[dict[str, float | str]],
+    ) -> list[str]:
+        """Detect labels anchored too close together with similar offsets."""
+        issues: list[str] = []
+        for index, first in enumerate(annotations):
+            for second in annotations[index + 1 :]:
+                same_x = abs(float(first["anchor_x"]) - float(second["anchor_x"])) < 0.5
+                close_anchor_y = (
+                    abs(float(first["anchor_y"]) - float(second["anchor_y"])) < 5
+                )
+                similar_offset = (
+                    abs(float(first["offset_y"]) - float(second["offset_y"])) < 8
+                )
+                if same_x and close_anchor_y and similar_offset:
+                    issues.append(
+                        "Label-to-label overlap likely between "
+                        f"'{first['label']}' and '{second['label']}'",
+                    )
         return issues
 
     def _validate_pixels(self, chart_path: Path) -> list[str]:
@@ -182,13 +359,14 @@ class ZoneBoundaryValidator:
             import numpy as np
             from PIL import Image
 
-            img = Image.open(chart_path)
-            pixels = np.array(img)
+            with Image.open(chart_path) as img:
+                pixels = np.array(img.convert("RGB"))
             height, width = pixels.shape[:2]
 
-            # Convert zone boundaries to pixel coordinates
-            red_bar_zone = (int(height * 0.96), height)
-            title_zone = (int(height * 0.85), int(height * 0.94))
+            # Raster rows count down from the top, unlike figure coordinates.
+            red_bar_height = max(1, int(height * 0.04))
+            red_bar_zone = (0, red_bar_height)
+            title_zone = (int(height * 0.06), int(height * 0.15))
 
             # Check 1: Red bar present at top
             red_bar_pixels = pixels[red_bar_zone[0] : red_bar_zone[1], :, :]
@@ -196,7 +374,7 @@ class ZoneBoundaryValidator:
 
             # Check if red bar color is dominant in that zone
             red_matches = np.all(np.abs(red_bar_pixels - red_bar_color) < 10, axis=2)
-            if red_matches.sum() < (width * 4 * 0.5):  # Less than 50% coverage
+            if red_matches.sum() < (red_bar_pixels.shape[0] * width * 0.5):
                 issues.append("Red bar not detected in RED BAR ZONE (top 4%)")
 
             # Check 2: Background color

--- a/tests/fixtures/bad_charts/scripts/clipped-elements.py
+++ b/tests/fixtures/bad_charts/scripts/clipped-elements.py
@@ -1,0 +1,9 @@
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots(figsize=(8, 5.5))
+ax.plot([2021, 2022, 2023], [20, 40, 60])
+fig.patches.append(mpatches.Rectangle((0, 0.96), 1, 0.04, transform=fig.transFigure))
+fig.text(0.08, 0.90, "Clipped label", fontsize=16)
+fig.text(1.02, 0.50, "This label is clipped", fontsize=10)
+fig.text(0.08, 0.03, "Source: test", fontsize=8)

--- a/tests/fixtures/bad_charts/scripts/inline-label-on-line.py
+++ b/tests/fixtures/bad_charts/scripts/inline-label-on-line.py
@@ -1,0 +1,9 @@
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots(figsize=(8, 5.5))
+ax.plot([2021, 2022, 2023], [20, 40, 60])
+fig.patches.append(mpatches.Rectangle((0, 0.96), 1, 0.04, transform=fig.transFigure))
+fig.text(0.08, 0.90, "Inline label on line", fontsize=16)
+ax.annotate("Series A", xy=(2022, 40), xytext=(0, 0), textcoords="offset points")
+fig.text(0.08, 0.03, "Source: test", fontsize=8)

--- a/tests/fixtures/bad_charts/scripts/inline-label-x-axis-zone.py
+++ b/tests/fixtures/bad_charts/scripts/inline-label-x-axis-zone.py
@@ -1,0 +1,9 @@
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots(figsize=(8, 5.5))
+ax.plot([2021, 2022, 2023], [8, 10, 12])
+fig.patches.append(mpatches.Rectangle((0, 0.96), 1, 0.04, transform=fig.transFigure))
+fig.text(0.08, 0.90, "Inline label in X-axis zone", fontsize=16)
+ax.annotate("Low series", xy=(2022, 8), xytext=(0, -25), textcoords="offset points")
+fig.text(0.08, 0.03, "Source: test", fontsize=8)

--- a/tests/fixtures/bad_charts/scripts/label-to-label-overlap.py
+++ b/tests/fixtures/bad_charts/scripts/label-to-label-overlap.py
@@ -1,0 +1,11 @@
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots(figsize=(8, 5.5))
+ax.plot([2021, 2022, 2023], [50, 60, 70])
+ax.plot([2021, 2022, 2023], [52, 62, 72])
+fig.patches.append(mpatches.Rectangle((0, 0.96), 1, 0.04, transform=fig.transFigure))
+fig.text(0.08, 0.90, "Labels collide", fontsize=16)
+ax.annotate("Series A", xy=(2022, 60), xytext=(0, 10), textcoords="offset points")
+ax.annotate("Series B", xy=(2022, 62), xytext=(0, 10), textcoords="offset points")
+fig.text(0.08, 0.03, "Source: test", fontsize=8)

--- a/tests/fixtures/bad_charts/scripts/title-red-bar-overlap.py
+++ b/tests/fixtures/bad_charts/scripts/title-red-bar-overlap.py
@@ -1,0 +1,13 @@
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots(figsize=(8, 5.5))
+ax.plot([2021, 2022, 2023], [20, 40, 60])
+fig.patches.append(mpatches.Rectangle((0, 0.96), 1, 0.04, transform=fig.transFigure))
+fig.text(
+    0.08,
+    0.97,
+    "Growth slows",
+    fontsize=16,
+)
+fig.text(0.08, 0.03, "Source: test", fontsize=8)

--- a/tests/test_chart_layouts.py
+++ b/tests/test_chart_layouts.py
@@ -1,0 +1,109 @@
+"""Regression tests for known chart layout failures."""
+
+from pathlib import Path
+
+import pytest
+from PIL import Image, ImageDraw
+
+from src.quality.visual_qa_zones import ZoneBoundaryValidator
+
+FIXTURE_SCRIPTS = Path(__file__).parent / "fixtures" / "bad_charts" / "scripts"
+BG_COLOR = (241, 240, 233)
+RED_BAR = (227, 49, 11)
+
+
+def _write_chart_image(path: Path) -> None:
+    """Create a minimal Economist-coloured PNG for validator pixel checks."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    image = Image.new("RGB", (800, 550), BG_COLOR)
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((0, 0, 800, 21), fill=RED_BAR)
+    image.save(path)
+
+
+def _copy_fixture_script(tmp_path: Path, name: str) -> Path:
+    """Copy one bad script into the layout expected by the validator."""
+    root = tmp_path / "bad_charts"
+    scripts_dir = root / "scripts"
+    images_dir = root / "images"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    images_dir.mkdir(parents=True, exist_ok=True)
+
+    source = FIXTURE_SCRIPTS / f"{name}.py"
+    target = scripts_dir / source.name
+    target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    image_path = images_dir / f"{name}.png"
+    _write_chart_image(image_path)
+    return image_path
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "expected_issue"),
+    [
+        ("title-red-bar-overlap", "y=0.97 intrudes into RED BAR ZONE"),
+        ("inline-label-on-line", "near-zero xytext offset"),
+        ("inline-label-x-axis-zone", "may intrude into X-axis zone"),
+        ("label-to-label-overlap", "Label-to-label overlap likely"),
+        ("clipped-elements", "may be clipped at chart edge"),
+    ],
+)
+def test_known_bad_chart_layouts_are_detected(
+    tmp_path: Path,
+    fixture_name: str,
+    expected_issue: str,
+) -> None:
+    """Every documented bad chart pattern must fail deterministic QA."""
+    chart_path = _copy_fixture_script(tmp_path, fixture_name)
+
+    is_valid, issues = ZoneBoundaryValidator().validate_chart(str(chart_path))
+
+    assert not is_valid
+    assert any(expected_issue in issue for issue in issues), issues
+
+
+def test_multiline_annotations_with_offsets_are_not_flagged_as_missing(
+    tmp_path: Path,
+) -> None:
+    """Project chart scripts use multi-line annotate calls and should parse cleanly."""
+    root = tmp_path / "good_charts"
+    scripts_dir = root / "scripts"
+    images_dir = root / "images"
+    scripts_dir.mkdir(parents=True)
+    images_dir.mkdir(parents=True)
+
+    (scripts_dir / "good-multiline.py").write_text(
+        """
+import matplotlib.pyplot as plt
+
+fig, ax = plt.subplots()
+ax.annotate(
+    "High series",
+    xy=(2024, 78),
+    xytext=(-50, 15),
+    textcoords="offset points",
+)
+ax.annotate(
+    "End label",
+    xy=(2025, 80),
+    xytext=(10, 0),
+    textcoords="offset points",
+)
+ax.annotate(
+    "Low series",
+    xy=(2021, 8),
+    xytext=(0, 18),
+    textcoords="offset points",
+)
+fig.text(0.08, 0.90, "Clean title")
+""".strip(),
+        encoding="utf-8",
+    )
+    image_path = images_dir / "good-multiline.png"
+    _write_chart_image(image_path)
+
+    _is_valid, issues = ZoneBoundaryValidator().validate_chart(str(image_path))
+
+    assert not any("missing xytext offset" in issue for issue in issues), issues
+    assert not any("overlap data line" in issue for issue in issues), issues
+    assert not any("X-axis zone" in issue for issue in issues), issues

--- a/tests/test_visual_qa_zones.py
+++ b/tests/test_visual_qa_zones.py
@@ -35,12 +35,11 @@ def _make_compliant_chart(path: Path, width: int = 100, height: int = 100) -> Pa
     img = Image.new("RGB", (width, height), BG_RGB)
     pixels = np.array(img)
 
-    # Pixel rows are top-down; the validator slices ``int(height * 0.96):``
-    # for the red bar zone — i.e. the bottom 4% of the array.
-    red_bar_start = int(height * 0.96)
-    pixels[red_bar_start:, :, :] = RED_BAR_RGB
+    # Pixel rows are top-down, so the red bar occupies the first 4%.
+    red_bar_end = max(1, int(height * 0.04))
+    pixels[:red_bar_end, :, :] = RED_BAR_RGB
 
-    # Title zone (rows 0.85..0.94) should already be the beige bg above.
+    # Raster rows 0.06..0.15 correspond to the figure-coordinate title zone.
     Image.fromarray(pixels).save(path)
     return path
 
@@ -52,6 +51,16 @@ def _make_blank_chart(path: Path, width: int = 100, height: int = 100) -> Path:
     background (#f1f0e9) to exceed the validator's 10/30 tolerance windows.
     """
     Image.new("RGB", (width, height), (0, 0, 0)).save(path)
+    return path
+
+
+def _make_bottom_bar_chart(path: Path, width: int = 100, height: int = 100) -> Path:
+    """Create a chart with the red bar incorrectly placed at the bottom."""
+    img = Image.new("RGB", (width, height), BG_RGB)
+    pixels = np.array(img)
+    red_bar_start = int(height * 0.96)
+    pixels[red_bar_start:, :, :] = RED_BAR_RGB
+    Image.fromarray(pixels).save(path)
     return path
 
 
@@ -174,6 +183,7 @@ class TestValidateMatplotlibCode:
         _, issues = validator.validate_chart(str(chart_path))
 
         assert any("Subtitle y=0.2 outside TITLE ZONE" in i for i in issues)
+        assert not any("Title y=0.2 outside TITLE ZONE" in i for i in issues)
 
     def test_source_outside_zone_is_flagged(self, tmp_path: Path) -> None:
         validator = ZoneBoundaryValidator()
@@ -241,6 +251,15 @@ class TestValidatePixels:
         joined = "\n".join(issues)
         assert "Red bar not detected" in joined
         assert "Background color #f1f0e9 not dominant" in joined
+
+    def test_bottom_red_bar_is_rejected(self, tmp_path: Path) -> None:
+        validator = ZoneBoundaryValidator()
+        chart = _make_bottom_bar_chart(tmp_path / "pixel-bottom-bar.png")
+
+        is_valid, issues = validator.validate_chart(str(chart))
+
+        assert is_valid is False
+        assert any("Red bar not detected" in issue for issue in issues)
 
     def test_pixel_validation_swallows_unexpected_errors(
         self,


### PR DESCRIPTION
Closes #412

## Summary
- add a spec and thin-slice plan for the highest-priority ready item in `.github/BACKLOG.md`
- add fixture-backed deterministic regression coverage for the five documented chart layout failures
- replace regex-only Matplotlib annotation inspection with AST-backed checks
- correct pixel validation so the Economist red bar is checked at the top of the raster image
- mark the backlog item complete with implementation evidence

## RED -> GREEN
- RED: `MPLBACKEND=Agg .venv/bin/python -m pytest tests/test_chart_layouts.py -q` -> 6 failed before implementation
- GREEN: `MPLBACKEND=Agg .venv/bin/python -m pytest tests/test_chart_layouts.py tests/test_visual_qa_zones.py tests/test_generate_chart.py -q` -> 61 passed

## Verification
- `MPLBACKEND=Agg .venv/bin/python -m pytest tests/ -q --cov=src --cov=scripts --cov-report=term-missing --cov-report=xml --cov-fail-under=70`
  - 2309 passed, 31 skipped
  - aggregate coverage: 78.13%
- `.venv/bin/python -m coverage report --include="src/quality/*" --fail-under=90`
  - quality-module coverage: 97%
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/python scripts/check_bare_name_imports.py`
- `.venv/bin/python scripts/pre_commit_arch_check.py <touched-python-files>`
- `git diff --check`

## Notes
- The requested `docs/BACKLOG.md` path does not exist. The repository backlog source is `.github/BACKLOG.md`.
- The isolated worktree has no local `.venv`, so the architecture sub-hook and pre-push hook were run manually with the shared root virtualenv before commit and push.