### PR TITLE
fix: visual QA parses positional annotate() xytext (#418)

### DIFF
--- a/src/quality/visual_qa_zones.py
+++ b/src/quality/visual_qa_zones.py
@@ -238,14 +238,17 @@ class ZoneBoundaryValidator:
             if not isinstance(node.func.value, ast.Name) or node.func.value.id != "ax":
                 continue
 
-            # Matplotlib's annotate signature is annotate(text, xy, ...), so the
-            # anchor may be supplied positionally as args[1] rather than as the
-            # xy keyword. Fall back to the positional form when the keyword is
-            # absent (#413) so X-axis intrusion and label-collision checks fire.
+            # Matplotlib's annotate signature is annotate(text, xy, xytext, ...),
+            # so the anchor (args[1]) and the offset (args[2]) may be supplied
+            # positionally rather than as keywords. Fall back to the positional
+            # form when each keyword is absent so the X-axis intrusion,
+            # label-collision, and offset checks fire either way (#413, #418).
             xy_node = self._find_keyword_node(node, "xy")
             if xy_node is None and len(node.args) > 1:
                 xy_node = node.args[1]
             xytext_node = self._find_keyword_node(node, "xytext")
+            if xytext_node is None and len(node.args) > 2:
+                xytext_node = node.args[2]
             annotations.append(
                 {
                     "label": self._extract_string_arg(node, 0),

--- a/tests/test_visual_qa_zones.py
+++ b/tests/test_visual_qa_zones.py
@@ -255,6 +255,34 @@ class TestValidateMatplotlibCode:
 
         assert any("collide" in i.lower() or "overlap" in i.lower() for i in issues)
 
+    def test_positional_xytext_not_flagged_as_missing(self, tmp_path: Path) -> None:
+        """Matplotlib accepts xytext positionally: annotate(text, xy, xytext, ...).
+
+        Regression for #418: the parser previously read only the ``xytext``
+        keyword, so a fully-positional call recorded ``has_xytext=False`` and
+        wrongly emitted the "missing xytext offset" warning.
+        """
+        validator = ZoneBoundaryValidator()
+        code = 'ax.annotate("label", (5, 50), (0, 5))\n'
+        chart_path = _setup_script_alongside_chart(tmp_path, code)
+
+        _, issues = validator.validate_chart(str(chart_path))
+
+        assert not any("missing xytext offset" in i for i in issues)
+
+    def test_positional_xytext_near_zero_offset_is_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        """A positional xytext with a near-zero offset must fire the same
+        overlap warning as the keyword form (#418)."""
+        validator = ZoneBoundaryValidator()
+        code = 'ax.annotate("label", (5, 50), (0, 0))\n'
+        chart_path = _setup_script_alongside_chart(tmp_path, code)
+
+        _, issues = validator.validate_chart(str(chart_path))
+
+        assert any("near-zero xytext offset" in i for i in issues)
+
     def test_no_script_means_no_code_issues(self, tmp_path: Path) -> None:
         """When no sibling script exists the code-validation step is skipped."""
         validator = ZoneBoundaryValidator()


### PR DESCRIPTION
## Summary
Follow-up to #413 (which fixed the positional `xy` anchor). `_iter_annotation_calls()` still read `xytext` only via the keyword, so a fully-positional call — `annotate(text, xy, xytext)` — recorded `has_xytext=False`, producing a **false** "missing xytext offset" warning and skipping the near-zero-offset check.

## Fix
Fall back to `node.args[2]` when the `xytext` keyword is absent, mirroring the `args[1]` anchor fix.

## Verification (TDD)
- Red: positional-xytext tests failed (false "missing" warning; near-zero not flagged).
- Green: `pytest tests/test_visual_qa_zones.py tests/test_chart_layouts.py` → **37 passed**.
- `ruff` + pre-commit pass.

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)