### PR TITLE
chore: migrate to local-first backlog, remove github MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,5 @@
 {
   "mcpServers": {
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/",
-      "description": "GitHub MCP for PR management, issues, and repository operations"
-    },
     "playwright": {
       "command": "npx",
       "args": [

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,82 @@
+# Backlog
+
+> **Source of record for planning items.** PRs + code review live on GitHub (`gh` CLI).
+> Item ids are `B-NNN` and are never reused. The `(was #N)` tag records the GitHub
+> issue an item was migrated from (those issues are closed, not deleted).
+>
+> See `docs/specs/local-backlog-migration.md` for why this file exists.
+
+## In Progress
+
+_(none)_
+
+## Todo
+
+### B-003 · P3 · Broken adr-lint pre-commit hook + ADR governance drift (was #428)
+
+Blocks new ADRs. `type:refactor`.
+
+The `adr-lint` pre-commit hook (`.pre-commit-config.yaml:64`) runs
+`.venv/bin/python scripts/lint_adrs.py`, but that script was archived to
+`scripts/archived/lint_adrs.py` (ADR-0010 scripts→src migration), so the hook
+fails with `can't open file '.../scripts/lint_adrs.py'` on **any** change under
+`docs/adr/`. New ADRs cannot be committed through the gate.
+
+Running the archived copy from the repo root also surfaces **pre-existing
+non-compliance** the broken hook had been masking:
+- `docs/adr/0010-scripts-to-src-migration.md`: status `Implemented` is not in the
+  allowed set (`Accepted/Deprecated/Proposed/Rejected/Superseded`).
+- `docs/adr/0010-...` is not referenced in `mkdocs.yml`.
+
+(The archived script's `repo_root` default is `Path(__file__).parent.parent`,
+which resolves to `scripts/` from `scripts/archived/` — so it must run with
+`--repo-root` or be restored to `scripts/`.)
+
+**Fix**
+1. Restore `scripts/lint_adrs.py` (or repoint the hook + fix the `repo_root`
+   default for the archived location).
+2. Bring ADR-0010 into compliance (status → `Accepted`; add to `mkdocs.yml`).
+3. Land **ADR-0011 (Deep Research)** — documents the #390 decision; rationale
+   currently lives in `docs/specs/390-deep-research.md`. Draft ADR-0011 text was
+   captured on GitHub issue #428 (closed) for reference.
+
+### B-002 · P3 · Remove asyncio.run stub in test_flow_agent_sdk.py (was #425)
+
+Residual coroutine warnings. `type:refactor`.
+
+Surfaced by the PR #424 review. `tests/test_flow_agent_sdk.py` (the
+`TestGenerateContent` cases) patch `flow.asyncio.run` to a no-op stub, which
+leaves `run_pipeline()` coroutines un-awaited and emits
+`RuntimeWarning: coroutine ... was never awaited` — the defect class commit
+236cd48 set out to resolve.
+
+`tests/test_flow_image_mode.py` was already migrated (PR #424) to patch
+`run_pipeline`/`refine_image_metadata` as `AsyncMock` and let the real
+`asyncio.run` drive them — no warnings.
+
+**Fix** Migrate the remaining `TestGenerateContent` tests to the same `AsyncMock`
+pattern so the un-awaited-coroutine warnings stop masking a potential future real leak.
+
+### B-001 · P3 · Wire Stage 4 author safety net to BLOG_AUTHOR constant (was #420)
+
+`type:refactor`.
+
+Follow-up from PR #416 (issue #401). `BLOG_AUTHOR`
+(`scripts/publication_validator.py`) is wired into the Stage 3 writer prompt and
+the validator's author contract. The Stage 4 frontmatter safety net at
+`src/agent_sdk/_shared.py:632` still emits the author as a literal
+(`author: "Ouray Viney"`), so it can drift if `BLOG_AUTHOR` changes.
+
+**Why deferred** `_shared.py` carries a pre-existing ADR-002 violation
+(`import anthropic` in the vision-refinement helper, ~line 734) that the
+arch-review gate blocks on any edit to that file.
+
+**Fix (once unblocked)**
+1. Resolve the ADR-002 `anthropic` import (route via AgentRegistry).
+2. Import `BLOG_AUTHOR` and interpolate at line 632.
+3. The behavioural test in `tests/test_author_contract.py` becomes load-bearing
+   against the constant.
+
+## Done
+
+_(append completed items here with a completion date)_

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -37,8 +37,32 @@ which resolves to `scripts/` from `scripts/archived/` — so it must run with
    default for the archived location).
 2. Bring ADR-0010 into compliance (status → `Accepted`; add to `mkdocs.yml`).
 3. Land **ADR-0011 (Deep Research)** — documents the #390 decision; rationale
-   currently lives in `docs/specs/390-deep-research.md`. Draft ADR-0011 text was
-   captured on GitHub issue #428 (closed) for reference.
+   currently lives in `docs/specs/390-deep-research.md`. Draft below (was inlined
+   from closed issue #428 so it survives locally):
+
+   > **ADR-0011: Opt-In Recursive Deep Research**
+   > **Status:** Accepted · **Date:** 2026-06-13 · **Decision Maker:** Ouray Viney (Engineering Lead)
+   >
+   > **Context:** The research phase (`build_research_brief`) is a one-shot,
+   > deterministic, no-LLM search burst. #390 adds a recursive
+   > planner→search→extract→synthesise loop (Deep Research pattern) that produces
+   > report-grade briefs at 5–10× cost ($1.50–3.00 vs ~$0.30), 30–60s vs ~5s, and
+   > introduces LLM calls into a path kept deterministic to prevent source hallucination.
+   >
+   > **Decision:** Add Deep Research as **opt-in**, not a replacement. `research_mode`
+   > (`deterministic` default | `deep`, `RESEARCH_MODE` env override) on
+   > `run_stage3`/`run_pipeline`. New `src/agent_sdk/research/` package reusing the
+   > existing providers. Bounded by a hard iteration cap (2) and `research_budget_usd`
+   > ($2.50). Model tiering: planner/synthesizer Sonnet, extractor Haiku. Brief keeps
+   > the same string contract (writer + stat audit unchanged); research spend recorded
+   > in the cost log.
+   >
+   > **Consequences:** + Report-grade briefs on demand without sacrificing the cheap
+   > default; bounded, observable cost. − Non-deterministic and expensive when opted
+   > in; v1 extracts from snippets only (full-page fetch deferred). Follow-ups:
+   > production trigger for `deep`, cross-article cache, full-page fetch.
+   >
+   > **References:** Issue #390; spec `docs/specs/390-deep-research.md`; companion #389.
 
 ### B-002 · P3 · Remove asyncio.run stub in test_flow_agent_sdk.py (was #425)
 
@@ -79,4 +103,4 @@ arch-review gate blocks on any edit to that file.
 
 ## Done
 
-_(append completed items here with a completion date)_
+_(append completed items here with an ISO completion date, e.g. `YYYY-MM-DD`)_

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,21 @@ Task arrives
 **No implementation starts without a spec. No sprint planning starts without a dependency-ordered task list.**
 Both require human review (a "LGTM") before proceeding.
 
+### Backlog & Issue Tracking (hybrid model)
+
+The backlog is **local-first**. The `github` MCP server has been removed (it was a
+token drain); see `docs/specs/local-backlog-migration.md`.
+
+- **Backlog / planning items → `BACKLOG.md`** at repo root. This is the source of
+  record for todo / in-progress / done work items (`B-NNN` ids). Edit the file
+  directly; do **not** open GitHub issues for new backlog items.
+- **PRs + code review → GitHub via the `gh` CLI** (authenticated, near-zero context
+  cost). `gh pr create / view / list` etc. remain the standard PR workflow.
+- **Bugs / defects** still log in `data/skills_state/defect_tracker.json` per the
+  flowchart above, then graduate to a `BACKLOG.md` item if they need scheduling.
+- `data/skills_state/backlog.json` is **machine state for autonomous sprint scripts**
+  (keyed by `STORY-NNN`) — not the human backlog. Don't conflate the two.
+
 ### Lifecycle discipline (non-negotiable)
 
 For any **non-trivial** response (anything beyond Q&A, status checks, or one-line edits):

--- a/docs/specs/local-backlog-migration.md
+++ b/docs/specs/local-backlog-migration.md
@@ -141,15 +141,15 @@ This is a config + docs migration; no unit tests. Verification is procedural:
 - [ ] A note that the `github` MCP token cost is gone (no github tool schemas load
       next session).
 
-## Open Questions
+## Resolved Decisions
 
-1. **Issue ids vs. backlog ids.** Spec proposes fresh `B-NNN` ids with `(was #N)`
-   provenance, rather than reusing GitHub numbers. OK? (Keeps the local backlog
-   independent of GitHub numbering.)
-2. **Close the 3 open issues now, or leave them open** as a read-only mirror until
-   you confirm the backlog feels right? Default in this spec: **close them** (clean
-   single source of record), but it's a one-flag change either way.
-3. **Should `gh` issue *creation* be discouraged in CLAUDE.md** going forward
-   (backlog items go to BACKLOG.md), while `gh` PR commands stay encouraged?
-   Default: yes.
+These were the open questions at spec time; all resolved by the user's "go with
+your defaults" (2026-06-13) and reflected in the implemented change:
+
+1. **Issue ids vs. backlog ids.** ✅ Fresh `B-NNN` ids with `(was #N)` provenance,
+   not reusing GitHub numbers — keeps the local backlog independent of GitHub.
+2. **Close the 3 open issues vs. leave as mirror.** ✅ Closed (not deleted), each
+   with a comment linking to `BACKLOG.md` — clean single source of record, reversible.
+3. **Discourage `gh` issue creation going forward.** ✅ Yes — backlog items go to
+   `BACKLOG.md`; `gh` PR commands stay encouraged. Documented in CLAUDE.md.
 ```

--- a/docs/specs/local-backlog-migration.md
+++ b/docs/specs/local-backlog-migration.md
@@ -1,0 +1,155 @@
+# Spec: Migrate from GitHub MCP to a Local Backlog (Hybrid)
+
+## Objective
+
+Stop the token drain caused by the **GitHub MCP server** (`https://api.githubcopilot.com/mcp/`),
+which injects a large bundle of tool schemas + verbose JSON responses into every
+session's context, while preserving the GitHub workflows the user values.
+
+**Decision (user, 2026-06-13): Hybrid model.**
+- A **local backlog file is the system of record for planning/backlog items.**
+- **GitHub stays** the system of record for **PRs + code review**, driven by the
+  `gh` CLI (already authenticated, near-zero context cost).
+- The **`github` MCP server is removed** from `.mcp.json`. That removal is what
+  actually stops the token bleed.
+
+**Success looks like:** a new session opens without loading any GitHub MCP tool
+schema; backlog items are read/written from a versioned repo file; `gh` still
+works for PRs; and CLAUDE.md + memory route future work to the local backlog
+rather than re-opening GitHub issues.
+
+### Why this matters / what it reverses
+
+This **reverses recorded user preferences** (`feedback_github_workflow`,
+`feedback_sprint_discipline` — "log all work via GitHub issues/PRs"). Those
+memories must be updated as part of this change, or the next session will
+silently route work back to GitHub issues and the migration won't stick.
+
+## Scope
+
+**In scope**
+1. Remove the `github` entry from `.mcp.json` (7 other MCP servers untouched).
+2. Create `BACKLOG.md` at repo root as the human-readable backlog source of record.
+3. Seed `BACKLOG.md` from the **3 currently-open GitHub issues** (#420, #425, #428).
+4. Close those 3 GitHub issues with a comment pointing to `BACKLOG.md` (reversible).
+5. Update `CLAUDE.md` (GitHub-workflow guidance + Skill Routing) to reflect hybrid.
+6. Update the three affected memory files.
+
+**Out of scope**
+- `data/skills_state/backlog.json` — left as-is. It is a machine-state file for
+  autonomous sprint scripts, keyed by `STORY-NNN`, parallel to GitHub issues. Not
+  the "local backlog file" the user means. Touching it risks breaking sprint tooling.
+- Deleting any GitHub issues or history. We close, not delete (reversible).
+- Migrating closed issues / PR history. GitHub remains the archive.
+- The other 7 MCP servers, the pipeline, or any runtime code (verified: no code
+  imports `mcp__github` — it is purely interactive).
+
+## Tech Stack / Tools
+
+- `gh` CLI (authenticated: `repo`, `project`, `workflow` scopes) — PRs, and the
+  one-time issue export/close.
+- Plain Markdown for `BACKLOG.md`.
+- No new dependencies, no new runtime code.
+
+## Commands
+
+```bash
+# Export the 3 open issues to seed the backlog (one-time, read-only)
+gh issue list --state open --json number,title,labels,body,url
+
+# After migration — managing the backlog is just editing a file
+$EDITOR BACKLOG.md
+
+# GitHub still drives PRs (unchanged)
+gh pr create / gh pr view / gh pr list
+
+# Verify the MCP server is gone (no github tools should appear next session)
+grep -c '"github"' .mcp.json   # expect 0
+```
+
+## Project Structure
+
+```
+BACKLOG.md                      → NEW. Backlog source of record (root, versioned)
+.mcp.json                       → EDIT. Remove the `github` server entry
+CLAUDE.md                       → EDIT. Hybrid workflow + routing guidance
+docs/specs/local-backlog-migration.md → this spec
+~/.claude/.../memory/*.md       → EDIT. 3 memory files + MEMORY.md index
+data/skills_state/backlog.json  → UNTOUCHED (out of scope)
+```
+
+## Code Style — `BACKLOG.md` format
+
+Lightweight, greppable, human-editable. One section per status. Items carry a
+stable `B-NNN` id (independent of GitHub issue numbers), priority, and an
+optional `(was #NNN)` provenance tag for the migrated three.
+
+```markdown
+# Backlog
+
+> Source of record for planning items. PRs + code review live on GitHub (`gh` CLI).
+> Item ids are `B-NNN` and never reused.
+
+## In Progress
+_(none)_
+
+## Todo
+- **B-003** · P3 · Broken adr-lint pre-commit hook + ADR governance drift (was #428)
+  - Blocks new ADRs. type:refactor.
+- **B-002** · P3 · Remove asyncio.run stub in test_flow_agent_sdk.py (was #425)
+  - Residual coroutine warnings. type:refactor.
+- **B-001** · P3 · Wire Stage 4 author safety net to BLOG_AUTHOR constant (was #420)
+  - type:refactor.
+
+## Done
+_(append items here on completion with a date)_
+```
+
+## Testing Strategy
+
+This is a config + docs migration; no unit tests. Verification is procedural:
+
+1. **MCP removal:** `.mcp.json` parses as valid JSON and contains no `github` key.
+2. **Backlog fidelity:** all 3 open issues appear in `BACKLOG.md` with title +
+   provenance; nothing dropped.
+3. **Reversibility:** the 3 issues are *closed* (not deleted); each has a comment
+   linking to `BACKLOG.md`.
+4. **gh still works:** `gh pr list` succeeds (proves GitHub-for-PRs intact).
+5. **Stickiness:** CLAUDE.md no longer instructs "open a GitHub issue" for backlog
+   items; memories updated; `MEMORY.md` index consistent.
+
+## Boundaries
+
+- **Always:** keep `.mcp.json` valid JSON; preserve the other 7 MCP servers;
+  close-not-delete on GitHub; keep changes reversible.
+- **Ask first:** anything touching `data/skills_state/backlog.json` or sprint
+  tooling; deleting any GitHub issue; removing MCP servers other than `github`.
+- **Never:** delete GitHub issues/PRs/history; commit secrets; touch runtime
+  pipeline code as part of this migration.
+
+## Success Criteria
+
+- [ ] `.mcp.json` has no `github` server and remains valid JSON.
+- [ ] `BACKLOG.md` exists at root and contains all 3 open issues (#420/#425/#428)
+      as `B-NNN` items with provenance.
+- [ ] The 3 issues are closed on GitHub with a comment pointing to `BACKLOG.md`.
+- [ ] `gh pr list` still works (GitHub-for-PRs path intact).
+- [ ] `CLAUDE.md` describes the hybrid model and stops mandating GitHub issues for
+      backlog items.
+- [ ] `feedback_github_workflow`, `feedback_sprint_discipline`, and
+      `project_next_session` memories updated; `MEMORY.md` index consistent.
+- [ ] A note that the `github` MCP token cost is gone (no github tool schemas load
+      next session).
+
+## Open Questions
+
+1. **Issue ids vs. backlog ids.** Spec proposes fresh `B-NNN` ids with `(was #N)`
+   provenance, rather than reusing GitHub numbers. OK? (Keeps the local backlog
+   independent of GitHub numbering.)
+2. **Close the 3 open issues now, or leave them open** as a read-only mirror until
+   you confirm the backlog feels right? Default in this spec: **close them** (clean
+   single source of record), but it's a one-flag change either way.
+3. **Should `gh` issue *creation* be discouraged in CLAUDE.md** going forward
+   (backlog items go to BACKLOG.md), while `gh` PR commands stay encouraged?
+   Default: yes.
+```


### PR DESCRIPTION
## Why

The `github` MCP server (`api.githubcopilot.com/mcp`) injected a large tool-schema bundle + verbose JSON into **every** session — a significant token drain. This removes it and adopts a **hybrid backlog model** (user's explicit choice):

- **Backlog / planning items → repo-root `BACKLOG.md`** (`B-NNN` ids). Source of record for work items.
- **PRs + code review → GitHub via `gh` CLI** (already authed, near-zero context cost). Unchanged.

The token cost was the *MCP transport*, not GitHub itself — so we dropped the transport and kept the PR workflow.

## Changes

- Remove `github` from `.mcp.json` (7 other MCP servers untouched; valid JSON verified)
- Add `BACKLOG.md` seeded from the 3 open issues (#420 / #425 / #428 → `B-001`/`B-002`/`B-003`), full detail preserved
- Document the hybrid backlog model in `CLAUDE.md`
- Spec: `docs/specs/local-backlog-migration.md`

## Migration / reversibility

- The 3 source issues were **closed (not deleted)** with a comment pointing to `BACKLOG.md` — reopen anytime.
- `data/skills_state/backlog.json` (machine state for autonomous sprint scripts, keyed by `STORY-NNN`) left untouched — it is **not** the human backlog.
- No runtime code touched (verified: nothing imports the github MCP).

## Verification

- [x] `.mcp.json` valid JSON, no `github` server (7 remain)
- [x] All 3 items present in `BACKLOG.md` with `(was #N)` provenance
- [x] 0 open GitHub issues; the 3 closed with migration comments
- [x] `gh pr list` works (GitHub-for-PRs path intact)
- [x] `CLAUDE.md` routes future backlog work to `BACKLOG.md`

> Note: `/mcp` will still show `github` until Claude Code is restarted (`.mcp.json` is read at startup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)