### PR TITLE
feat: hybrid research — writer on-demand source fetch (#389)

### DIFF
--- a/docs/specs/389-hybrid-research.md
+++ b/docs/specs/389-hybrid-research.md
@@ -1,0 +1,117 @@
+# Spec: Hybrid Research — Deterministic Seed + Writer On-Demand Source Fetch (#389)
+
+**Status:** DRAFT — awaiting human LGTM (do not implement until approved)
+**Issue:** [#389](https://github.com/oviney/economist-agents/issues/389)
+**Author:** Claude (spec-driven-development)
+**Date:** 2026-06-13
+
+---
+
+## Assumptions
+
+> Correct any of these before I proceed to PLAN.
+
+1. The production writer path is `src/agent_sdk/stage3_runner.py` (`run_stage3` → `_collect_text`), which today runs the writer with **`ClaudeAgentOptions(allowed_tools=[])`** (line 296) — i.e. tools are disabled. Enabling one search tool is the core change.
+2. The **multi-provider research fallback the issue lists as a dependency already exists** — `build_research_brief()` in `_shared.py` already fans out across arXiv, Google, Semantic Scholar, Brave (and Tavily). **#389 is therefore unblocked**; the search tool will reuse these existing provider functions, not build new ones.
+3. The stat audit (`audit_article_stats(article, research_brief)`, `_shared.py:341`) strips any article sentence whose statistics are absent from the **research-brief text**. So writer-fetched sources must be **appended to the brief text that the audit sees**, or the writer's newly-cited stats get stripped. This is the single most important integration point.
+4. We accept that enabling a tool makes the writer turn a **tool-use loop** (the Claude Agent SDK drives the back-and-forth); `_collect_text` must tolerate multiple turns and tool results, not just a single completion.
+5. Scope is the **writer** search tool only. The recursive Deep Research pattern is explicitly out of scope (that is #390).
+
+## Objective
+
+Let the Stage 3 writer fetch additional sources mid-draft for specific claims it wants to support, instead of being locked into the one-shot seed brief. Keep the deterministic pre-research as the **primary, pre-vetted seed**; add an opt-in `search_for_source` tool the writer calls **sparingly (0–3×)** to strengthen weak claims, pull counter-evidence, or anchor an opening hook.
+
+**Quality floor is unchanged** — the stat audit and Stage 4 validators still catch fabrications. Only the ceiling moves: fewer `[NEEDS SOURCE]` stubs, fewer stripped claims, more complete drafts.
+
+**User:** the pipeline operator (and ultimately the blog reader, via better-sourced articles).
+
+## Tech Stack
+
+- Python 3.11/3.12, Claude via `claude-agent-sdk` (existing).
+- Reuses existing search providers in `scripts/*_search.py` (no new providers).
+- `orjson`, `logging` per project standards.
+
+## Commands
+
+```
+Test (targeted):   .venv/bin/python -m pytest tests/test_research_tools.py tests/test_stage3_writer_skill.py -q
+Full suite:        env MPLBACKEND=Agg .venv/bin/pytest tests/ -q
+Lint:              .venv/bin/ruff check src/agent_sdk tests
+Arch gate:         pre-commit run arch-review --all-files
+```
+
+## Project Structure
+
+```
+src/agent_sdk/tools/__init__.py        → new package
+src/agent_sdk/tools/research_tools.py  → new: search_for_source tool + in-run dedupe cache
+src/agent_sdk/stage3_runner.py         → edit: wire tool into writer ClaudeAgentOptions; thread fetched
+                                          sources into the brief passed to the stat audit
+src/agent_sdk/_shared.py               → NOT edited (pre-existing ADR-002 gate; see #420). If brief
+                                          augmentation must live here, that constraint must be resolved first.
+tests/test_research_tools.py           → new
+tests/test_stage3_writer_skill.py      → extend (writer-with-tool paths)
+```
+
+> **Open structural question:** the cleanest place to append on-demand sources to the brief before the audit is the `run_stage3` body (which already holds `research_brief`), so we can likely avoid editing `_shared.py` and its ADR-002 gate. To confirm in PLAN.
+
+## Code Style
+
+```python
+@tool(
+    "search_for_source",
+    "Find sources for a specific claim. Returns title/url/snippet for each. "
+    "Call sparingly (max 3/article) — each call adds latency. Prefer the seed brief.",
+    {"query": str, "max_results": int},
+)
+async def search_for_source(args: dict) -> dict:
+    """Writer-callable source fetch, budget- and dedupe-guarded."""
+    ...
+```
+
+(Exact decorator/registration form to be confirmed against the `claude-agent-sdk` docs during PLAN — see Boundaries → source-driven-development.)
+
+## Testing Strategy
+
+- `pytest`, providers **mocked** (no live API calls), per project standard.
+- Required cases:
+  - Writer happy path: tool offered, writer calls it once, fetched source integrated, draft well-formed.
+  - **Budget exhaustion**: 4th call in one article is refused gracefully; writer still finalises.
+  - **Tool failure**: provider raises → tool returns empty/marked result → writer does not crash.
+  - **Stat survival**: a stat from a writer-fetched source is NOT stripped by the audit (the key regression).
+  - **Dedupe**: identical query within one run hits the cache, not the provider.
+- Coverage > 80% on `research_tools.py`.
+
+## Boundaries
+
+- **Always:** mock providers in tests; keep the seed brief primary; route the tool through the existing provider functions; verify the SDK tool-wiring against official `claude-agent-sdk` docs (`source-driven-development`) before coding.
+- **Ask first:** any edit to `_shared.py` (ADR-002 gate, see #420); raising the default call budget above 3; adding a new search provider.
+- **Never:** let writer-fetched stats bypass the stat audit; commit provider API keys; remove the determinism of the seed brief.
+
+## Success Criteria
+
+1. With the tool mocked to return a source, the writer can cite a claim **not in the seed brief**, and that claim **survives the stat audit** (regression-tested).
+2. The writer never exceeds **3** search calls/article; the cap is enforced deterministically and the count is recorded in the cost log alongside `writer_cost_usd`.
+3. Tool failure or budget exhaustion **never** breaks the writer turn — it always produces a well-formed article (existing `MalformedArticleError` path stays green).
+4. Identical queries within one article run are deduped (≤1 provider hit per distinct query).
+5. Full suite green; `ruff` + arch-review pass; new code > 80% covered.
+
+## Resolved Design Questions (from the issue)
+
+| # | Question | Recommendation |
+|---|----------|----------------|
+| 1 | Call budget | **Hard cap = 3/article**, recorded in cost log. Simple, cheap insurance; revisit only with data. |
+| 2 | Determinism | **Accept run-to-run variation.** The stat audit + Stage 4 gates hold the floor; determinism is not worth the ceiling we'd lose. |
+| 3 | Provider routing | **Reuse the existing stack, Brave-first for latency.** No leaner bespoke path in v1 — keep one code path. |
+| 4 | Cache | **In-run, in-memory dedupe** keyed by normalised query. No cross-article persistence in v1. |
+| 5 | Attribution | **Seed brief stays primary** (pre-vetted); on-demand sources get "supporting, if relevant" treatment in the prompt. |
+
+## Open Questions (need human input)
+
+1. **Brief augmentation site:** confirm we can append on-demand sources to the brief inside `run_stage3` (avoiding `_shared.py` / the ADR-002 gate). If not, #420 must land first.
+2. **SDK tool mechanism:** the exact `claude-agent-sdk` API for exposing a custom tool to the writer (in-process `@tool` + sdk MCP server, vs. `allowed_tools`) — to be pinned in PLAN via official docs.
+3. **Latency budget:** is +6–9s worst case (3 calls) acceptable for the article SLA?
+
+## Estimate
+
+Per the issue: ~3 files added, ~3 edited, ~8 tests, **2–3 hours**. Concur.

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -429,6 +429,8 @@ async def run_stage3(
         max_budget_usd=writer_budget_usd,
         mcp_servers={"research": research_server},
         allowed_tools=["mcp__research__search_for_source"],
+        # Each search costs 2 turns (the tool_use, then consuming the
+        # tool_result); plus the initial draft and 1 turn of headroom.
         max_turns=2 * search_session.max_calls + 2,
     )
     if search_session.calls_made:

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -26,6 +26,7 @@ import sys
 import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import Any
 
 import orjson
 from claude_agent_sdk import (
@@ -33,6 +34,7 @@ from claude_agent_sdk import (
     ClaudeAgentOptions,
     ResultMessage,
     TextBlock,
+    create_sdk_mcp_server,
     query,
 )
 
@@ -50,6 +52,7 @@ from src.agent_sdk._shared import (
 )
 from src.agent_sdk.chart_renderer import render_chart
 from src.agent_sdk.image_prompt_synth import PromptSynthError, compose_prompt
+from src.agent_sdk.tools.research_tools import SourceFetchSession, build_search_tool
 
 logger = logging.getLogger(__name__)
 
@@ -98,8 +101,11 @@ DEFAULT_WRITER_MODEL = _validated_model("WRITER_MODEL", "claude-sonnet-4-6")
 DEFAULT_GRAPHICS_MODEL = _validated_model("GRAPHICS_MODEL", "claude-sonnet-4-6")
 
 WRITER_SYSTEM_PROMPT = """You are an Economist-style Writer renowned for sharp, witty prose with British flair.
-Every article must satisfy the 10 rules below before submission. Do not attempt to read any files
-or use any tools — write the article directly from this brief.
+Every article must satisfy the 10 rules below before submission. Do not read files. Write primarily
+from the brief. You MAY call the `search_for_source` tool sparingly (at most 3 times per article)
+to find a source for a specific claim the brief does not cover — for example to strengthen a weak
+claim, anchor the opening with a recent statistic, or cite counter-evidence. Prefer the brief's
+pre-vetted sources; only search when a claim genuinely needs support the brief lacks.
 
 STRUCTURE RULES:
 - State a specific, debatable THESIS in the first two paragraphs — not a topic, an argument
@@ -196,6 +202,7 @@ class Stage3Result:
     research_brief_chars: int
     article_chars: int
     stat_audit_removed: int
+    writer_search_calls: int = 0  # #389: on-demand source searches the writer made
     chart_path: Path | None = None  # #403 slice 1: rendered chart PNG
     prompt_path: Path | None = None  # #403 slice 3: image-prompt artefact
     slug: str = ""  # #403 slice 3: canonical slug for downstream resume
@@ -280,20 +287,28 @@ async def _collect_text(
     system_prompt: str,
     model: str = DEFAULT_WRITER_MODEL,
     max_budget_usd: float | None = None,
+    mcp_servers: dict[str, Any] | None = None,
+    allowed_tools: list[str] | None = None,
+    max_turns: int = 1,
 ) -> tuple[str, float]:
-    """Run a single Agent SDK query and return ``(text, cost_usd)``.
+    """Run an Agent SDK query and return ``(text, cost_usd)``.
 
     Streaming text chunks are joined with a space when the boundary
     between two chunks looks like an unintended word concatenation
     (lowercase letter followed by uppercase letter), to avoid artefacts
     such as "OrganisationsDoubleDown" seen in the Story 1 spike output.
+
+    By default no tools are exposed and the query runs in a single turn. Pass
+    ``mcp_servers``/``allowed_tools`` with ``max_turns > 1`` to enable a tool-use
+    loop (e.g. the writer's on-demand source search, #389).
     """
     options = ClaudeAgentOptions(
         system_prompt=system_prompt,
         model=model,
-        max_turns=1,
+        max_turns=max_turns,
         permission_mode="bypassPermissions",
-        allowed_tools=[],
+        allowed_tools=allowed_tools or [],
+        mcp_servers=mcp_servers or {},
         stderr=lambda line: logger.warning("agent-sdk stderr: %s", line),
         max_budget_usd=max_budget_usd,
     )
@@ -400,12 +415,29 @@ async def run_stage3(
         style_section = ""
 
     writer_prompt = _build_writer_prompt(topic, research_brief, style_section)
+    # #389 hybrid research: expose a budget-capped source-search tool the writer
+    # can call mid-draft. A fresh session per article isolates budget/dedupe.
+    # max_turns must exceed 1 so the SDK can drive the tool-use loop.
+    search_session = SourceFetchSession()
+    research_server = create_sdk_mcp_server(
+        "research", tools=[build_search_tool(search_session)]
+    )
     raw_writer_output, writer_cost = await _collect_text(
         writer_prompt,
         WRITER_SYSTEM_PROMPT,
         model=writer_model,
         max_budget_usd=writer_budget_usd,
+        mcp_servers={"research": research_server},
+        allowed_tools=["mcp__research__search_for_source"],
+        max_turns=2 * search_session.max_calls + 2,
     )
+    if search_session.calls_made:
+        logger.info(
+            "Writer made %d on-demand source search(es)", search_session.calls_made
+        )
+    # Append writer-fetched sources to the brief so the stat audit does not
+    # strip statistics the writer legitimately cited from them (#389).
+    research_brief = research_brief + search_session.brief_supplement()
     pre_audit_article = _strip_duplicate_article(raw_writer_output)
 
     # Require opening ---, a closing --- on its own line, and a non-empty body.
@@ -487,6 +519,7 @@ async def run_stage3(
         research_brief_chars=len(research_brief),
         article_chars=len(article),
         stat_audit_removed=max(stat_audit_removed, 0),
+        writer_search_calls=search_session.calls_made,
         chart_path=chart_path,
         prompt_path=prompt_path,
         slug=slug,

--- a/src/agent_sdk/tools/__init__.py
+++ b/src/agent_sdk/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Agent SDK tool definitions for the content pipeline."""

--- a/src/agent_sdk/tools/research_tools.py
+++ b/src/agent_sdk/tools/research_tools.py
@@ -1,0 +1,154 @@
+"""Writer-callable research tools for the Stage 3 hybrid-research flow (#389).
+
+The deterministic pre-research (``build_research_brief``) remains the primary,
+pre-vetted seed. This module adds a ``search_for_source`` tool the writer can
+call sparingly mid-draft to fetch additional sources for specific claims it
+wants to support.
+
+Design (see docs/specs/389-hybrid-research.md):
+- Per-article ``SourceFetchSession`` enforces a hard call budget and dedupes
+  identical queries within one run (no cross-article persistence).
+- Backed by the existing provider stack (Brave-first for latency, Google web
+  fallback) via ``scripts/*_search.py`` — no new providers.
+- Fetched sources are accumulated so ``run_stage3`` can append them to the
+  research brief *before* the stat audit, so writer-cited stats are not
+  stripped as unsupported.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import orjson
+from claude_agent_sdk import tool
+
+logger = logging.getLogger(__name__)
+
+# Hard cap on writer search calls per article (resolved design question #1).
+DEFAULT_SEARCH_CALL_BUDGET = 3
+
+Source = dict[str, str]
+
+
+def _run_provider_search(query: str, max_results: int) -> list[Source]:
+    """Fetch sources for ``query`` via the existing provider stack.
+
+    Brave first (lowest latency), Google web as fallback when Brave returns
+    nothing (e.g. no API key). Never raises — returns a possibly-empty list of
+    ``{"title", "url", "snippet"}`` dicts.
+    """
+    from scripts.brave_search import search_brave_for_topic
+
+    brave = search_brave_for_topic(query, max_results=max_results)
+    sources = [
+        {
+            "title": r.get("title", ""),
+            "url": r.get("url", ""),
+            "snippet": r.get("snippet", ""),
+        }
+        for r in brave.get("results", [])
+    ]
+    if sources:
+        return sources[:max_results]
+
+    # Fallback: Google web search. Its helper returns a list that may contain a
+    # single ``{"error": ...}`` sentinel on failure; filter those out.
+    try:
+        from scripts.google_search import search_google_for_topic
+
+        google = search_google_for_topic(query, max_results=max_results)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Google fallback failed for '%s': %s", query, exc)
+        return []
+
+    return [
+        {
+            "title": r.get("title", ""),
+            "url": r.get("url", r.get("link", "")),
+            "snippet": r.get("snippet", ""),
+        }
+        for r in google
+        if isinstance(r, dict) and "error" not in r
+    ][:max_results]
+
+
+class SourceFetchSession:
+    """Per-article budget, dedupe cache, and accumulator for writer searches."""
+
+    def __init__(self, max_calls: int = DEFAULT_SEARCH_CALL_BUDGET) -> None:
+        self.max_calls = max_calls
+        self.calls_made = 0
+        self.fetched: list[Source] = []
+        self._cache: dict[str, list[Source]] = {}
+
+    def search(self, query: str, max_results: int = 3) -> list[Source]:
+        """Return sources for ``query``, honouring the dedupe cache and budget.
+
+        Returns an empty list (never raises) when the budget is exhausted or the
+        provider fails, so the writer turn always survives.
+        """
+        key = query.strip().lower()
+        if key in self._cache:
+            return self._cache[key]
+
+        if self.calls_made >= self.max_calls:
+            logger.info(
+                "search_for_source budget (%d) exhausted; refusing query %r",
+                self.max_calls,
+                query,
+            )
+            return []
+
+        self.calls_made += 1
+        try:
+            results = _run_provider_search(query, max_results)
+        except Exception as exc:  # provider must never break the writer
+            logger.warning("search_for_source provider error for %r: %s", query, exc)
+            results = []
+
+        self._cache[key] = results
+        for source in results:
+            if source not in self.fetched:
+                self.fetched.append(source)
+        return results
+
+    def brief_supplement(self) -> str:
+        """Return a markdown block of fetched sources to append to the research
+        brief before the stat audit, or ``""`` if nothing was fetched."""
+        if not self.fetched:
+            return ""
+        lines = ["\n\n## Writer-fetched sources (supporting)\n"]
+        for source in self.fetched:
+            lines.append(f"- {source['title']}: {source['snippet']} ({source['url']})")
+        return "\n".join(lines)
+
+
+def build_search_tool(session: SourceFetchSession) -> Any:
+    """Build the ``search_for_source`` SDK tool bound to ``session``.
+
+    A fresh session (and therefore a fresh tool) is created per article so the
+    budget and dedupe cache do not leak across runs.
+    """
+
+    @tool(
+        "search_for_source",
+        (
+            "Find sources for a specific claim. Returns title/url/snippet for "
+            "each result. Use this only when you are about to make a claim that "
+            "is not supported by the research brief. Call sparingly (at most 3 "
+            "per article) — prefer claims from the brief when possible."
+        ),
+        {"query": str, "max_results": int},
+    )
+    async def search_for_source(args: dict[str, Any]) -> dict[str, Any]:
+        query = str(args.get("query", "")).strip()
+        if not query:
+            return {"content": [{"type": "text", "text": "[]"}]}
+        max_results = int(args.get("max_results", 3) or 3)
+        results = session.search(query, max_results)
+        return {
+            "content": [{"type": "text", "text": orjson.dumps(results).decode("utf-8")}]
+        }
+
+    return search_for_source

--- a/src/agent_sdk/tools/research_tools.py
+++ b/src/agent_sdk/tools/research_tools.py
@@ -52,8 +52,9 @@ def _run_provider_search(query: str, max_results: int) -> list[Source]:
     if sources:
         return sources[:max_results]
 
-    # Fallback: Google web search. Its helper returns a list that may contain a
-    # single ``{"error": ...}`` sentinel on failure; filter those out.
+    # Fallback: Google. search_google_for_topic returns a *dict* with
+    # ``web_results`` / ``scholar_results`` lists (not a flat list) — read those
+    # keys rather than iterating the dict.
     try:
         from scripts.google_search import search_google_for_topic
 
@@ -62,13 +63,16 @@ def _run_provider_search(query: str, max_results: int) -> list[Source]:
         logger.warning("Google fallback failed for '%s': %s", query, exc)
         return []
 
+    items = list(google.get("web_results", [])) + list(
+        google.get("scholar_results", [])
+    )
     return [
         {
             "title": r.get("title", ""),
             "url": r.get("url", r.get("link", "")),
             "snippet": r.get("snippet", ""),
         }
-        for r in google
+        for r in items
         if isinstance(r, dict) and "error" not in r
     ][:max_results]
 
@@ -145,7 +149,12 @@ def build_search_tool(session: SourceFetchSession) -> Any:
         query = str(args.get("query", "")).strip()
         if not query:
             return {"content": [{"type": "text", "text": "[]"}]}
-        max_results = int(args.get("max_results", 3) or 3)
+        # The model may emit a non-numeric max_results (e.g. "three"); never let
+        # a bad arg raise out of the tool handler and break the writer turn.
+        try:
+            max_results = int(args.get("max_results", 3) or 3)
+        except (TypeError, ValueError):
+            max_results = 3
         results = session.search(query, max_results)
         return {
             "content": [{"type": "text", "text": orjson.dumps(results).decode("utf-8")}]

--- a/tests/test_research_tools.py
+++ b/tests/test_research_tools.py
@@ -115,6 +115,68 @@ def test_tool_returns_json_results(monkeypatch) -> None:
     assert session.calls_made == 1
 
 
+def test_provider_search_returns_and_maps_brave_results(monkeypatch) -> None:
+    """Brave results are returned and mapped to title/url/snippet; Google is
+    not consulted when Brave has results."""
+    monkeypatch.setattr(
+        "scripts.brave_search.search_brave_for_topic",
+        lambda q, max_results: {
+            "results": [
+                {"title": "B", "url": "https://b", "snippet": "brave snip", "age": "1d"}
+            ]
+        },
+    )
+
+    def _google_must_not_be_called(q, max_results):  # pragma: no cover
+        raise AssertionError("Google should not be called when Brave has results")
+
+    monkeypatch.setattr(
+        "scripts.google_search.search_google_for_topic", _google_must_not_be_called
+    )
+
+    out = research_tools._run_provider_search("q", 3)
+
+    assert out == [{"title": "B", "url": "https://b", "snippet": "brave snip"}]
+
+
+def test_provider_search_falls_back_to_google_dict_shape(monkeypatch) -> None:
+    """When Brave returns nothing, the Google *dict* (web_results/scholar_results)
+    is read correctly. Regression for the dead-fallback bug found in #422 review.
+    """
+    monkeypatch.setattr(
+        "scripts.brave_search.search_brave_for_topic",
+        lambda q, max_results: {"results": []},
+    )
+    monkeypatch.setattr(
+        "scripts.google_search.search_google_for_topic",
+        lambda q, max_results: {
+            "success": True,
+            "web_results": [{"title": "W", "url": "https://w", "snippet": "web snip"}],
+            "scholar_results": [
+                {"title": "S", "link": "https://s", "snippet": "scholar snip"}
+            ],
+            "error": None,
+        },
+    )
+
+    out = research_tools._run_provider_search("q", 5)
+
+    assert {"title": "W", "url": "https://w", "snippet": "web snip"} in out
+    # scholar item exposes its URL via `link` — must be mapped to `url`.
+    assert {"title": "S", "url": "https://s", "snippet": "scholar snip"} in out
+
+
+def test_tool_malformed_max_results_does_not_raise(monkeypatch) -> None:
+    """A non-numeric max_results from the model must not break the tool handler."""
+    _patch_provider(monkeypatch, lambda q, n: list(_SAMPLE))
+    session = SourceFetchSession()
+    search_tool = build_search_tool(session)
+
+    out = asyncio.run(search_tool.handler({"query": "roi", "max_results": "three"}))
+
+    assert orjson.loads(out["content"][0]["text"]) == _SAMPLE
+
+
 def test_tool_empty_query_short_circuits(monkeypatch) -> None:
     counter = _patch_provider(monkeypatch, lambda q, n: list(_SAMPLE))
     session = SourceFetchSession()

--- a/tests/test_research_tools.py
+++ b/tests/test_research_tools.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Tests for the writer-callable research tool (#389).
+
+Providers are mocked — no live API calls. Covers the SourceFetchSession budget,
+dedupe, and failure-resilience contracts, the brief supplement, and the SDK
+tool wrapper's JSON output.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import orjson
+
+from src.agent_sdk.tools import research_tools
+from src.agent_sdk.tools.research_tools import (
+    DEFAULT_SEARCH_CALL_BUDGET,
+    SourceFetchSession,
+    build_search_tool,
+)
+
+_SAMPLE = [
+    {"title": "Gartner Report", "url": "https://g.example/r", "snippet": "80% cut."},
+]
+
+
+def _patch_provider(monkeypatch, fn) -> list[int]:
+    """Patch the provider seam; return a call counter list (counter[0])."""
+    counter = [0]
+
+    def _wrapped(query: str, max_results: int):
+        counter[0] += 1
+        return fn(query, max_results)
+
+    monkeypatch.setattr(research_tools, "_run_provider_search", _wrapped)
+    return counter
+
+
+def test_search_returns_sources(monkeypatch) -> None:
+    _patch_provider(monkeypatch, lambda q, n: list(_SAMPLE))
+    session = SourceFetchSession()
+
+    results = session.search("self-healing tests roi")
+
+    assert results == _SAMPLE
+    assert session.calls_made == 1
+    assert session.fetched == _SAMPLE
+
+
+def test_budget_is_hard_capped(monkeypatch) -> None:
+    counter = _patch_provider(monkeypatch, lambda q, n: list(_SAMPLE))
+    session = SourceFetchSession(max_calls=3)
+
+    for i in range(3):
+        assert session.search(f"distinct query {i}") == _SAMPLE
+    # 4th distinct query exceeds the budget → empty, provider NOT hit again.
+    assert session.search("distinct query 4") == []
+    assert session.calls_made == 3
+    assert counter[0] == 3
+
+
+def test_default_budget_is_three() -> None:
+    assert DEFAULT_SEARCH_CALL_BUDGET == 3
+    assert SourceFetchSession().max_calls == 3
+
+
+def test_identical_query_is_deduped(monkeypatch) -> None:
+    counter = _patch_provider(monkeypatch, lambda q, n: list(_SAMPLE))
+    session = SourceFetchSession()
+
+    session.search("Same Query")
+    session.search("same query")  # case-insensitive cache hit
+    session.search("  same query  ")  # whitespace-insensitive cache hit
+
+    assert counter[0] == 1, "identical queries must hit the cache, not the provider"
+    assert session.calls_made == 1
+
+
+def test_provider_failure_returns_empty_and_does_not_raise(monkeypatch) -> None:
+    def _boom(query: str, max_results: int):
+        raise RuntimeError("provider down")
+
+    _patch_provider(monkeypatch, _boom)
+    session = SourceFetchSession()
+
+    assert session.search("anything") == []
+    assert session.calls_made == 1  # the failed attempt still consumes budget
+
+
+def test_brief_supplement_lists_fetched_sources(monkeypatch) -> None:
+    _patch_provider(monkeypatch, lambda q, n: list(_SAMPLE))
+    session = SourceFetchSession()
+    session.search("q")
+
+    supplement = session.brief_supplement()
+
+    assert "Writer-fetched sources" in supplement
+    assert "Gartner Report" in supplement
+    assert "https://g.example/r" in supplement
+
+
+def test_brief_supplement_empty_when_nothing_fetched() -> None:
+    assert SourceFetchSession().brief_supplement() == ""
+
+
+def test_tool_returns_json_results(monkeypatch) -> None:
+    _patch_provider(monkeypatch, lambda q, n: list(_SAMPLE))
+    session = SourceFetchSession()
+    search_tool = build_search_tool(session)
+
+    out = asyncio.run(search_tool.handler({"query": "roi of qa", "max_results": 2}))
+
+    text = out["content"][0]["text"]
+    assert orjson.loads(text) == _SAMPLE
+    assert session.calls_made == 1
+
+
+def test_tool_empty_query_short_circuits(monkeypatch) -> None:
+    counter = _patch_provider(monkeypatch, lambda q, n: list(_SAMPLE))
+    session = SourceFetchSession()
+    search_tool = build_search_tool(session)
+
+    out = asyncio.run(search_tool.handler({"query": "   "}))
+
+    assert out["content"][0]["text"] == "[]"
+    assert counter[0] == 0, "empty query must not hit the provider"

--- a/tests/test_stage3_hybrid_research.py
+++ b/tests/test_stage3_hybrid_research.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Integration tests for hybrid-research wiring in Stage 3 (#389).
+
+Covers the slices that connect the writer search tool to the runner:
+- the stat-survival contract (writer-fetched stats are not stripped by the audit
+  once their source is appended to the brief),
+- ``_collect_text`` actually forwarding the tool config to the SDK options,
+- ``run_stage3`` appending the fetched-source supplement to the brief the audit
+  sees and recording the search-call count.
+
+The SDK is never invoked live — ``query`` / ``_collect_text`` are mocked.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import src.agent_sdk.stage3_runner as s3
+from src.agent_sdk._shared import audit_article_stats
+from src.agent_sdk.tools import research_tools
+from src.agent_sdk.tools.research_tools import SourceFetchSession
+
+
+def test_writer_fetched_stat_survives_audit_when_brief_augmented(monkeypatch) -> None:
+    """A stat from a writer-fetched source must survive the stat audit once the
+    source is appended to the brief — and be stripped without it (control)."""
+    monkeypatch.setattr(
+        research_tools,
+        "_run_provider_search",
+        lambda q, n: [
+            {"title": "Gartner", "url": "https://g/x", "snippet": "an 80% cut in costs"}
+        ],
+    )
+    session = SourceFetchSession()
+    session.search("qa roi")
+
+    article = (
+        "---\nlayout: post\ntitle: x\n---\n\n"
+        "Self-healing tests deliver an 80% cut in costs.\n"
+    )
+    base_brief = "# Brief\n\nNo numbers here."
+
+    # Control: without the supplement the fabricated-looking stat is stripped.
+    stripped = audit_article_stats(article, base_brief)
+    assert "80% cut" not in stripped
+
+    # With the supplement appended, the cited stat survives.
+    augmented = base_brief + session.brief_supplement()
+    kept = audit_article_stats(article, augmented)
+    assert "80% cut" in kept
+
+
+def test_collect_text_passes_tool_config_to_options(monkeypatch) -> None:
+    """_collect_text must forward mcp_servers/allowed_tools/max_turns to the SDK."""
+    captured: dict = {}
+
+    async def fake_query(*, prompt, options):
+        captured["options"] = options
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+    monkeypatch.setattr(s3, "query", fake_query)
+
+    text, cost = asyncio.run(
+        s3._collect_text(
+            "prompt",
+            "system",
+            mcp_servers={"research": object()},
+            allowed_tools=["mcp__research__search_for_source"],
+            max_turns=8,
+        )
+    )
+
+    opts = captured["options"]
+    assert opts.max_turns == 8
+    assert opts.allowed_tools == ["mcp__research__search_for_source"]
+    assert "research" in opts.mcp_servers
+    assert (text, cost) == ("", 0.0)
+
+
+def test_collect_text_defaults_remain_toolless_single_turn(monkeypatch) -> None:
+    """Default call (e.g. the graphics agent) stays single-turn with no tools."""
+    captured: dict = {}
+
+    async def fake_query(*, prompt, options):
+        captured["options"] = options
+        return
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(s3, "query", fake_query)
+    asyncio.run(s3._collect_text("p", "s"))
+
+    opts = captured["options"]
+    assert opts.max_turns == 1
+    assert opts.allowed_tools == []
+    assert opts.mcp_servers == {}
+
+
+def test_run_stage3_appends_supplement_and_records_search_calls(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """run_stage3 must append the fetched-source supplement to the brief the
+    audit sees, and record the writer's search-call count."""
+    monkeypatch.chdir(tmp_path)
+
+    class StubSession:
+        max_calls = 3
+        calls_made = 2
+
+        def brief_supplement(self) -> str:
+            return "\n\nSUPPLEMENT_MARKER_42pct"
+
+    monkeypatch.setattr(s3, "SourceFetchSession", lambda *a, **k: StubSession())
+    monkeypatch.setattr(s3, "build_search_tool", lambda session: object())
+    monkeypatch.setattr(s3, "create_sdk_mcp_server", lambda name, tools: {name: tools})
+
+    article_text = (
+        "---\nlayout: post\ntitle: x\n"
+        "image: /assets/images/test-slug.png\n---\n\n"
+        "Body paragraph. As the chart shows, things happen.\n"
+    )
+    chart_json = (
+        '{"title": "T", "data": [{"metric": "A", "value": 1, "color": "navy"}]}'
+    )
+    call_results = iter([(article_text, 0.0), (chart_json, 0.0)])
+
+    async def fake_collect(*args, **kwargs):
+        return next(call_results)
+
+    captured_brief: dict = {}
+
+    def fake_audit(article: str, research_brief: str) -> str:
+        captured_brief["brief"] = research_brief
+        return article
+
+    monkeypatch.setattr(s3, "_collect_text", fake_collect)
+    monkeypatch.setattr(s3, "_audit_article_stats", fake_audit)
+    monkeypatch.setattr(
+        s3, "build_research_brief", lambda topic: "# Brief\n\nseed source"
+    )
+    monkeypatch.setattr(s3, "_fetch_style_context", lambda topic: "")
+
+    result = asyncio.run(s3.run_stage3("test topic"))
+
+    assert "SUPPLEMENT_MARKER_42pct" in captured_brief["brief"]
+    assert result.writer_search_calls == 2


### PR DESCRIPTION
## Summary
Implements the approved spec (`docs/specs/389-hybrid-research.md`). Gives the Stage 3 writer a budget-capped `search_for_source` tool to fetch sources mid-draft for claims the deterministic seed brief doesn't cover. Seed brief stays primary; the writer turn becomes a tool-use loop.

## Key design points
- **`SourceFetchSession`** (`src/agent_sdk/tools/research_tools.py`): hard cap of **3 calls/article**, in-run query **dedupe**, **failure-resilient** (provider errors/budget exhaustion → empty list, never breaks the writer). Backed by the existing provider stack (Brave-first, Google fallback) — no new providers.
- **`_collect_text`** gains optional `mcp_servers`/`allowed_tools`/`max_turns`; **defaults preserve** the single-turn, tool-less graphics path.
- **Stat-survival** (the critical contract): writer-fetched sources are appended to the research brief **before** the stat audit, so legitimately-cited stats aren't stripped. The `_shared.py` ADR-002 gate is avoided by doing this in `run_stage3`.
- `WRITER_SYSTEM_PROMPT` updated to permit the tool sparingly (it previously said "use no tools", which would have suppressed it).
- `Stage3Result.writer_search_calls` added for observability.

## Resolved design questions (from the issue)
Hard cap 3 · accept nondeterminism · reuse providers (Brave-first) · in-run dedupe · seed brief stays primary. (See spec.)

## Verification (TDD, providers mocked, SDK not invoked live)
- 9 tests: session budget/dedupe/failure-resilience, brief supplement, tool JSON output, empty-query short-circuit.
- 4 integration tests: **stat-survival contract** (control + augmented), `_collect_text` forwards tool config, defaults stay tool-less, `run_stage3` appends supplement + records `writer_search_calls`.
- 96 related tests pass; `ruff` + arch-review + pre-commit green.

## Follow-ups (not in scope)
- #390 (recursive Deep Research) builds on this pattern.
- Live end-to-end with the real SDK tool-use loop is not unit-tested (deterministically mocked instead) — worth a manual smoke run before relying on it in production.

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)