### PR TITLE
fix: stdio MCP servers crash on standalone launch (published-topics, style-memory)

### DIFF
--- a/mcp_servers/published_topics_server.py
+++ b/mcp_servers/published_topics_server.py
@@ -21,11 +21,20 @@ Usage:
 """
 
 import logging
+import sys
+from pathlib import Path
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+# Ensure the repo root is on sys.path so the scripts package is importable
+# when this server is launched directly (python mcp_servers/<name>.py), where
+# sys.path[0] is the mcp_servers/ directory rather than the project root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
-from scripts.article_archive import ArticleArchive
+from mcp.server.fastmcp import FastMCP  # noqa: E402
+
+from scripts.article_archive import ArticleArchive  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/mcp_servers/style_memory_server.py
+++ b/mcp_servers/style_memory_server.py
@@ -14,7 +14,16 @@ Transport: stdio (FastMCP)
 from __future__ import annotations
 
 import logging
+import sys
+from pathlib import Path
 from typing import Any
+
+# Ensure the repo root is on sys.path so the src package is importable when this
+# server is launched directly (python mcp_servers/<name>.py), where sys.path[0]
+# is the mcp_servers/ directory rather than the project root.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 try:
     import chromadb
@@ -29,9 +38,9 @@ try:
 except ImportError:
     _UPSERT_ERRORS = (ValueError, RuntimeError, OSError)
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP  # noqa: E402
 
-from src.tools.style_memory_tool import StyleMemoryTool
+from src.tools.style_memory_tool import StyleMemoryTool  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/src/tools/style_memory_tool.py
+++ b/src/tools/style_memory_tool.py
@@ -69,7 +69,7 @@ class StyleMemoryTool:
         self.indexed_count = 0
 
         if not CHROMADB_AVAILABLE:
-            print("⚠️  ChromaDB unavailable - Style Memory Tool disabled")
+            logger.warning("ChromaDB unavailable - Style Memory Tool disabled")
             return
 
         try:
@@ -95,10 +95,12 @@ class StyleMemoryTool:
                 self._index_archive()
             else:
                 self.indexed_count = self.collection.count()
-                print(f"✅ Style Memory loaded: {self.indexed_count} patterns indexed")
+                logger.info(
+                    "Style Memory loaded: %d patterns indexed", self.indexed_count
+                )
 
         except Exception as e:
-            print(f"⚠️  Style Memory Tool initialization failed: {e}")
+            logger.warning("Style Memory Tool initialization failed: %s", e)
             self.client = None
             self.collection = None
 
@@ -108,16 +110,16 @@ class StyleMemoryTool:
         Graceful degradation: If archive is empty, continues without error.
         """
         if not self.archive_path.exists():
-            print(f"ℹ️  Archive directory not found: {self.archive_path}")
+            logger.info("Archive directory not found: %s", self.archive_path)
             return
 
         # Find all markdown files
         md_files = list(self.archive_path.glob("**/*.md"))
         if not md_files:
-            print(f"ℹ️  No Gold Standard articles found in {self.archive_path}")
+            logger.info("No Gold Standard articles found in %s", self.archive_path)
             return
 
-        print(f"📚 Indexing {len(md_files)} Gold Standard articles...")
+        logger.info("Indexing %d Gold Standard articles...", len(md_files))
 
         documents = []
         metadatas = []
@@ -149,20 +151,22 @@ class StyleMemoryTool:
                     ids.append(doc_id)
 
             except Exception as e:
-                print(f"⚠️  Failed to index {md_file.name}: {e}")
+                logger.warning("Failed to index %s: %s", md_file.name, e)
                 continue
 
         if documents:
             try:
                 self.collection.add(documents=documents, metadatas=metadatas, ids=ids)
                 self.indexed_count = len(documents)
