### PR TITLE
test: remove asyncio.run stub in test_flow_agent_sdk.py (B-002)

### DIFF
--- a/docs/specs/B-002-asyncio-run-stub-removal.md
+++ b/docs/specs/B-002-asyncio-run-stub-removal.md
@@ -1,0 +1,166 @@
+# Spec: B-002 — Remove `asyncio.run` stub in `test_flow_agent_sdk.py`
+
+> Slice 2 of the 2026-06-14 backlog sprint (see `BACKLOG.md` → Sprint Goal).
+> Source item: `BACKLOG.md` B-002 (was GitHub #425). `type:refactor`, test-only.
+
+## Objective
+
+`tests/test_flow_agent_sdk.py` patches `flow.asyncio.run` to a stub. Because the
+real `asyncio.run` is replaced, the `run_pipeline(...)` / `refine_image_metadata(...)`
+**coroutines that `flow.generate_content` constructs are never awaited**, so each
+test emits `RuntimeWarning: coroutine '...' was never awaited`. That warning class
+is noise that would **mask a real future un-awaited-coroutine leak**.
+
+`tests/test_flow_image_mode.py` (PR #424) already solved this: it patches
+`run_pipeline` / `refine_image_metadata` as `AsyncMock` and lets the **real**
+`asyncio.run` drive them — no warnings.
+
+**Success = the migrated tests assert the same behaviour as today, emit zero
+`coroutine ... was never awaited` warnings, and the suite passes with
+`-W error::RuntimeWarning` on the touched tests.**
+
+## Root cause (verified 2026-06-14)
+
+`flow.generate_content` (`src/economist_agents/flow.py:276`, `:398`) and
+`flow.request_revision` (`:634`) call `asyncio.run(run_pipeline(...))` and
+`asyncio.run(refine_image_metadata(...))`. When a test does
+`@patch("src.economist_agents.flow.asyncio.run")`, Python still **evaluates the
+argument** — i.e. constructs the coroutine — before handing it to the mock, which
+returns a fake result without awaiting it. The orphaned coroutine triggers the
+`RuntimeWarning` at GC time. Patching the awaited callables as `AsyncMock` instead
+means no real coroutine is ever constructed, so there is nothing to leak.
+
+Per-mode call shape (confirmed by reading `flow.py:268-407`):
+
+| Flow path | `asyncio.run` calls today | Awaited callables to mock |
+|-----------|---------------------------|---------------------------|
+| `generate_content`, `chart_only` (default) | **1** (`run_pipeline`) | `run_pipeline` only |
+| `generate_content`, `hero` | **2** (`run_pipeline`, then `refine_image_metadata`) | both |
+| `request_revision` | **1** (`run_pipeline`) | `run_pipeline` only |
+
+Note: in `chart_only`, `refine_image_metadata` is **never called** — so the second
+`side_effect` value in `test_calls_pipeline_and_returns_article` is dead code today.
+
+## Scope decision (needs LGTM)
+
+B-002's title scopes to `TestGenerateContent`. But **two other test classes in the
+same file patch `flow.asyncio.run` and leak the identical warning**:
+`TestRequestRevision` (2 tests) and `TestKickoffResultFile` (4 tests).
+
+**Recommendation — migrate all `asyncio.run`-patching tests in this one file (9
+tests across 3 classes).** Rationale: B-002's stated *goal* is "stop the
+un-awaited-coroutine warnings so they don't mask a future real leak." Migrating only
+`TestGenerateContent` leaves 6 tests in the same file emitting the same warning,
+which defeats that goal — the warning class survives and a future `-W error` gate
+can't be turned on cleanly. The fix is mechanical, identical per test, test-only, and
+the reference pattern (`test_flow_image_mode.py`) already proves it. Staying strictly
+within the title would be scope discipline at the cost of the actual objective.
+
+*Alternative if you'd rather keep the slice literal:* migrate `TestGenerateContent`
+(3 tests) only and open a B-NNN follow-up for the other six. I do not recommend this —
+it splits one mechanical change across two sessions for no risk reduction.
+
+→ **Please pick the scope before I build.** Spec below assumes the recommended
+(whole-file) scope.
+
+## The one design change beyond mechanical substitution
+
+`test_refine_image_metadata_called_via_asyncio_run` (`:211-236`) asserts directly on
+`mock_asyncio_run.call_count == 2` and that the 2nd positional arg
+`iscoroutine(...)`. Those assertions are **coupled to the `asyncio.run` seam we are
+removing** — they cannot survive the migration verbatim.
+
+Rewrite to assert the intent-preserving equivalent against the `AsyncMock`:
+
+```python
+mock_refine.assert_awaited_once()
+assert mock_refine.await_args.args[0] == image_path  # or .kwargs, per call site
+```
+
+This is strictly *better*: it verifies `refine_image_metadata` was actually awaited
+with the right argument, instead of asserting an implementation detail of how the
+flow reaches the event loop. It mirrors `test_flow_image_mode.py`'s
+`mock_run_pipeline.await_args.kwargs` style. The test will be renamed to
+`test_hero_mode_awaits_refine_image_metadata` to reflect what it now proves.
+
+## Migration pattern (from `test_flow_image_mode.py:80-116`)
+
+Before:
+```python
+@patch("src.economist_agents.flow.generate_featured_image", return_value=False)
+@patch("src.economist_agents.flow.asyncio.run")
+def test_calls_pipeline_and_returns_article(self, mock_asyncio_run, mock_image):
+    mock_asyncio_run.side_effect = [_passing_pipeline_result(), {...}]
+```
+
+After:
+```python
+@patch("src.economist_agents.flow.generate_featured_image", return_value=False)
+@patch("src.economist_agents.flow.run_pipeline", new_callable=AsyncMock)
+def test_calls_pipeline_and_returns_article(self, mock_run_pipeline, mock_image):
+    mock_run_pipeline.return_value = _passing_pipeline_result()
+```
+
+Hero-mode tests additionally patch
+`@patch("src.economist_agents.flow.refine_image_metadata", new_callable=AsyncMock)`
+and set `mock_refine.return_value = {"image_alt": ..., "image_caption": ...}`.
+
+`TestKickoffResultFile` uses a shared `_run_kickoff` helper plus per-test decorator
+stacks — both the helper's `mock_asyncio_run.side_effect = [...]` wiring and the
+decorator stacks migrate to the two `AsyncMock` patches. The revision-path test
+(`:937`) sets two pipeline results because it triggers generate **and** revision;
+both become `mock_run_pipeline.side_effect = [failing, failing]`.
+
+## Commands
+
+```
+Run touched file:   .venv/bin/pytest tests/test_flow_agent_sdk.py -q
+Prove no warnings:  .venv/bin/pytest tests/test_flow_agent_sdk.py -q -W error::RuntimeWarning
+Full regression:    .venv/bin/pytest -q
+Lint:               .venv/bin/ruff check tests/test_flow_agent_sdk.py
+```
+
+## Scope of changes (1 file)
+
+| File | Change |
+|------|--------|
+| `tests/test_flow_agent_sdk.py` | Replace `@patch(...asyncio.run)` with `AsyncMock` patches of `run_pipeline` / `refine_image_metadata` across `TestGenerateContent`, `TestRequestRevision`, `TestKickoffResultFile`; rewrite the one `asyncio.run`-introspecting test to assert `await`; add `AsyncMock` to the imports. No production code changes. |
+
+The `from unittest.mock import Mock, patch` import gains `AsyncMock`.
+`flow.py` is **not** touched — this is test-only.
+
+## Testing Strategy
+
+This *is* a test refactor, so verification is behavioural-equivalence + warning-free:
+
+1. Each migrated test asserts the **same** observable outcomes it asserts today
+   (article content, `featured_image`, scores, deploy routing, result-JSON fields).
+   No assertion is weakened; the one introspection test is strengthened (see above).
+2. `pytest tests/test_flow_agent_sdk.py -W error::RuntimeWarning` must pass — this is
+   the regression guard that proves the warning class is gone.
+3. Full-suite `pytest -q` stays green (no collateral).
+
+## Boundaries
+
+- **Always:** keep every existing assertion's intent; run the `-W error` check.
+- **Ask first:** widening scope beyond this file; touching `flow.py`.
+- **Never:** delete a test to silence a warning; weaken an assertion; patch
+  `asyncio.run` again anywhere in this file.
+
+## Success Criteria
+
+- [ ] No `@patch("src.economist_agents.flow.asyncio.run")` remains in the file.
+- [ ] `pytest tests/test_flow_agent_sdk.py -q -W error::RuntimeWarning` exits 0.
+- [ ] `pytest -q` (full suite) stays green.
+- [ ] `ruff check tests/test_flow_agent_sdk.py` clean.
+- [ ] Every migrated test preserves its original observable assertions; the
+      `asyncio.run`-introspection test is rewritten to assert `await` instead.
+- [ ] `BACKLOG.md` B-002 moved to Done; PR merged to `main`.
+
+## Open Questions
+
+1. **Scope** (above): whole-file (recommended) vs. `TestGenerateContent`-only? Need LGTM.
+2. Should `-W error::RuntimeWarning` be wired into the project's pytest config as a
+   permanent gate, or just run as a one-off verification for this PR? (Default: one-off
+   for this PR; a permanent gate is a separate, larger backlog item since it would need
+   the whole suite to be warning-clean first.)

--- a/tests/test_flow_agent_sdk.py
+++ b/tests/test_flow_agent_sdk.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -166,16 +166,15 @@ class TestEditorialReview:
 
 class TestGenerateContent:
     @patch("src.economist_agents.flow.generate_featured_image", return_value=False)
-    @patch("src.economist_agents.flow.asyncio.run")
+    @patch("src.economist_agents.flow.run_pipeline", new_callable=AsyncMock)
     def test_calls_pipeline_and_returns_article(
         self,
-        mock_asyncio_run: Mock,
+        mock_run_pipeline: AsyncMock,
         mock_image: Mock,
     ) -> None:
-        mock_asyncio_run.side_effect = [
-            _passing_pipeline_result(),
-            {"image_alt": "alt text", "image_caption": "caption text"},
-        ]
+        # chart_only (default) makes a single asyncio.run(run_pipeline(...)) call;
+        # refine_image_metadata is not invoked.
+        mock_run_pipeline.return_value = _passing_pipeline_result()
         flow = EconomistContentFlow()
 
         result = flow.generate_content({"topic": "AI Testing"})
@@ -191,49 +190,51 @@ class TestGenerateContent:
         # default flow is chart_only (#410): ships image-less, no DALL-E
         assert result["featured_image"] == ""
 
+    @patch("src.economist_agents.flow.refine_image_metadata", new_callable=AsyncMock)
     @patch("src.economist_agents.flow.generate_featured_image", return_value=True)
-    @patch("src.economist_agents.flow.asyncio.run")
+    @patch("src.economist_agents.flow.run_pipeline", new_callable=AsyncMock)
     def test_uses_dalle_image_when_generated(
         self,
-        mock_asyncio_run: Mock,
+        mock_run_pipeline: AsyncMock,
         mock_image: Mock,
+        mock_refine: AsyncMock,
     ) -> None:
-        mock_asyncio_run.side_effect = [
-            _passing_pipeline_result(),
-            {"image_alt": "alt text", "image_caption": "caption text"},
-        ]
+        mock_run_pipeline.return_value = _passing_pipeline_result()
+        mock_refine.return_value = {
+            "image_alt": "alt text",
+            "image_caption": "caption text",
+        }
         flow = EconomistContentFlow(image_mode="hero")
 
         result = flow.generate_content({"topic": "AI Coding Assistants"})
 
         assert result["featured_image"] == "/assets/images/ai-coding-assistants.png"
 
+    @patch("src.economist_agents.flow.refine_image_metadata", new_callable=AsyncMock)
     @patch("src.economist_agents.flow.generate_featured_image", return_value=False)
-    @patch("src.economist_agents.flow.asyncio.run")
-    def test_refine_image_metadata_called_via_asyncio_run(
+    @patch("src.economist_agents.flow.run_pipeline", new_callable=AsyncMock)
+    def test_hero_mode_awaits_refine_image_metadata(
         self,
-        mock_asyncio_run: Mock,
+        mock_run_pipeline: AsyncMock,
         mock_image: Mock,
+        mock_refine: AsyncMock,
     ) -> None:
-        """asyncio.run must be called twice: once for run_pipeline, once for
-        refine_image_metadata. The second call must receive a coroutine."""
-        import asyncio as _asyncio
-
-        mock_asyncio_run.side_effect = [
-            _passing_pipeline_result(),
-            {"image_alt": "editorial alt", "image_caption": "editorial caption"},
-        ]
+        """In hero mode the flow must await refine_image_metadata exactly once, with
+        the generated image path. (Replaces the old asyncio.run-introspection test
+        that asserted call_count/iscoroutine on the seam we've removed.)"""
+        mock_run_pipeline.return_value = _passing_pipeline_result()
+        mock_refine.return_value = {
+            "image_alt": "editorial alt",
+            "image_caption": "editorial caption",
+        }
         flow = EconomistContentFlow(image_mode="hero")
 
         flow.generate_content({"topic": "AI Testing"})
 
-        assert mock_asyncio_run.call_count == 2
-        second_arg = mock_asyncio_run.call_args_list[1][0][0]
-        assert _asyncio.iscoroutine(second_arg), (
-            "Second asyncio.run() call should pass the refine_image_metadata coroutine, "
-            f"got {type(second_arg)}"
-        )
-        second_arg.close()  # prevent ResourceWarning
+        mock_refine.assert_awaited_once()
+        # First positional arg is the DALL-E image path (output/images/<slug>.png).
+        image_path = mock_refine.await_args.args[0]
+        assert image_path.endswith("ai-testing.png")
 
 
 # ─── stage 4 routing ────────────────────────────────────────────────────
@@ -391,9 +392,9 @@ class TestPublishArticle:
 
 
 class TestRequestRevision:
-    @patch("src.economist_agents.flow.asyncio.run")
-    def test_succeeds_on_retry(self, mock_asyncio_run: Mock) -> None:
-        mock_asyncio_run.return_value = _passing_pipeline_result()
+    @patch("src.economist_agents.flow.run_pipeline", new_callable=AsyncMock)
+    def test_succeeds_on_retry(self, mock_run_pipeline: AsyncMock) -> None:
+        mock_run_pipeline.return_value = _passing_pipeline_result()
         flow = EconomistContentFlow()
         flow.state["selected_topic"] = {"topic": "Retry Me"}
         flow.state["revision_feedback"] = ["fix the ending"]
@@ -404,10 +405,10 @@ class TestRequestRevision:
         assert result["status"] == "published"
         assert result["retry_count"] == 1
 
-    @patch("src.economist_agents.flow.asyncio.run")
+    @patch("src.economist_agents.flow.run_pipeline", new_callable=AsyncMock)
     def test_quarantines_when_retry_still_fails(
         self,
-        mock_asyncio_run: Mock,
+        mock_run_pipeline: AsyncMock,
         tmp_path,
     ) -> None:
         failing = _passing_pipeline_result()
@@ -420,7 +421,7 @@ class TestRequestRevision:
             },
         ]
         failing.editorial_score = 40
-        mock_asyncio_run.return_value = failing
+        mock_run_pipeline.return_value = failing
 
         flow = EconomistContentFlow()
         flow.state["selected_topic"] = {"topic": "Stuck Topic"}
@@ -847,7 +848,7 @@ class TestKickoffResultFile:
         mock_client,
         mock_scout,
         mock_board,
-        mock_asyncio_run,
+        mock_run_pipeline,
     ) -> Path:
         """Wire all mocks and run kickoff(); return the result JSON path."""
         import src.economist_agents.flow as flow_module
