### PR TITLE
fix: make Anthropic work under the ant OAuth profile (auth resolver + model default)

### DIFF
--- a/docs/specs/anthropic-auth-token-resolution.md
+++ b/docs/specs/anthropic-auth-token-resolution.md
@@ -1,0 +1,163 @@
+# Spec: Honor `ant` OAuth credentials in the Anthropic auth path
+
+## Objective
+
+After migrating local auth to `ant auth login` (a platform.claude.com OAuth
+profile), there is no `ANTHROPIC_API_KEY` in the environment. The installed
+`anthropic` SDK (0.75.0) does **not** auto-resolve the on-disk `ant` profile —
+it only reads the `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` env vars
+(verified empirically). Our code hard-gates on, and explicitly passes,
+`ANTHROPIC_API_KEY`, so every direct-`anthropic`-SDK path raises
+`No API key found` / `KeyError` even though valid OAuth credentials exist on
+disk.
+
+Affected (direct `anthropic` SDK) paths: `scripts/llm_client.py`
+(`create_llm_client`, `_create_anthropic_client`, `create_async_anthropic_client`)
+and the Stage 4 vision-refinement gate in `src/agent_sdk/_shared.py`. These back
+the topic scout, editorial board, deep-research LLM, and chart/vision steps.
+
+**Success looks like:** with only an `ant` profile present (no env key), a real
+pipeline run authenticates Anthropic calls successfully and the article reaches
+the publication validator.
+
+## Assumptions
+
+1. Stage 3 writing via `claude_agent_sdk` already honors `ant` profile
+   resolution itself (per the Anthropic CLI docs) and is **out of scope** — this
+   spec only covers the direct `anthropic` SDK paths.
+2. `ant auth print-credentials --access-token` is the supported way to obtain
+   (and refresh) the active profile's short-lived OAuth token; it prints a bare
+   token on stdout. Verified: feeding that token to the SDK as
+   `ANTHROPIC_AUTH_TOKEN` makes a real API call succeed.
+3. The active profile targets `api.anthropic.com` (no custom `ANTHROPIC_BASE_URL`
+   needed). If a profile ever carries a base_url, the user exports it separately
+   via `ant auth print-credentials --env`; this spec does not manage base_url.
+4. Existing behavior when `ANTHROPIC_API_KEY` is set must be byte-for-byte
+   unchanged (existing tests assert `Anthropic(api_key=...)` / `AsyncAnthropic(api_key=...)`).
+
+## Tech Stack
+
+Python 3.x, `anthropic` SDK, `orjson`, `pytest`. No new dependencies.
+
+## Commands
+
+```
+Test (changed files): pytest tests/test_anthropic_auth_resolution.py tests/test_llm_client.py tests/test_async_anthropic_factory.py tests/test_llm_providers.py -q
+Lint: ruff check scripts/llm_client.py src/agent_sdk/_shared.py
+Coverage gate: pytest --cov=scripts.llm_client --cov-report=term-missing
+```
+
+## Project Structure
+
+```
+scripts/llm_client.py            → auth resolver + client factories (changed)
+src/agent_sdk/_shared.py         → Stage 4 vision gate (changed)
+tests/test_anthropic_auth_resolution.py → new unit tests (TDD)
+docs/specs/anthropic-auth-token-resolution.md → this spec
+```
+
+## Design
+
+Add one resolver to `scripts/llm_client.py`:
+
+```python
+def resolve_anthropic_auth() -> str | None:
+    """Return the available Anthropic auth kind, or None.
+
+    Priority:
+      1. ANTHROPIC_API_KEY env  -> "api_key"
+      2. ANTHROPIC_AUTH_TOKEN env -> "auth_token"
+      3. active `ant` profile    -> "auth_token"  (side effect: sets
+         os.environ["ANTHROPIC_AUTH_TOKEN"] from the profile token)
+    Returns None when no credential is available. Never raises.
+    """
+```
+
+`_load_ant_profile_token()` shells `ant auth print-credentials --access-token`
+with a short timeout; returns the stripped token on rc 0 + non-empty stdout,
+else `None`. Guards `FileNotFoundError` (ant not installed),
+`subprocess.TimeoutExpired`, and any other failure → `None`.
+
+Wire-ups:
+
+- `create_llm_client()`: gate on `resolve_anthropic_auth()` instead of
+  `ANTHROPIC_API_KEY` only; keep the OpenAI fallback; update the final error
+  message to mention `ant auth login`.
+- `_create_anthropic_client()`: construct `Anthropic()` with **no explicit
+  api_key** — the SDK reads whichever env var the resolver populated. (`api_key`
+  and `auth_token` are both honored by a bare `Anthropic()`.)
+- `create_async_anthropic_client(api_key=None)`: when `api_key` (arg) or
+  `ANTHROPIC_API_KEY` is present, keep current behavior
+  (`AsyncAnthropic(api_key=key)`); otherwise call `resolve_anthropic_auth()`
+  and, on success, return a bare `AsyncAnthropic()`; if no creds, raise the
+  existing "no API key" error.
+- `src/agent_sdk/_shared.py` vision gate: replace
+  `api_key = os.environ.get("ANTHROPIC_API_KEY"); if not api_key: skip` with
+  `if not resolve_anthropic_auth(): skip`, then call
+  `create_async_anthropic_client()` with no explicit key. (`_shared.py` keeps its
+  ADR-002 rule: it imports the resolver/factory from `scripts.llm_client`, never
+  `anthropic` directly.)
+
+## Code Style
+
+```python
+def _load_ant_profile_token() -> str | None:
+    """Return the active ant profile's OAuth token, or None if unavailable."""
+    try:
+        result = subprocess.run(
+            ["ant", "auth", "print-credentials", "--access-token"],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("ant profile token unavailable: %s", exc)
+        return None
+    token = result.stdout.strip()
+    return token if result.returncode == 0 and token else None
+```
+
+Type hints mandatory, docstrings required, `logger` not `print()` for new code.
+
+## Testing Strategy
+
+`pytest`, mocks for all externals (`subprocess.run`, the `anthropic` module).
+New file `tests/test_anthropic_auth_resolution.py`:
+
+1. `resolve_anthropic_auth` → `"api_key"` when `ANTHROPIC_API_KEY` set; does
+   **not** shell out to `ant`.
+2. → `"auth_token"` when only `ANTHROPIC_AUTH_TOKEN` set; no shell-out.
+3. → `"auth_token"` when neither env set and mocked `subprocess.run` returns a
+   token; asserts `os.environ["ANTHROPIC_AUTH_TOKEN"]` is populated.
+4. → `None` when neither env set and `ant` missing (`FileNotFoundError`); no env
+   mutation.
+5. → `None` when `ant` returns rc≠0 or empty stdout.
+6. `create_llm_client()` selects the anthropic provider when only
+   `ANTHROPIC_AUTH_TOKEN` is set (mocked anthropic module).
+7. `create_async_anthropic_client()` with only `ANTHROPIC_AUTH_TOKEN` builds
+   `AsyncAnthropic()` with no `api_key` kwarg.
+
+Regression: `tests/test_llm_client.py`, `tests/test_async_anthropic_factory.py`,
+`tests/test_llm_providers.py` must still pass unchanged. >80% coverage on the new
+code.
+
+## Boundaries
+
+- **Always:** mock `subprocess` and `anthropic` in tests; keep `_shared.py` free
+  of a direct `anthropic` import; preserve existing `api_key`-path behavior.
+- **Ask first:** any change to the Stage 3 `claude_agent_sdk` auth path; adding a
+  token-refresh daemon; managing `ANTHROPIC_BASE_URL`.
+- **Never:** log token values; commit credentials; weaken the OpenAI fallback.
+
+## Success Criteria
+
+1. New + existing tests in the four files above pass; ruff clean.
+2. `resolve_anthropic_auth()` returns a truthy kind with only an `ant` profile
+   present (no env key).
+3. End-to-end: a fresh pipeline run with only the `ant` profile authenticates
+   Anthropic calls and produces an article that reaches the publication
+   validator (this is the real acceptance test from the next-session plan).
+
+## Open Questions
+
+None blocking. (Token expiry mid-run is handled per-call by
+`print-credentials`, which refreshes; a long-lived refresh daemon is explicitly
+out of scope.)

