### PR TITLE
chore: remove transitional import fallback in continuous_burndown.py (#360)

### DIFF
--- a/scripts/continuous_burndown.py
+++ b/scripts/continuous_burndown.py
@@ -48,22 +48,13 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for minimal envs
 
     orjson = _OrjsonCompat()
 
-try:
-    from scripts.github_issue_claim import GitHubIssueClaimer
-    from scripts.sprint_validator import SprintValidator
-    from src.backlog.backlog_groomer import BacklogGroomer
-    from src.backlog.ci_health_monitor import CIHealthMonitor
-    from src.backlog.migrate_backlog_to_github import BacklogParser
-    from src.backlog.validate_documentation_accuracy import DocumentationValidator
-except ModuleNotFoundError:  # pragma: no cover - direct script execution fallback
-    from backlog_groomer import BacklogGroomer
-    from ci_health_monitor import CIHealthMonitor
-    from migrate_backlog_to_github import BacklogParser
-    from validate_documentation_accuracy import DocumentationValidator
-
-    from scripts.github_issue_claim import GitHubIssueClaimer
-    from scripts.sprint_validator import SprintValidator
 from schemas.validate_schemas import validate_json_file
+from scripts.github_issue_claim import GitHubIssueClaimer
+from scripts.sprint_validator import SprintValidator
+from src.backlog.backlog_groomer import BacklogGroomer
+from src.backlog.ci_health_monitor import CIHealthMonitor
+from src.backlog.migrate_backlog_to_github import BacklogParser
+from src.backlog.validate_documentation_accuracy import DocumentationValidator
 
 DEFAULT_REPORT = "logs/continuous_burndown_report.json"
 


### PR DESCRIPTION
## Summary
PR #357 (ADR-0010) migrated the backlog modules to `src/backlog/` and removed the `sys.path` hack that let bare-name imports resolve. The `try/except ModuleNotFoundError` fallback in `continuous_burndown.py` was transitional insurance during that migration.

## Soak satisfied
PR #357 merged **2026-05-15**; today is **2026-06-12** — ~4 weeks of clean soak, matching the issue's 2–4 week window. Collapse the block to the canonical package imports.

The repo-root `sys.path` bootstrap (line 27) is unrelated and retained — it's what makes `src.backlog` / `scripts` / `schemas` importable when the file runs directly.

## Verification
- `python -c "import scripts.continuous_burndown"` → OK
- `pytest -k burndown` → **2 passed**
- `ruff` + arch-review + pre-commit hooks pass

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)