@@ -871,15 +872,14 @@ class TestKickoffResultFile:
             "consensus": True,
             "dissenting_views": [],
         }
-        mock_asyncio_run.side_effect = [
-            _passing_pipeline_result(),
-            {"image_alt": "alt", "image_caption": "cap"},
-        ]
+        # chart_only (default) publish path: a single run_pipeline await, no
+        # refine_image_metadata call.
+        mock_run_pipeline.return_value = _passing_pipeline_result()
         flow.kickoff()
         return result_path
 
     @patch("src.economist_agents.flow.generate_featured_image", return_value=False)
-    @patch("src.economist_agents.flow.asyncio.run")
+    @patch("src.economist_agents.flow.run_pipeline", new_callable=AsyncMock)
     @patch("src.economist_agents.flow.run_editorial_board")
     @patch("src.economist_agents.flow.scout_topics")
     @patch("src.economist_agents.flow.create_llm_client")
@@ -888,7 +888,7 @@ class TestKickoffResultFile:
         mock_client: Mock,
         mock_scout: Mock,
         mock_board: Mock,
-        mock_asyncio_run: Mock,
+        mock_run_pipeline: AsyncMock,
         mock_image: Mock,
         tmp_path,
         monkeypatch,
@@ -896,7 +896,12 @@ class TestKickoffResultFile:
         import orjson
 
         result_path = self._run_kickoff(
-            tmp_path, monkeypatch, mock_client, mock_scout, mock_board, mock_asyncio_run
+            tmp_path,
+            monkeypatch,
+            mock_client,
+            mock_scout,
+            mock_board,
+            mock_run_pipeline,
         )
         assert result_path.exists(), "pipeline_result.json was not written"
         data = orjson.loads(result_path.read_bytes())