-                print(
-                    f"✅ Indexed {self.indexed_count} style patterns from {len(md_files)} articles",
+                logger.info(
+                    "Indexed %d style patterns from %d articles",
+                    self.indexed_count,
+                    len(md_files),
                 )
             except Exception as e:
-                print(f"❌ Failed to add documents to ChromaDB: {e}")
+                logger.error("Failed to add documents to ChromaDB: %s", e)
         else:
-            print("ℹ️  No valid content found to index")
+            logger.info("No valid content found to index")
 
     def query(
         self,
@@ -237,7 +241,7 @@ class StyleMemoryTool:
             return formatted_results
 
         except Exception as e:
-            print(f"⚠️  Style Memory query failed: {e}")
+            logger.warning("Style Memory query failed: %s", e)
             return []
 
     def get_style_context(

--- a/src/tools/style_memory_tool.py
+++ b/src/tools/style_memory_tool.py
@@ -20,8 +20,11 @@ Usage:
         print(result["text"], result["score"])
 """
 
+import logging
 from pathlib import Path
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 try:
     import chromadb
@@ -30,7 +33,9 @@ try:
     CHROMADB_AVAILABLE = True
 except ImportError:
     CHROMADB_AVAILABLE = False
-    print("⚠️  ChromaDB not installed. Style Memory Tool in fallback mode.")
+    # Must not print to stdout: this module is imported by a stdio MCP server,
+    # where stdout carries the JSON-RPC stream. Log to stderr via logging.
+    logger.warning("ChromaDB not installed. Style Memory Tool in fallback mode.")
 
 
 class StyleMemoryTool:

--- a/tests/test_mcp_servers/test_server_launch.py
+++ b/tests/test_mcp_servers/test_server_launch.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Regression guard: stdio MCP servers must launch as standalone subprocesses.
+"""Regression guard: stdio MCP servers must launch and stay protocol-clean.
 
 The MCP client (Claude Code) starts each server with ``python mcp_servers/<name>.py``.
 When launched that way, ``sys.path[0]`` is the ``mcp_servers/`` directory rather
@@ -7,10 +7,19 @@ than the project root, so a server that imports ``scripts.*`` or ``src.*`` witho
 bootstrapping the repo root onto ``sys.path`` crashes with ``ModuleNotFoundError``
 and the client reports ``MCP error -32000: Connection closed``.
 
+On a stdio transport, **stdout carries the JSON-RPC stream**. Any stray ``print``
+in an imported module — including ones that only fire later, on the first
+``tools/call`` when a lazy singleton is constructed — corrupts that stream and
+reproduces the same "Connection closed" failure, just deferred from launch to
+first use. So these tests assert two things:
+
+1. The server launches and answers ``initialize`` (no import crash).
+2. Every line the server writes to stdout is valid JSON-RPC — across launch,
+   handshake, ``tools/list`` and an actual ``tools/call`` — so a stray print on
+   any reachable path is caught.
+
 The unit tests in this package patch ``sys.path`` before importing the server
-module, which masks that failure. These tests deliberately do NOT — they spawn the
-server exactly as the client does and assert a clean JSON-RPC ``initialize``
-handshake on stdout, with no import error on stderr.
+module, which masks the launch failure; these spawn a real subprocess instead.
 
 Usage:
     pytest tests/test_mcp_servers/test_server_launch.py -v
@@ -22,6 +31,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -29,12 +39,19 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 # stdio servers that import local packages (scripts.* / src.*) and need no
 # external API keys to complete an initialize handshake.
-_SERVERS = [
+_LOCAL_SERVERS = [
     "published_topics_server",
     "style_memory_server",
     "article_evaluator_server",
     "publication_validator_server",
 ]
+
+# A representative, side-effect-light tool call per server that constructs the
+# server's lazily-initialised backing object (the path where stray prints hide).
+_TOOL_CALLS = {
+    "published_topics_server": ("get_archive_stats", {}),
+    "style_memory_server": ("query_style_memory", {"query": "test"}),
+}
 
 _INITIALIZE = {
     "jsonrpc": "2.0",
@@ -46,33 +63,89 @@ _INITIALIZE = {
         "clientInfo": {"name": "pytest", "version": "1.0"},
     },
 }
+_INITIALIZED = {"jsonrpc": "2.0", "method": "notifications/initialized"}
 
 
-@pytest.mark.parametrize("server", _SERVERS)
-def test_server_launches_and_completes_handshake(server: str) -> None:
-    """Each stdio server, launched standalone, answers initialize on stdout."""
+def _run_server(
+    server: str, payloads: list[dict[str, Any]]
+) -> subprocess.CompletedProcess[str]:
+    """Spawn a server standalone and feed it newline-delimited JSON-RPC messages."""
     script = _REPO_ROOT / "mcp_servers" / f"{server}.py"
     assert script.exists(), f"missing server script: {script}"
-
-    proc = subprocess.run(
+    stdin = "".join(json.dumps(p) + "\n" for p in payloads)
+    # cwd is the repo root, but `python path/to/x.py` still puts the script dir
+    # (not cwd) on sys.path[0] — so the bootstrap is what actually matters.
+    return subprocess.run(
         [sys.executable, str(script)],
-        input=json.dumps(_INITIALIZE) + "\n",
+        input=stdin,
         capture_output=True,
         text=True,
         timeout=30,
-        # cwd intentionally the repo root: even so, `python path/to/x.py` puts the
-        # script dir (not cwd) on sys.path[0], so the bootstrap is what matters.
         cwd=str(_REPO_ROOT),
     )
+
+
+def _assert_stdout_all_json_rpc(
+    server: str, stdout: str, stderr: str
+) -> list[dict[str, Any]]:
+    """Every non-empty stdout line must parse as a JSON-RPC object."""
+    messages: list[dict[str, Any]] = []
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:  # pragma: no cover - failure path
+            pytest.fail(
+                f"{server} wrote non-JSON to stdout (corrupts the stdio stream): "
+                f"{line!r}\nstderr:\n{stderr}"
+            )
+        assert isinstance(message, dict) and message.get("jsonrpc") == "2.0", (
+            f"{server} stdout line is not a JSON-RPC message: {line!r}"
+        )
+        messages.append(message)
+    return messages
+
+
+@pytest.mark.parametrize("server", _LOCAL_SERVERS)
+def test_server_launches_and_completes_handshake(server: str) -> None:
+    """Each stdio server, launched standalone, answers initialize on stdout."""
+    proc = _run_server(server, [_INITIALIZE])
 
     assert "ModuleNotFoundError" not in proc.stderr, (
         f"{server} failed to import when launched standalone:\n{proc.stderr}"
     )
+    messages = _assert_stdout_all_json_rpc(server, proc.stdout, proc.stderr)
+    init_result = next((m for m in messages if m.get("id") == 1), None)
+    assert init_result is not None, f"{server} returned no initialize response"
+    assert "result" in init_result, f"{server} did not return an initialize result"
+    assert init_result["result"].get("protocolVersion")
 
-    first_line = proc.stdout.strip().splitlines()[0] if proc.stdout.strip() else ""
-    assert first_line, f"{server} produced no stdout. stderr:\n{proc.stderr}"
 
-    message = json.loads(first_line)
-    assert message.get("id") == 1
-    assert "result" in message, f"{server} did not return an initialize result"
-    assert message["result"].get("protocolVersion")
+@pytest.mark.parametrize("server", sorted(_TOOL_CALLS))
+def test_tool_call_keeps_stdout_protocol_clean(server: str) -> None:
+    """A real tools/call must not leak any non-JSON-RPC output to stdout.
+
+    Regression for #414: lazily-constructed backing objects (StyleMemoryTool /
+    ArticleArchive) previously printed status banners to stdout on first use,
+    corrupting the JSON-RPC stream after a clean handshake.
+    """
+    tool_name, arguments = _TOOL_CALLS[server]
+    proc = _run_server(
+        server,
+        [
+            _INITIALIZE,
+            _INITIALIZED,
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": tool_name, "arguments": arguments},
+            },
+        ],
+    )
+
+    assert "ModuleNotFoundError" not in proc.stderr, proc.stderr
+    # Purity is the assertion that matters: every stdout line is JSON-RPC, even
+    # though the tool call itself may succeed or return a JSON-RPC error.
+    _assert_stdout_all_json_rpc(server, proc.stdout, proc.stderr)

--- a/tests/test_mcp_servers/test_server_launch.py
+++ b/tests/test_mcp_servers/test_server_launch.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Regression guard: stdio MCP servers must launch as standalone subprocesses.
+
+The MCP client (Claude Code) starts each server with ``python mcp_servers/<name>.py``.
+When launched that way, ``sys.path[0]`` is the ``mcp_servers/`` directory rather
+than the project root, so a server that imports ``scripts.*`` or ``src.*`` without
+bootstrapping the repo root onto ``sys.path`` crashes with ``ModuleNotFoundError``
+and the client reports ``MCP error -32000: Connection closed``.
+
+The unit tests in this package patch ``sys.path`` before importing the server
+module, which masks that failure. These tests deliberately do NOT — they spawn the
+server exactly as the client does and assert a clean JSON-RPC ``initialize``
+handshake on stdout, with no import error on stderr.
+
+Usage:
+    pytest tests/test_mcp_servers/test_server_launch.py -v
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+# stdio servers that import local packages (scripts.* / src.*) and need no
+# external API keys to complete an initialize handshake.
+_SERVERS = [
+    "published_topics_server",
+    "style_memory_server",
+    "article_evaluator_server",
+    "publication_validator_server",
+]
+
+_INITIALIZE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2024-11-05",
+        "capabilities": {},
+        "clientInfo": {"name": "pytest", "version": "1.0"},
+    },
+}
+
+
+@pytest.mark.parametrize("server", _SERVERS)
+def test_server_launches_and_completes_handshake(server: str) -> None:
+    """Each stdio server, launched standalone, answers initialize on stdout."""
+    script = _REPO_ROOT / "mcp_servers" / f"{server}.py"
+    assert script.exists(), f"missing server script: {script}"
+
+    proc = subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(_INITIALIZE) + "\n",
+        capture_output=True,
+        text=True,
+        timeout=30,
+        # cwd intentionally the repo root: even so, `python path/to/x.py` puts the
+        # script dir (not cwd) on sys.path[0], so the bootstrap is what matters.
+        cwd=str(_REPO_ROOT),
+    )
+
+    assert "ModuleNotFoundError" not in proc.stderr, (
+        f"{server} failed to import when launched standalone:\n{proc.stderr}"
+    )
+
+    first_line = proc.stdout.strip().splitlines()[0] if proc.stdout.strip() else ""
+    assert first_line, f"{server} produced no stdout. stderr:\n{proc.stderr}"
+
+    message = json.loads(first_line)
+    assert message.get("id") == 1
+    assert "result" in message, f"{server} did not return an initialize result"
+    assert message["result"].get("protocolVersion")


### PR DESCRIPTION
## Summary
Two stdio MCP servers — **published-topics** and **style-memory** — were failing with `MCP error -32000: Connection closed` (surfaced by `/doctor`). They are broken on `main` today.

## Root cause
When the MCP client launches a server via `python mcp_servers/<name>.py`, `sys.path[0]` is the `mcp_servers/` directory, not the project root. So `from scripts.*` (published-topics) and `from src.*` (style-memory) raise `ModuleNotFoundError` before the server starts. The working servers (`article-evaluator`, `publication-validator`) already bootstrap the repo root onto `sys.path`; these two did not.

Secondary defect: `src/tools/style_memory_tool.py` printed its ChromaDB-fallback warning to **stdout**, which corrupts the JSON-RPC stream on a stdio transport. Now routed through `logging` (stderr), per the CLAUDE.md "logger not print()" standard.

## Fix
- Add the repo-root `sys.path` bootstrap to both servers, matching the existing working-server pattern.
- Route the ChromaDB-fallback warning through `logging`.

## Why the existing tests missed it
The unit tests `sys.path.insert(...)` **before** importing the server module, masking the standalone-launch failure.

## Verification
- New `tests/test_mcp_servers/test_server_launch.py` spawns each server as a subprocess (the way the client does) and asserts a clean `initialize` handshake with no `ModuleNotFoundError`.
- `pytest tests/test_mcp_servers/` → **175 passed**.
- `ruff check` / pre-commit hooks → pass.

## Not covered
The third `/doctor` item — `github` MCP "needs authentication" — is a user action (`/mcp` → authenticate), not a code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #419
