### PR TITLE
fix: pin writer-prompt author to a single source of truth (#401)

### DIFF
--- a/scripts/publication_validator.py
+++ b/scripts/publication_validator.py
@@ -23,9 +23,12 @@ from pathlib import Path
 import yaml
 
 # Single source of truth for the production blog author. The Stage 3 writer
-# prompt, the Stage 4 frontmatter safety net, and this validator's author
-# contract all reference this constant so the value is configured in exactly
-# one place (see issue #401).
+# prompt and this validator's author contract both reference this constant so
+# the writer is instructed with the exact value the contract enforces, in one
+# place (see issue #401). The Stage 4 frontmatter safety net in
+# ``src/agent_sdk/_shared.py`` still emits the same value as a literal; wiring
+# it to this constant is deferred (that module carries an unrelated ADR-002
+# violation that the arch-review gate blocks on edit).
 BLOG_AUTHOR = "Ouray Viney"
 
 # Import defect prevention rules (learned from historical bugs)

--- a/scripts/publication_validator.py
+++ b/scripts/publication_validator.py
@@ -22,6 +22,12 @@ from pathlib import Path
 
 import yaml
 
+# Single source of truth for the production blog author. The Stage 3 writer
+# prompt, the Stage 4 frontmatter safety net, and this validator's author
+# contract all reference this constant so the value is configured in exactly
+# one place (see issue #401).
+BLOG_AUTHOR = "Ouray Viney"
+
 # Import defect prevention rules (learned from historical bugs)
 try:
     from scripts.defect_prevention_rules import DefectPrevention
@@ -549,14 +555,14 @@ class PublicationValidator:
                     if not isinstance(front_matter, dict):
                         return
                     author = front_matter.get("author")
-                    if author != "Ouray Viney":
+                    if author != BLOG_AUTHOR:
                         self.issues.append(
                             {
                                 "check": "author_contract",
                                 "severity": "CRITICAL",
-                                "message": f'Invalid author "{author}". Expected "Ouray Viney"',
+                                "message": f'Invalid author "{author}". Expected "{BLOG_AUTHOR}"',
                                 "details": "Published blog posts must use the production author metadata contract",
-                                "fix": 'Set author to "Ouray Viney"',
+                                "fix": f'Set author to "{BLOG_AUTHOR}"',
                             },
                         )
         except Exception:

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -36,6 +36,7 @@ from claude_agent_sdk import (
     query,
 )
 
+from scripts.publication_validator import BLOG_AUTHOR
 from src.agent_sdk._shared import (
     _ALLOWED_MODELS as _ALLOWED_MODELS,
 )
@@ -141,6 +142,42 @@ FORMATTING:
 - Separate paragraphs with a blank line
 - Place a blank line before and after every `## ` heading
 - Do not emit the article more than once; output exactly one article per response"""
+
+
+def _build_writer_prompt(topic: str, research_brief: str, style_section: str) -> str:
+    """Build the Stage 3 writer user-prompt.
+
+    The author is pinned to ``BLOG_AUTHOR`` (the single source of truth shared
+    with the publication validator) so the model does not invent an author name
+    that Stage 4's author contract would then reject (issue #401).
+    """
+    return (
+        f"Write the complete Economist-style article on this topic: {topic}\n\n"
+        f"Output the entire article text with YAML frontmatter at the top. "
+        f"Start directly with `---` — no preamble, no commentary.\n\n"
+        f"Frontmatter must include: layout, title, date, author (set exactly "
+        f'to "{BLOG_AUTHOR}" — do not invent an author name), categories '
+        f"(Title Case from: Quality Engineering, Software Engineering, "
+        f"Test Automation, Security), image (/assets/images/SLUG.png), "
+        f"description (160 chars max), "
+        f"image_alt (one sentence describing the ideal editorial illustration "
+        f"for accessibility — written from the article thesis, e.g. "
+        f"'An Economist-style editorial illustration of a developer staring at "
+        f"a dashboard filled with green checkmarks while a production server burns'), "
+        f"and image_caption (one punchy editorial sentence framing the image's "
+        f"point, e.g. 'Coverage metrics and shipping confidence are not the same thing').\n\n"
+        f"Body must be at least 850 words (the publication validator "
+        f"rejects anything under 700, so leave a margin). End with a "
+        f"`## References` section containing 3+ numbered citations.\n\n"
+        f"At least one paragraph in the body must reference the chart "
+        f"explicitly — write something like 'as the chart shows', "
+        f"'the chart makes clear', or 'the chart below illustrates'. "
+        f"This is required by the publication validator.\n\n"
+        f"RESEARCH BRIEF (use ONLY these sources and statistics — do NOT "
+        f"invent any statistics, researcher names, or URLs):\n\n"
+        f"{research_brief}"
+        f"{style_section}"
+    )
 
 
 @dataclass
@@ -362,32 +399,7 @@ async def run_stage3(
     else:
         style_section = ""
 
-    writer_prompt = (
-        f"Write the complete Economist-style article on this topic: {topic}\n\n"
-        f"Output the entire article text with YAML frontmatter at the top. "
-        f"Start directly with `---` — no preamble, no commentary.\n\n"
-        f"Frontmatter must include: layout, title, date, author, categories "
-        f"(Title Case from: Quality Engineering, Software Engineering, "
-        f"Test Automation, Security), image (/assets/images/SLUG.png), "
-        f"description (160 chars max), "
-        f"image_alt (one sentence describing the ideal editorial illustration "
-        f"for accessibility — written from the article thesis, e.g. "
-        f"'An Economist-style editorial illustration of a developer staring at "
-        f"a dashboard filled with green checkmarks while a production server burns'), "
-        f"and image_caption (one punchy editorial sentence framing the image's "
-        f"point, e.g. 'Coverage metrics and shipping confidence are not the same thing').\n\n"
-        f"Body must be at least 850 words (the publication validator "
-        f"rejects anything under 700, so leave a margin). End with a "
-        f"`## References` section containing 3+ numbered citations.\n\n"
-        f"At least one paragraph in the body must reference the chart "
-        f"explicitly — write something like 'as the chart shows', "
-        f"'the chart makes clear', or 'the chart below illustrates'. "
-        f"This is required by the publication validator.\n\n"
-        f"RESEARCH BRIEF (use ONLY these sources and statistics — do NOT "
-        f"invent any statistics, researcher names, or URLs):\n\n"
-        f"{research_brief}"
-        f"{style_section}"
-    )
+    writer_prompt = _build_writer_prompt(topic, research_brief, style_section)
     raw_writer_output, writer_cost = await _collect_text(
         writer_prompt,
         WRITER_SYSTEM_PROMPT,

--- a/tests/test_author_contract.py
+++ b/tests/test_author_contract.py
@@ -9,6 +9,8 @@ that Stage 4 then rejects.
 
 from __future__ import annotations
 
+import re
+
 from scripts.publication_validator import BLOG_AUTHOR, PublicationValidator
 from src.agent_sdk._shared import apply_editorial_fixes
 from src.agent_sdk.stage3_runner import _build_writer_prompt
@@ -38,9 +40,14 @@ def test_writer_prompt_does_not_emit_the_known_bad_author() -> None:
     assert "Economist Writer" not in prompt
 
 
-def test_safety_net_uses_configured_author_when_missing() -> None:
-    """The Stage 4 frontmatter safety net adds the configured author, not a
-    hardcoded literal that could drift from the validator's contract."""
+def test_safety_net_emits_the_production_author_when_missing() -> None:
+    """Behavioural guard: the Stage 4 frontmatter safety net fills in the
+    production author when the writer omits it.
+
+    NB: the safety net currently emits the value as a literal (it is not yet
+    wired to ``BLOG_AUTHOR`` — see the constant's docstring), so this asserts
+    the observable output equals the configured author, not the implementation.
+    """
     article = '---\nlayout: post\ntitle: "X"\ncategories: ["Quality Engineering"]\n---\n\nBody text.'
     fixed = apply_editorial_fixes(article)
     assert f'author: "{BLOG_AUTHOR}"' in fixed
@@ -53,6 +60,26 @@ def test_validator_accepts_configured_author() -> None:
         f'author: "{BLOG_AUTHOR}"\ncategories: ["quality-engineering"]\n'
         f"---\n\nBody.\n"
     )