@@ -905,7 +910,7 @@ class TestKickoffResultFile:
         assert "status" in data
 
     @patch("src.economist_agents.flow.generate_featured_image", return_value=False)
-    @patch("src.economist_agents.flow.asyncio.run")
+    @patch("src.economist_agents.flow.run_pipeline", new_callable=AsyncMock)
     @patch("src.economist_agents.flow.run_editorial_board")
     @patch("src.economist_agents.flow.scout_topics")
     @patch("src.economist_agents.flow.create_llm_client")
@@ -914,7 +919,7 @@ class TestKickoffResultFile:
         mock_client: Mock,
         mock_scout: Mock,
         mock_board: Mock,
-        mock_asyncio_run: Mock,
+        mock_run_pipeline: AsyncMock,
         mock_image: Mock,
         tmp_path,
         monkeypatch,
@@ -922,7 +927,12 @@ class TestKickoffResultFile:
         import orjson
 
         result_path = self._run_kickoff(
-            tmp_path, monkeypatch, mock_client, mock_scout, mock_board, mock_asyncio_run
+            tmp_path,
+            monkeypatch,
+            mock_client,
+            mock_scout,
+            mock_board,
+            mock_run_pipeline,
         )
         data = orjson.loads(result_path.read_bytes())
         assert data["editorial_score"] == 88  # from _passing_pipeline_result