--- a/scripts/llm_client.py
+++ b/scripts/llm_client.py
@@ -6,7 +6,7 @@ OpenAI when only OPENAI_API_KEY is available.
 
 Environment Variables:
     ANTHROPIC_API_KEY: Anthropic API key (preferred)
-    ANTHROPIC_MODEL: Anthropic model (default: claude-sonnet-4-20250514)
+    ANTHROPIC_MODEL: Anthropic model (default: claude-sonnet-4-6)
     OPENAI_API_KEY: OpenAI API key (fallback)
     OPENAI_MODEL: OpenAI model (default: gpt-4o)
 
@@ -145,7 +145,7 @@ def _create_anthropic_client() -> LLMClient:
         ) from err
 
     client = Anthropic()
-    model = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
+    model = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-6")
     print(f"   Model: {model}")
     return LLMClient("anthropic", client, model)
 

--- a/scripts/llm_client.py
+++ b/scripts/llm_client.py
@@ -19,6 +19,7 @@ Usage:
 
 import logging
 import os
+import subprocess
 import time
 from typing import Any
 
@@ -35,6 +36,56 @@ try:
         load_dotenv(env_path)
 except ImportError:
     pass  # python-dotenv not installed, use system env vars
+
+
+def _load_ant_profile_token() -> str | None:
+    """Return the active ``ant`` profile's OAuth token, or ``None``.
+
+    Shells ``ant auth print-credentials --access-token`` (which refreshes the
+    short-lived token as a side effect). Returns the stripped token on a clean
+    exit with non-empty output; otherwise ``None``. Never raises — a missing
+    ``ant`` binary, a timeout, or any failure resolves to ``None`` so callers
+    can fall through to the next credential source.
+    """
+    try:
+        result = subprocess.run(
+            ["ant", "auth", "print-credentials", "--access-token"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("ant profile token unavailable: %s", exc)
+        return None
+
+    token = result.stdout.strip()
+    return token if result.returncode == 0 and token else None
+
+
+def resolve_anthropic_auth() -> str | None:
+    """Return the available Anthropic auth kind, or ``None``.
+
+    Resolution order:
+        1. ``ANTHROPIC_API_KEY`` env  -> ``"api_key"``
+        2. ``ANTHROPIC_AUTH_TOKEN`` env -> ``"auth_token"``
+        3. active ``ant`` profile      -> ``"auth_token"`` (side effect: sets
+           ``os.environ["ANTHROPIC_AUTH_TOKEN"]`` from the profile token so the
+           ``anthropic`` SDK, which only reads env vars, can authenticate)
+
+    Returns ``None`` when no credential is available. Never raises.
+    """
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return "api_key"
+    if os.environ.get("ANTHROPIC_AUTH_TOKEN"):
+        return "auth_token"
+
+    token = _load_ant_profile_token()
+    if token:
+        os.environ["ANTHROPIC_AUTH_TOKEN"] = token
+        return "auth_token"
+
+    return None
 
 
 class LLMClient:
@@ -63,7 +114,7 @@ def create_llm_client(max_retries: int = 3, base_delay: int = 1) -> LLMClient:
         ValueError: If neither API key is set.
 
     """
-    if os.environ.get("ANTHROPIC_API_KEY"):
+    if resolve_anthropic_auth():
         print("🤖 LLM Provider: anthropic")
         return _create_anthropic_client()
 
@@ -72,14 +123,19 @@ def create_llm_client(max_retries: int = 3, base_delay: int = 1) -> LLMClient:
         return _create_openai_client(max_retries, base_delay)
 
     raise ValueError(
-        "[LLM_CLIENT] No API key found. Set ANTHROPIC_API_KEY or OPENAI_API_KEY.",
+        "[LLM_CLIENT] No API key found. Set ANTHROPIC_API_KEY or OPENAI_API_KEY, "
+        "or run 'ant auth login'.",
     )
 
 
 def _create_anthropic_client() -> LLMClient:
-    """Create Anthropic client."""
-    api_key = os.environ["ANTHROPIC_API_KEY"]
+    """Create Anthropic client.
 
+    Credentials are resolved by :func:`resolve_anthropic_auth` (env API key, env
+    auth token, or ``ant`` profile) and surfaced via env vars, so the bare
+    ``Anthropic()`` constructor — which honours both ``ANTHROPIC_API_KEY`` and
+    ``ANTHROPIC_AUTH_TOKEN`` — authenticates without an explicit key argument.
+    """
     try:
         from anthropic import Anthropic
     except ImportError as err:
@@ -88,7 +144,7 @@ def _create_anthropic_client() -> LLMClient:
             "Install it: pip install anthropic",
         ) from err
 
-    client = Anthropic(api_key=api_key)
+    client = Anthropic()
     model = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-4-20250514")
     print(f"   Model: {model}")
     return LLMClient("anthropic", client, model)
@@ -113,7 +169,7 @@ def create_async_anthropic_client(api_key: str | None = None) -> Any:
         ImportError: If the ``anthropic`` package is not installed.
 
     """
-    key = api_key or os.environ["ANTHROPIC_API_KEY"]
+    key = api_key or os.environ.get("ANTHROPIC_API_KEY")
 
     try:
         from anthropic import AsyncAnthropic
@@ -123,7 +179,19 @@ def create_async_anthropic_client(api_key: str | None = None) -> Any:
             "Install it: pip install anthropic",
         ) from err
 
-    return AsyncAnthropic(api_key=key)
+    if key:
+        return AsyncAnthropic(api_key=key)
+
+    # No explicit/env API key — fall back to auth-token resolution (env var or
+    # `ant` profile). ``resolve_anthropic_auth`` populates ANTHROPIC_AUTH_TOKEN,
+    # which the bare ``AsyncAnthropic()`` constructor reads.
+    if resolve_anthropic_auth():
+        return AsyncAnthropic()
+
+    raise ValueError(
+        "[LLM_CLIENT] No Anthropic credentials found. Set ANTHROPIC_API_KEY or "
+        "ANTHROPIC_AUTH_TOKEN, or run 'ant auth login'.",
+    )
 
 
 def _create_openai_client(max_retries: int, base_delay: int) -> LLMClient:

--- a/src/agent_sdk/_shared.py
+++ b/src/agent_sdk/_shared.py
@@ -714,9 +714,13 @@ async def refine_image_metadata(
 
     fallback = {"image_alt": draft_alt, "image_caption": draft_caption}
 
-    api_key = os.environ.get("ANTHROPIC_API_KEY")
-    if not api_key:
-        logger.warning("ANTHROPIC_API_KEY not set — skipping vision refinement")
+    from scripts.llm_client import resolve_anthropic_auth
+
+    if not resolve_anthropic_auth():
+        logger.warning(
+            "No Anthropic credentials (ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN / "
+            "ant profile) — skipping vision refinement",
+        )
         return fallback
 
     path = _Path(image_path)
@@ -751,7 +755,7 @@ async def refine_image_metadata(
                 vision_model,
             )
             vision_model = _DEFAULT_VISION_MODEL
-        client = create_async_anthropic_client(api_key)
+        client = create_async_anthropic_client()
         response = await client.messages.create(
             model=vision_model,
             max_tokens=256,

--- a/tests/test_anthropic_auth_resolution.py
+++ b/tests/test_anthropic_auth_resolution.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Tests for Anthropic auth resolution honouring `ant` OAuth profiles.
+
+Spec: docs/specs/anthropic-auth-token-resolution.md
+
+The installed ``anthropic`` SDK reads only the ``ANTHROPIC_API_KEY`` /
+``ANTHROPIC_AUTH_TOKEN`` env vars — it does not auto-resolve the on-disk ``ant``
+profile. ``resolve_anthropic_auth`` bridges that gap: env key, then env auth
+token, then the active ``ant`` profile (surfaced as ``ANTHROPIC_AUTH_TOKEN``).
+
+NB: token literals are kept short on purpose — the pre-commit secret scanner
+flags key-assignment literals of eight or more characters.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+from scripts.llm_client import (
+    create_async_anthropic_client,
+    create_llm_client,
+    resolve_anthropic_auth,
+)
+
+
+def _clear_anthropic_env(monkeypatch) -> None:
+    """Remove both Anthropic credential env vars for a deterministic baseline."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_AUTH_TOKEN", raising=False)
+
+
+def _fake_anthropic_module(**attrs) -> types.ModuleType:
+    """Return a stand-in ``anthropic`` module exposing the given class attrs."""
+    module = types.ModuleType("anthropic")
+    for name, value in attrs.items():
+        setattr(module, name, value)
+    return module
+
+
+class TestResolveAnthropicAuth:
+    """Unit tests for the credential-priority resolver."""
+
+    def test_api_key_takes_priority_without_shelling_out(self, monkeypatch) -> None:
+        _clear_anthropic_env(monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "envkey")
+
+        with patch("scripts.llm_client.subprocess.run") as run:
+            assert resolve_anthropic_auth() == "api_key"
+        run.assert_not_called()
+
+    def test_auth_token_env_without_shelling_out(self, monkeypatch) -> None:
+        _clear_anthropic_env(monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok")
+
+        with patch("scripts.llm_client.subprocess.run") as run:
+            assert resolve_anthropic_auth() == "auth_token"
+        run.assert_not_called()
+
+    def test_profile_fallback_populates_auth_token_env(self, monkeypatch) -> None:
+        _clear_anthropic_env(monkeypatch)
+        completed = MagicMock(returncode=0, stdout="oat-tok\n")
+
+        with patch("scripts.llm_client.subprocess.run", return_value=completed) as run:
+            assert resolve_anthropic_auth() == "auth_token"
+            run.assert_called_once()
+
+        assert os.environ.get("ANTHROPIC_AUTH_TOKEN") == "oat-tok"
+
+    def test_returns_none_when_ant_not_installed(self, monkeypatch) -> None:
+        _clear_anthropic_env(monkeypatch)
+
+        with patch(
+            "scripts.llm_client.subprocess.run",
+            side_effect=FileNotFoundError("no ant"),
+        ):
+            assert resolve_anthropic_auth() is None
+
+        assert "ANTHROPIC_AUTH_TOKEN" not in os.environ
+
+    def test_returns_none_when_ant_fails_or_empty(self, monkeypatch) -> None:
+        _clear_anthropic_env(monkeypatch)
+        completed = MagicMock(returncode=1, stdout="")
+
+        with patch("scripts.llm_client.subprocess.run", return_value=completed):
+            assert resolve_anthropic_auth() is None
+
+        assert "ANTHROPIC_AUTH_TOKEN" not in os.environ
+
+
+class TestFactoriesHonourAuthToken:
+    """The client factories must build clients from auth-token credentials."""
+
+    def test_create_llm_client_selects_anthropic_via_auth_token(
+        self,
+        monkeypatch,
+    ) -> None:
+        _clear_anthropic_env(monkeypatch)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok")
+
+        anthropic_cls = MagicMock(return_value=MagicMock())
+        fake = _fake_anthropic_module(Anthropic=anthropic_cls)
+
+        with patch.dict(sys.modules, {"anthropic": fake}):
+            client = create_llm_client()
+
+        assert client.provider == "anthropic"
+        anthropic_cls.assert_called_once_with()  # no explicit api_key
+
+    def test_create_async_client_uses_auth_token(self, monkeypatch) -> None:
+        _clear_anthropic_env(monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "tok")
+
+        instance = MagicMock()
+        async_cls = MagicMock(return_value=instance)
+        fake = _fake_anthropic_module(AsyncAnthropic=async_cls)
+
+        with patch.dict(sys.modules, {"anthropic": fake}):
+            client = create_async_anthropic_client()
+
+        assert client is instance
+        async_cls.assert_called_once_with()  # no api_key kwarg

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -42,15 +42,28 @@ def mock_openai_client():
 
 @pytest.fixture
 def clean_env():
-    """Clean environment for testing."""
+    """Clean environment for the OpenAI-isolation tests.
+
+    Also clears the Anthropic credential env vars and disables the ``ant``
+    profile fallback: ``create_llm_client`` now resolves Anthropic auth (incl.
+    an on-disk ``ant`` profile) before OpenAI, so without this these OpenAI-path
+    tests would non-deterministically pick the anthropic provider on any machine
+    that happens to be logged in via ``ant``.
+    """
     # Store original env vars
     original_vars = {}
-    for key in ["OPENAI_API_KEY", "OPENAI_MODEL"]:
+    for key in [
+        "OPENAI_API_KEY",
+        "OPENAI_MODEL",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+    ]:
         original_vars[key] = os.environ.get(key)
         if key in os.environ:
             del os.environ[key]
 
-    yield
+    with patch("scripts.llm_client._load_ant_profile_token", return_value=None):
+        yield
 
     # Restore original environment
     for key, value in original_vars.items():

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -134,6 +134,27 @@ class TestClientCreation:
             client = create_llm_client()
             assert client.model == "gpt-3.5-turbo"
 
+    def test_anthropic_default_model_is_sonnet_4_6(self):
+        """Default Anthropic model is claude-sonnet-4-6 when ANTHROPIC_MODEL is unset."""
+        import types
+
+        mock_anthropic_instance = MagicMock()
+        fake_module = types.ModuleType("anthropic")
+        fake_module.Anthropic = MagicMock(  # type: ignore[attr-defined]
+            return_value=mock_anthropic_instance,
+        )
+
+        env = {"ANTHROPIC_API_KEY": "sk-ant-test"}
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch.dict(sys.modules, {"anthropic": fake_module}),
+        ):
+            client = create_llm_client()
+
+        assert isinstance(client, LLMClient)
+        assert client.provider == "anthropic"
+        assert client.model == "claude-sonnet-4-6"
+
 
 # ═══════════════════════════════════════════════════════════════════════════
 # TEST ERROR HANDLING


### PR DESCRIPTION
## Problem
After migrating local auth to `ant auth login` (a platform.claude.com OAuth profile), there is no `ANTHROPIC_API_KEY` in the environment. The installed `anthropic` SDK (0.75.0) only reads the `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` env vars — it does **not** auto-resolve the on-disk `ant` profile. Our factories hard-gated on and passed `ANTHROPIC_API_KEY`, so every direct-`anthropic`-SDK path (topic scout, editorial board, deep-research LLM, Stage 4 vision) raised `No API key found` / `KeyError` even with valid OAuth credentials on disk.

## Change
Add `resolve_anthropic_auth()` (+ `_load_ant_profile_token()`) to `scripts/llm_client.py`. Resolution order:
1. `ANTHROPIC_API_KEY` (env) — unchanged behavior
2. `ANTHROPIC_AUTH_TOKEN` (env)
3. active `ant` profile — shells `ant auth print-credentials --access-token` (which also refreshes the short-lived token) and exports it as `ANTHROPIC_AUTH_TOKEN`

Wired into `create_llm_client`, `_create_anthropic_client`, `create_async_anthropic_client`, and the Stage 4 vision gate in `src/agent_sdk/_shared.py`.

## Verification
- New `tests/test_anthropic_auth_resolution.py` (7 cases); existing `ANTHROPIC_API_KEY`-path tests unchanged.
- Proven live: a real pipeline run authenticates Anthropic end-to-end via the `ant` profile alone.

## Notes
- Stage 3 (`claude_agent_sdk`) honors profile resolution itself — out of scope.
- Spec: `docs/specs/anthropic-auth-token-resolution.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)