### PR TITLE
fix: wire Stage 4 author safety net to BLOG_AUTHOR (B-001)

### DIFF
--- a/docs/specs/B-001-blog-author-safety-net.md
+++ b/docs/specs/B-001-blog-author-safety-net.md
@@ -1,0 +1,168 @@
+# Spec: B-001 · Wire Stage 4 author safety net to `BLOG_AUTHOR`
+
+> Backlog item: **B-001** (`type:refactor`, was #420). Slice 3 of the
+> 2026-06-14 "clear the backlog" sprint. Follow-up from PR #416 (issue #401).
+
+## Objective
+
+The production author name must live in exactly one place (`BLOG_AUTHOR` in
+`scripts/publication_validator.py:32`) and flow from there into every stage that
+emits or checks it. Today the Stage 4 frontmatter safety net hard-codes the
+author as a string literal:
+
+```python
+# src/agent_sdk/_shared.py:632
+fm = fm.rstrip() + '\nauthor: "Ouray Viney"\n'
+```
+
+If `BLOG_AUTHOR` ever changes, this literal silently drifts and the safety net
+will inject an author the publication validator then rejects. **Goal:**
+interpolate `BLOG_AUTHOR` here so the constant is the single source of truth.
+
+**Why it was deferred (the real work in this slice):** `_shared.py` carries a
+pre-existing **ADR-002 violation** — `import anthropic` inside
+`refine_image_metadata` (line 734). The `pre_commit_arch_check.py` gate blocks
+*any* edit to a file that imports a prohibited LLM library directly, so we
+cannot touch line 632 until the import is routed through a compliant module.
+
+Success = the constant is wired, the ADR-002 gate passes on `_shared.py`, and
+the existing author-contract tests become load-bearing against `BLOG_AUTHOR`.
+
+## Scope
+
+**In scope**
+1. Add an async Anthropic client factory to `scripts/llm_client.py` (the sole
+   LLM-client factory; already in `LLM_IMPORT_EXCEPTIONS`).
+2. Replace `import anthropic` + `AsyncAnthropic(...)` in `_shared.py`'s
+   `refine_image_metadata` with a call to that factory.
+3. Interpolate `BLOG_AUTHOR` into the Stage 4 safety net at `_shared.py:632`.
+
+**Out of scope** (non-negotiable — scope discipline)
+- Extending `AgentRegistry` with async/vision support (the backlog's "route via
+  AgentRegistry" note is aspirational; AgentRegistry has no async/vision path,
+  and building one is disproportionate to this slice — see Decision below).
+- Any behaviour change to vision refinement, frontmatter assembly, or the
+  validator beyond removing the author literal.
+- Refactoring the other exception-file violations (`featured_image_agent.py`,
+  `visual_qa.py`).
+
+## Decision: clear ADR-002 via the `llm_client.py` factory
+
+**Chosen (human-confirmed):** Add a thin `create_async_anthropic_client()` to
+`scripts/llm_client.py` and call it from `_shared.py`.
+
+- `scripts/llm_client.py` is already an ADR-002 exception file and is *the* sole
+  factory for LLM client creation — adding the async sibling of the existing
+  `_create_anthropic_client()` keeps client construction in one compliant place.
+- `_shared.py` then imports a plain function (`from scripts.llm_client import
+  create_async_anthropic_client`) — no prohibited import remains, so the AST
+  gate passes. Verified: `scripts/llm_client.py` imports nothing from `src/`, so
+  no circular import is introduced.
+
+**Rejected:** Extending `AgentRegistry` (too large for this slice; new async
+provider + vision content-block helper + registry tests). Adding `_shared.py` to
+`LLM_IMPORT_EXCEPTIONS` (entrenches the violation rather than fixing it; against
+ADR-002 intent).
+
+## Commands
+
+```
+Test (targeted):   .venv/bin/pytest tests/test_author_contract.py -q
+Test (vision):     .venv/bin/pytest tests/ -k "refine_image or vision or _shared" -q
+ADR-002 gate:      .venv/bin/python scripts/pre_commit_arch_check.py src/agent_sdk/_shared.py scripts/llm_client.py
+Lint:              .venv/bin/ruff check src/agent_sdk/_shared.py scripts/llm_client.py
+Full suite:        .venv/bin/pytest -q
+```
+
+## Code Style
+
+New factory mirrors the existing `_create_anthropic_client()` (lazy import,
+typed, docstring, raises a clear `ImportError`):
+
+```python
+def create_async_anthropic_client(api_key: str | None = None) -> Any:
+    """Create an AsyncAnthropic client for async vision/messages calls.
+
+    ADR-002 factory route: keeps the ``anthropic`` import inside this
+    exception-listed factory so callers in ``src/`` need not import it directly.
+    """
+    key = api_key or os.environ["ANTHROPIC_API_KEY"]
+    try:
+        from anthropic import AsyncAnthropic
+    except ImportError as err:
+        raise ImportError(
+            "[LLM_CLIENT] anthropic package not installed. "
+            "Install it: pip install anthropic",
+        ) from err
+    return AsyncAnthropic(api_key=key)
+```
+
+Returns the raw `AsyncAnthropic` (not an `LLMClient` wrapper) because the caller
+needs the async `messages.create` with image content blocks; the `LLMClient`
+wrapper exists for the unified *sync* path and would not fit here.
+
+Caller change in `_shared.py` `refine_image_metadata` (keeps the lazy-import
+style already used in that function):
+
+```python
+# remove:  import anthropic as _anthropic
+from scripts.llm_client import create_async_anthropic_client
+...
+client = create_async_anthropic_client(api_key)   # was _anthropic.AsyncAnthropic(api_key=api_key)
+```
+
+Safety-net change at `_shared.py:632`:
+
+```python
+from scripts.publication_validator import BLOG_AUTHOR   # lazy, inside apply_editorial_fixes
+...
+if "author:" not in fm:
+    fm = fm.rstrip() + f'\nauthor: "{BLOG_AUTHOR}"\n'
+```
+
+## Testing Strategy
+
+`tests/test_author_contract.py` already encodes the target behaviour. Two
+changes make it load-bearing rather than describing the literal:
+
+- `test_safety_net_emits_the_production_author_when_missing` (lines 43–53)
+  already asserts the *observable* output equals `BLOG_AUTHOR` — it passes today
+  by coincidence (literal == constant) and will pass by *construction* after the
+  wiring. Update its docstring note that called out the not-yet-wired state.
+- Add one regression test proving the link is dynamic: monkeypatch /
+  parametrise so that a non-default author value flowing through the safety net
+  proves it reads the constant, not a literal. (If patching the constant is
+  awkward given import timing, assert via a comment-documented dynamic check
+  that `apply_editorial_fixes` output author == imported `BLOG_AUTHOR`.)
+
+Vision path: existing `_shared` / image-mode tests must still pass — they mock
+the Anthropic client; confirm the mock target still resolves after the factory
+swap (tests that patch `anthropic.AsyncAnthropic` or `_shared`'s client may need
+their patch target updated to `scripts.llm_client.create_async_anthropic_client`).
+
+TDD order: write/adjust the failing author test first, then wire the constant;
+swap the client factory under the protection of the existing vision tests.
+
+## Boundaries
+
+- **Always:** run the ADR-002 gate + targeted tests + full suite before PR;
+  branch off `main`; keep the diff to the three files above (+ test file).
+- **Ask first:** any change to `AgentRegistry`, the gate's exception list, or
+  the vision/frontmatter behaviour.
+- **Never:** commit the `import anthropic` workaround as an exception entry;
+  change `BLOG_AUTHOR`'s value; touch unrelated `_shared.py` helpers.
+
+## Success Criteria
+
+1. `scripts/pre_commit_arch_check.py src/agent_sdk/_shared.py` exits 0 (no
+   `import anthropic` in `_shared.py`).
+2. `_shared.py:632` interpolates `BLOG_AUTHOR`; grep for the `"Ouray Viney"`
+   literal in `_shared.py` returns nothing.
+3. `tests/test_author_contract.py` passes and at least one test fails if the
+   safety net is reverted to a literal (proves the link is load-bearing).
+4. Vision refinement behaviour unchanged: image-mode / `_shared` tests pass.
+5. Full suite green; ruff clean; all CI checks green on the PR.
+
+## Open Questions
+
+_(none — design decision resolved; circular-import and gate-wiring facts verified.)_

--- a/scripts/llm_client.py
+++ b/scripts/llm_client.py
@@ -94,6 +94,38 @@ def _create_anthropic_client() -> LLMClient:
     return LLMClient("anthropic", client, model)
 
 
+def create_async_anthropic_client(api_key: str | None = None) -> Any:
+    """Create an ``AsyncAnthropic`` client for async vision/messages calls.
+
+    ADR-002 factory route: keeps the ``anthropic`` import inside this
+    exception-listed factory so callers in ``src/`` (e.g. the Stage 4 vision
+    refinement helper) need not import ``anthropic`` directly.
+
+    Args:
+        api_key: Anthropic API key. Falls back to ``ANTHROPIC_API_KEY`` when
+            not provided.
+
+    Returns:
+        A raw ``anthropic.AsyncAnthropic`` instance (not an ``LLMClient``
+        wrapper — callers drive ``messages.create`` with async image blocks).
+
+    Raises:
+        ImportError: If the ``anthropic`` package is not installed.
+
+    """
+    key = api_key or os.environ["ANTHROPIC_API_KEY"]
+
+    try:
+        from anthropic import AsyncAnthropic
+    except ImportError as err:
+        raise ImportError(
+            "[LLM_CLIENT] anthropic package not installed. "
+            "Install it: pip install anthropic",
+        ) from err
+
+    return AsyncAnthropic(api_key=key)
+
+
 def _create_openai_client(max_retries: int, base_delay: int) -> LLMClient:
     """Create OpenAI client with retry logic."""
     api_key = os.environ.get("OPENAI_API_KEY")

--- a/src/agent_sdk/_shared.py
+++ b/src/agent_sdk/_shared.py
@@ -731,7 +731,7 @@ async def refine_image_metadata(
         return fallback
 
     try:
-        import anthropic as _anthropic
+        from scripts.llm_client import create_async_anthropic_client
 
         suffix = path.suffix.lower().lstrip(".")
         media_type = {
@@ -749,7 +749,7 @@ async def refine_image_metadata(
                 vision_model,
             )
             vision_model = _DEFAULT_VISION_MODEL
-        client = _anthropic.AsyncAnthropic(api_key=api_key)
+        client = create_async_anthropic_client(api_key)
         response = await client.messages.create(
             model=vision_model,
             max_tokens=256,

--- a/src/agent_sdk/_shared.py
+++ b/src/agent_sdk/_shared.py
@@ -629,7 +629,9 @@ def apply_editorial_fixes(article: str, current_date: str | None = None) -> str:
             if "layout:" not in fm:
                 fm = "\nlayout: post" + fm
             if "author:" not in fm:
-                fm = fm.rstrip() + '\nauthor: "Ouray Viney"\n'
+                from scripts.publication_validator import BLOG_AUTHOR
+
+                fm = fm.rstrip() + f'\nauthor: "{BLOG_AUTHOR}"\n'
             if "categories:" not in fm:
                 fm = fm.rstrip() + '\ncategories: ["Quality Engineering"]\n'
             fm = _normalize_category_casing(fm)

--- a/tests/test_async_anthropic_factory.py
+++ b/tests/test_async_anthropic_factory.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Unit tests for ``create_async_anthropic_client`` (B-001, ADR-002 route).
+
+``src/agent_sdk/_shared.py`` must not import ``anthropic`` directly — it is not
+in the arch-check ``LLM_IMPORT_EXCEPTIONS`` list. This factory lives in the
+exception-listed ``scripts/llm_client.py`` so the Stage 4 vision-refinement
+helper can obtain an ``AsyncAnthropic`` client without a prohibited import.
+
+NB: key values here are kept short on purpose — the pre-commit secret scanner
+flags key-assignment literals of eight or more characters.
+"""
+
+from __future__ import annotations
+
+import os
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from scripts.llm_client import create_async_anthropic_client
+
+
+def _fake_anthropic_module(async_class: MagicMock) -> types.ModuleType:
+    """Return a stand-in ``anthropic`` module exposing *async_class*."""
+    module = types.ModuleType("anthropic")
+    module.AsyncAnthropic = async_class  # type: ignore[attr-defined]
+    return module
+
+
+def test_returns_async_anthropic_client_built_from_env_key() -> None:
+    """Factory returns the AsyncAnthropic instance, keyed from the env var."""
+    import sys
+
+    instance = MagicMock()
+    async_class = MagicMock(return_value=instance)
+
+    with (
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": "envkey"}),
+        patch.dict(sys.modules, {"anthropic": _fake_anthropic_module(async_class)}),
+    ):
+        client = create_async_anthropic_client()
+
+    assert client is instance
+    async_class.assert_called_once_with(api_key="envkey")
+
+
+def test_explicit_api_key_overrides_env() -> None:
+    """An explicit api_key argument wins over the environment variable."""
+    import sys
+
+    instance = MagicMock()
+    async_class = MagicMock(return_value=instance)
+
+    with (
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": "envkey"}),
+        patch.dict(sys.modules, {"anthropic": _fake_anthropic_module(async_class)}),
+    ):
+        client = create_async_anthropic_client(api_key="argkey")
+
+    assert client is instance
+    async_class.assert_called_once_with(api_key="argkey")
+
+
+def test_raises_import_error_when_anthropic_missing() -> None:
+    """A clear ImportError is raised when the anthropic package is absent."""
+    import builtins
+    import sys
+
+    real_import = builtins.__import__
+
+    def _blocked_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "anthropic":
+            raise ImportError("no anthropic")
+        return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+    with (
+        patch.dict(os.environ, {"ANTHROPIC_API_KEY": "envkey"}),
+        patch.dict(sys.modules, {"anthropic": None}),
+        patch.object(builtins, "__import__", _blocked_import),
+        pytest.raises(ImportError, match="anthropic package not installed"),
+    ):
+        create_async_anthropic_client()

--- a/tests/test_author_contract.py
+++ b/tests/test_author_contract.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import re
 
+import pytest
+
 from scripts.publication_validator import BLOG_AUTHOR, PublicationValidator
 from src.agent_sdk._shared import apply_editorial_fixes
 from src.agent_sdk.stage3_runner import _build_writer_prompt
@@ -44,13 +46,29 @@ def test_safety_net_emits_the_production_author_when_missing() -> None:
     """Behavioural guard: the Stage 4 frontmatter safety net fills in the
     production author when the writer omits it.
 
-    NB: the safety net currently emits the value as a literal (it is not yet
-    wired to ``BLOG_AUTHOR`` — see the constant's docstring), so this asserts
-    the observable output equals the configured author, not the implementation.
+    The safety net is wired to ``BLOG_AUTHOR`` (B-001), so this asserts the
+    observable output equals the single-source-of-truth constant.
     """
     article = '---\nlayout: post\ntitle: "X"\ncategories: ["Quality Engineering"]\n---\n\nBody text.'
     fixed = apply_editorial_fixes(article)
     assert f'author: "{BLOG_AUTHOR}"' in fixed
+
+
+def test_safety_net_tracks_blog_author_constant_dynamically(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Load-bearing: the injected author must track ``BLOG_AUTHOR``, not a
+    hard-coded literal.
+
+    Patching the constant at its source and seeing the new value flow into the
+    frontmatter proves the safety net reads the constant at runtime. This test
+    fails if the safety net is reverted to emitting a string literal.
+    """
+    monkeypatch.setattr("scripts.publication_validator.BLOG_AUTHOR", "Sentinel Author")
+    article = '---\nlayout: post\ntitle: "X"\ncategories: ["Quality Engineering"]\n---\n\nBody text.'
+    fixed = apply_editorial_fixes(article)
+    assert 'author: "Sentinel Author"' in fixed
+    assert "Ouray Viney" not in fixed
 
 
 def test_validator_accepts_configured_author() -> None:


### PR DESCRIPTION
## Summary

Closes **B-001** (was #420) — slice 3 of the 2026-06-14 backlog-clearing sprint. Spec: \`docs/specs/B-001-blog-author-safety-net.md\`.

The Stage 4 frontmatter safety net (\`src/agent_sdk/_shared.py\`) hard-coded the blog author as the literal \`"Ouray Viney"\`, so it could silently drift from \`BLOG_AUTHOR\` (\`scripts/publication_validator.py\`) — the supposed single source of truth wired into the Stage 3 writer prompt and the validator's author contract.

Editing \`_shared.py\` was blocked by a **pre-existing ADR-002 violation** (`import anthropic` in the vision-refinement helper), which the arch-check pre-commit gate flags on any change to the file. So this PR first clears the gate, then does the one-line wiring.

## Changes (3 thin slices, each tested + committed)

| Slice | Change |
|-------|--------|
| **A** | Add `create_async_anthropic_client()` to `scripts/llm_client.py` (the sole LLM-client factory, already an ADR-002 exception). Returns a raw `AsyncAnthropic`. New dedicated test file. |
| **B** | Route `_shared.py`'s `refine_image_metadata` through that factory instead of `import anthropic` → **clears the ADR-002 gate**. No behaviour change: the factory's lazy `from anthropic import AsyncAnthropic` keeps existing `patch("anthropic.AsyncAnthropic")` tests valid. |
| **C** | Interpolate `f'author: "{BLOG_AUTHOR}"'` at the safety net (lazy import). Add a **load-bearing** regression that monkeypatches `BLOG_AUTHOR` at its source and asserts the new value flows into the frontmatter — fails if reverted to a literal. |

## Design decision (human-confirmed at spec time)

Cleared ADR-002 via the `llm_client.py` factory — **not** by extending `AgentRegistry` (no async/vision path; disproportionate) or whitelisting `_shared.py` (entrenches the violation).

## Verification

- `scripts/pre_commit_arch_check.py src/agent_sdk/_shared.py` → ✅ passes (no `anthropic` import)
- No `"Ouray Viney"` literal remains in `_shared.py`
- `tests/test_author_contract.py` → 8 passed (incl. the new load-bearing test, confirmed RED before the fix)
- Full suite: **2410 passed, 9 skipped**; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)