@@ -930,7 +940,7 @@ class TestKickoffResultFile:
         assert data["status"] == "published"
 
     @patch("src.economist_agents.flow.generate_featured_image", return_value=False)
-    @patch("src.economist_agents.flow.asyncio.run")
+    @patch("src.economist_agents.flow.run_pipeline", new_callable=AsyncMock)
     @patch("src.economist_agents.flow.run_editorial_board")
     @patch("src.economist_agents.flow.scout_topics")
     @patch("src.economist_agents.flow.create_llm_client")
@@ -939,7 +949,7 @@ class TestKickoffResultFile:
         mock_client: Mock,
         mock_scout: Mock,
         mock_board: Mock,
-        mock_asyncio_run: Mock,
+        mock_run_pipeline: AsyncMock,
         mock_image: Mock,
         tmp_path,
         monkeypatch,
@@ -967,8 +977,8 @@ class TestKickoffResultFile:
         failing.editorial_score = 40
         failing.publication_validator_passed = False
         # chart_only (default) makes no refine_image_metadata call, so the only
-        # asyncio.run calls are the two run_pipeline invocations.
-        mock_asyncio_run.side_effect = [
+        # run_pipeline awaits are the generate + revision invocations.
+        mock_run_pipeline.side_effect = [
             failing,  # run_pipeline (generate)
             failing,  # run_pipeline (revision)
         ]
@@ -988,7 +998,7 @@ class TestKickoffResultFile:
         assert "gates_passed" in data
 
     @patch("src.economist_agents.flow.generate_featured_image", return_value=False)
-    @patch("src.economist_agents.flow.asyncio.run")
+    @patch("src.economist_agents.flow.run_pipeline", new_callable=AsyncMock)
     @patch("src.economist_agents.flow.run_editorial_board")
     @patch("src.economist_agents.flow.scout_topics")
     @patch("src.economist_agents.flow.create_llm_client")
@@ -997,7 +1007,7 @@ class TestKickoffResultFile:
         mock_client: Mock,
         mock_scout: Mock,
         mock_board: Mock,
-        mock_asyncio_run: Mock,
+        mock_run_pipeline: AsyncMock,
         mock_image: Mock,
         tmp_path,
         monkeypatch,
@@ -1018,10 +1028,7 @@ class TestKickoffResultFile:
             "consensus": True,
             "dissenting_views": [],
         }
