### PR TITLE
fix: visual QA parses positional annotate() anchors (#413)

### DIFF
--- a/src/quality/visual_qa_zones.py
+++ b/src/quality/visual_qa_zones.py
@@ -238,7 +238,13 @@ class ZoneBoundaryValidator:
             if not isinstance(node.func.value, ast.Name) or node.func.value.id != "ax":
                 continue
 
+            # Matplotlib's annotate signature is annotate(text, xy, ...), so the
+            # anchor may be supplied positionally as args[1] rather than as the
+            # xy keyword. Fall back to the positional form when the keyword is
+            # absent (#413) so X-axis intrusion and label-collision checks fire.
             xy_node = self._find_keyword_node(node, "xy")
+            if xy_node is None and len(node.args) > 1:
+                xy_node = node.args[1]
             xytext_node = self._find_keyword_node(node, "xytext")
             annotations.append(
                 {

--- a/tests/test_visual_qa_zones.py
+++ b/tests/test_visual_qa_zones.py
@@ -212,6 +212,49 @@ class TestValidateMatplotlibCode:
 
         assert any("Inline label missing xytext offset" in i for i in issues)
 
+    def test_positional_xy_anchor_triggers_xaxis_intrusion(
+        self, tmp_path: Path
+    ) -> None:
+        """Matplotlib accepts the anchor positionally: annotate(text, xy, ...).
+
+        Regression for #413: the parser previously read only the ``xy`` keyword,
+        so a positional anchor recorded ``xy=None`` and silently skipped the
+        X-axis intrusion check. The positional form must behave like the keyword
+        form below.
+        """
+        validator = ZoneBoundaryValidator()
+        code = 'ax.annotate("label", (5, 10), xytext=(0, -5))\n'
+        chart_path = _setup_script_alongside_chart(tmp_path, code)
+
+        _, issues = validator.validate_chart(str(chart_path))
+
+        assert any("may intrude into X-axis zone" in i for i in issues)
+
+    def test_keyword_xy_anchor_triggers_xaxis_intrusion(self, tmp_path: Path) -> None:
+        """Parity baseline: keyword ``xy`` must fire the same check as positional."""
+        validator = ZoneBoundaryValidator()
+        code = 'ax.annotate("label", xy=(5, 10), xytext=(0, -5))\n'
+        chart_path = _setup_script_alongside_chart(tmp_path, code)
+
+        _, issues = validator.validate_chart(str(chart_path))
+
+        assert any("may intrude into X-axis zone" in i for i in issues)
+
+    def test_positional_xy_anchor_triggers_label_collision(
+        self, tmp_path: Path
+    ) -> None:
+        """Positional anchors must also feed label-collision detection (#413)."""
+        validator = ZoneBoundaryValidator()
+        code = (
+            'ax.annotate("a", (5, 50), xytext=(0, 5))\n'
+            'ax.annotate("b", (5, 50), xytext=(0, 5))\n'
+        )
+        chart_path = _setup_script_alongside_chart(tmp_path, code)
+
+        _, issues = validator.validate_chart(str(chart_path))
+
+        assert any("collide" in i.lower() or "overlap" in i.lower() for i in issues)
+
     def test_no_script_means_no_code_issues(self, tmp_path: Path) -> None:
         """When no sibling script exists the code-validation step is skipped."""
         validator = ZoneBoundaryValidator()


### PR DESCRIPTION
## Summary
`ZoneBoundaryValidator._iter_annotation_calls()` read the anchor only from the `xy` keyword. Matplotlib also accepts it positionally — `annotate(text, xy, ...)`. A positional anchor recorded `xy=None`, silently skipping the **X-axis intrusion** and **label-collision** checks even when `xytext` was present.

This was the remaining unresolved Copilot finding carried over from the closed PR #407 and still present in the implementation merged by #411.

## Fix
Fall back to `node.args[1]` when the `xy` keyword is absent.

## Verification (TDD)
- Red: two new tests for the positional form failed; the keyword-form parity baseline passed.
- Green after fix: `pytest tests/test_visual_qa_zones.py tests/test_chart_layouts.py` → **35 passed**.
- New coverage proves both the X-axis intrusion check and label-collision detection fire for positional anchors.
- `ruff` clean; pre-commit hooks pass.

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)