+    validator._check_author(article)
+    assert not any(i["check"] == "author_contract" for i in validator.issues)
+
+
+def test_prompt_pinned_author_passes_the_validator_contract() -> None:
+    """End-to-end: the exact author the writer prompt pins must satisfy the
+    validator's author contract — verified dynamically, not via independent
+    literal checks, so the two cannot silently drift.
+    """
+    prompt = _build_writer_prompt("T", "B", "")
+    match = re.search(r'set exactly to "([^"]+)"', prompt)
+    assert match, "writer prompt no longer pins an explicit author value"
+    pinned_author = match.group(1)
+
+    article = (
+        f'---\nlayout: post\ntitle: "X"\ndate: 2026-06-11\n'
+        f'author: "{pinned_author}"\ncategories: ["quality-engineering"]\n'
+        f"---\n\nBody.\n"
+    )
+    validator = PublicationValidator()
     validator._check_author(article)
     assert not any(i["check"] == "author_contract" for i in validator.issues)
 

--- a/tests/test_author_contract.py
+++ b/tests/test_author_contract.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Regression tests for the blog author contract (issue #401).
+
+The production author name must live in exactly one place and flow from there
+into the Stage 3 writer prompt, the Stage 4 frontmatter safety net, and the
+publication validator's author contract — so the writer never emits an author
+that Stage 4 then rejects.
+"""
+
+from __future__ import annotations
+
+from scripts.publication_validator import BLOG_AUTHOR, PublicationValidator
+from src.agent_sdk._shared import apply_editorial_fixes
+from src.agent_sdk.stage3_runner import _build_writer_prompt
+
+
+def test_blog_author_is_the_configured_production_author() -> None:
+    assert BLOG_AUTHOR == "Ouray Viney"
+
+
+def test_writer_prompt_pins_the_configured_author() -> None:
+    """The Stage 3 writer prompt must tell the model the exact author to use.
+
+    Previously the prompt only listed ``author`` as a required field without a
+    value, so the model invented "Economist Writer" and Stage 4 failed.
+    """
+    prompt = _build_writer_prompt(
+        topic="Test topic",
+        research_brief="Some brief.",
+        style_section="",
+    )
+    assert BLOG_AUTHOR in prompt
+    assert "do not invent an author" in prompt.lower()
+
+
+def test_writer_prompt_does_not_emit_the_known_bad_author() -> None:
+    prompt = _build_writer_prompt("T", "B", "")
+    assert "Economist Writer" not in prompt
+
+
+def test_safety_net_uses_configured_author_when_missing() -> None:
+    """The Stage 4 frontmatter safety net adds the configured author, not a
+    hardcoded literal that could drift from the validator's contract."""
+    article = '---\nlayout: post\ntitle: "X"\ncategories: ["Quality Engineering"]\n---\n\nBody text.'
+    fixed = apply_editorial_fixes(article)
+    assert f'author: "{BLOG_AUTHOR}"' in fixed
+
+
+def test_validator_accepts_configured_author() -> None:
+    validator = PublicationValidator()
+    article = (
+        f'---\nlayout: post\ntitle: "X"\ndate: 2026-06-11\n'
+        f'author: "{BLOG_AUTHOR}"\ncategories: ["quality-engineering"]\n'
+        f"---\n\nBody.\n"
+    )
+    validator._check_author(article)
+    assert not any(i["check"] == "author_contract" for i in validator.issues)
+
+
+def test_validator_rejects_wrong_author_referencing_constant() -> None:
+    validator = PublicationValidator()
+    article = (
+        '---\nlayout: post\ntitle: "X"\ndate: 2026-06-11\n'
+        'author: "Economist Writer"\ncategories: ["quality-engineering"]\n'
+        "---\n\nBody.\n"
+    )
+    validator._check_author(article)
+    author_issues = [i for i in validator.issues if i["check"] == "author_contract"]
+    assert len(author_issues) == 1
+    assert BLOG_AUTHOR in author_issues[0]["message"]


### PR DESCRIPTION
## Summary
The Stage 3 writer prompt (the production Agent SDK path, `src/agent_sdk/stage3_runner.py`) listed `author` as a required frontmatter field but never told the model *which* value to use. The model emitted `author: Economist Writer`, and Stage 4's `author_contract` then FAILed (`Invalid author "Economist Writer". Expected "Ouray Viney"`) — forcing a manual `sed` fix on every clean run (reproduced 2026-05-18).

## Fix (prevention at the source)
- New single source of truth: `BLOG_AUTHOR` constant in `scripts/publication_validator.py`.
- The validator's `author_contract` check now references it.
- The Stage 3 writer prompt now instructs the **exact** author (`set exactly to "Ouray Viney" — do not invent an author name`), so the writer stops emitting the wrong value and no Stage 4 catch-and-patch is needed.
- Extracted the inline prompt into a pure `_build_writer_prompt()` helper so the author instruction is unit-testable.

## Scope note
I deliberately did **not** modify `src/agent_sdk/_shared.py`: its frontmatter safety net already emits the correct author, and that file carries a pre-existing ADR-002 `anthropic`-import violation (flagged by the arch-review hook) that is out of scope for this fix.

## Verification (TDD)
- `tests/test_author_contract.py` (6 tests): prompt pins the author, never emits the known-bad value, validator accepts the configured author and rejects others referencing the constant.
- `pytest -k "publication_validator or stage3 or shared or schema_validator or agent_contracts"` → **207 passed, 3 skipped**.
- `ruff` + arch-review + pre-commit hooks pass.

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)