-        mock_asyncio_run.side_effect = [
-            _passing_pipeline_result(),
-            {"image_alt": "alt", "image_caption": "cap"},
-        ]
+        mock_run_pipeline.return_value = _passing_pipeline_result()
         flow = EconomistContentFlow()
         flow._deduplicator = Mock()
         flow._deduplicator.filter_topics.side_effect = lambda t: (t, [])


### PR DESCRIPTION
## What

Slice 2 of the 2026-06-14 backlog sprint. Closes **B-002** (was #425).

`tests/test_flow_agent_sdk.py` patched `flow.asyncio.run` to a stub. Because the real `asyncio.run` was replaced, the `run_pipeline` / `refine_image_metadata` coroutines that `flow.generate_content` constructs were **never awaited**, so each affected test emitted `RuntimeWarning: coroutine ... was never awaited` — noise that would mask a future *real* un-awaited-coroutine leak.

## Change (test-only — `flow.py` untouched)

Migrate all **9** `asyncio.run`-patching tests across 3 classes (`TestGenerateContent`, `TestRequestRevision`, `TestKickoffResultFile`) to the `AsyncMock` pattern already proven in `test_flow_image_mode.py` (PR #424): patch `run_pipeline` / `refine_image_metadata` as `AsyncMock` and let the real `asyncio.run` drive them.

Scope note: B-002's title named only `TestGenerateContent`, but the other two classes leaked the identical warning. Whole-file migration was chosen (LGTM'd) so the warning class is fully cleared.

One test rewritten rather than re-mocked: `test_refine_image_metadata_called_via_asyncio_run` asserted on the `asyncio.run` seam being removed (`call_count` / `iscoroutine`). It becomes `test_hero_mode_awaits_refine_image_metadata`, asserting `refine_image_metadata` was awaited once with the generated image path — intent preserved, coupling dropped.

## Verification

- `pytest tests/test_flow_agent_sdk.py -W error::RuntimeWarning` → **41 passed, 0 warnings**
- Full suite → **2406 passed, 9 skipped**
- `ruff check` clean

Spec: `docs/specs/B-002-asyncio-run-stub-removal.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)