### PR TITLE
fix: strip code-fence-wrapped writer output in Stage 3

### DIFF
--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -304,6 +304,37 @@ def _strip_code_fence(text: str) -> str:
     return inner + "\n" if inner else text
 
 
+# Real article frontmatter opens with --- immediately followed by a known
+# frontmatter key. Used to discard conversational preamble (and any stray
+# markdown rule) the writer may emit before the article.
+_FRONTMATTER_START = re.compile(
+    r"(?m)^---[ \t]*\r?\n"
+    r"(?=(?:layout|title|date|author|categories|description|image)\s*:)"
+)
+
+
+def _extract_article(text: str) -> str:
+    """Recover the article from noisy writer output.
+
+    Handles three observed writer quirks, in order:
+    1. The whole article wrapped in a ```yaml fence (``_strip_code_fence``).
+    2. Conversational preamble (and/or a stray ``---`` markdown rule) before the
+       real frontmatter — everything before the first genuine ``---\\n<key>:``
+       block is discarded.
+    3. A dangling trailing code fence left after the body once a between-preamble
+       fence's opener is removed.
+
+    Prose with no frontmatter at all is returned unchanged so the downstream
+    well-formed check still rejects it.
+    """
+    text = _strip_code_fence(text)
+    match = _FRONTMATTER_START.search(text)
+    if match and match.start() > 0:
+        text = text[match.start() :]
+    text = re.sub(r"\r?\n[ \t]*```[a-zA-Z]*[ \t]*$", "", text.rstrip())
+    return text.rstrip() + "\n"
+
+
 async def _collect_text(
     prompt: str,
     system_prompt: str,
@@ -481,7 +512,7 @@ async def run_stage3(
     # Fence-strip BEFORE duplicate-strip: a wrapping ```yaml fence puts a
     # "\n---\nlayout:" sequence right after the opener, which the duplicate
     # detector would otherwise mistake for a second article and truncate.
-    pre_audit_article = _strip_duplicate_article(_strip_code_fence(raw_writer_output))
+    pre_audit_article = _strip_duplicate_article(_extract_article(raw_writer_output))
 
     # Require opening ---, a closing --- on its own line, and a non-empty body.
     # re.DOTALL so the frontmatter block can contain newlines.

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -284,6 +284,26 @@ def _strip_duplicate_article(text: str) -> str:
     return text
 
 
+def _strip_code_fence(text: str) -> str:
+    """Strip a markdown code fence the writer may wrap the whole article in.
+
+    LLMs sometimes emit the entire article (frontmatter + body) inside a
+    ```` ```yaml ```` / ```` ``` ```` fence. The well-formed check requires the
+    text to start with the frontmatter ``---``, so peel a single leading fence
+    line and its matching trailing fence. Inner fences (e.g. code blocks in the
+    body) are left untouched — only the outermost wrapper is removed, and only
+    when the text both opens with a fence and ends with one.
+    """
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return text
+    lines = stripped.split("\n")
+    if len(lines) < 2 or not lines[-1].strip().startswith("```"):
+        return text  # opening fence with no matching close — leave as-is
+    inner = "\n".join(lines[1:-1]).strip()
+    return inner + "\n" if inner else text
+
+
 async def _collect_text(
     prompt: str,
     system_prompt: str,
@@ -458,7 +478,10 @@ async def run_stage3(
     # Append writer-fetched sources to the brief so the stat audit does not
     # strip statistics the writer legitimately cited from them (#389).
     research_brief = research_brief + search_session.brief_supplement()
-    pre_audit_article = _strip_duplicate_article(raw_writer_output)
+    # Fence-strip BEFORE duplicate-strip: a wrapping ```yaml fence puts a
+    # "\n---\nlayout:" sequence right after the opener, which the duplicate
+    # detector would otherwise mistake for a second article and truncate.
+    pre_audit_article = _strip_duplicate_article(_strip_code_fence(raw_writer_output))
 
     # Require opening ---, a closing --- on its own line, and a non-empty body.
     # re.DOTALL so the frontmatter block can contain newlines.

--- a/tests/test_malformed_article_guard.py
+++ b/tests/test_malformed_article_guard.py
@@ -98,6 +98,77 @@ class TestMalformedArticleError:
             result = asyncio.run(run_stage3("AI Testing"))
             assert result.article.startswith("---")
 
+    def test_run_stage3_strips_code_fence_wrapped_article(self) -> None:
+        """A valid article wrapped in a ```yaml fence must be unwrapped, not
+        rejected. Prove-It for the writer emitting fenced output."""
+        from src.agent_sdk.stage3_runner import run_stage3
+
+        valid = (
+            '---\nlayout: post\ntitle: "Test"\ndate: 2026-01-01\n'
+            'author: "Ouray Viney"\ncategories: ["Quality Engineering"]\n'
+            'description: "A test."\nimage: /assets/images/test.png\n'
+            'image_alt: "alt"\nimage_caption: "cap"\n---\n\n'
+            + " ".join(["word"] * 900)
+            + '\n\n## References\n\n1. Gartner, ["Report"](https://example.com), 2024\n'
+            '2. Forrester, ["Report"](https://example.com), 2024\n'
+            '3. IEEE, ["Report"](https://example.com), 2024\n'
+        )
+        fenced = "```yaml\n" + valid + "\n```"
+
+        with (
+            patch(
+                "src.agent_sdk.stage3_runner.build_research_brief", return_value="brief"
+            ),
+            patch(
+                "src.agent_sdk.stage3_runner._collect_text",
+                new=AsyncMock(
+                    side_effect=[
+                        (fenced, 0.01),
+                        ('{"title":"Chart","data":[{"metric":"A","value":1}]}', 0.005),
+                    ]
+                ),
+            ),
+            patch(
+                "src.agent_sdk.stage3_runner.render_chart",
+                return_value=Path("output/charts/test.png"),
+            ),
+        ):
+            result = asyncio.run(run_stage3("AI Testing"))
+            assert result.article.startswith("---")
+            assert "```" not in result.article.split("\n", 1)[0]
+
+
+class TestStripCodeFence:
+    """Unit tests for the code-fence stripper."""
+
+    def test_strips_yaml_fence_wrapper(self) -> None:
+        from src.agent_sdk.stage3_runner import _strip_code_fence
+
+        out = _strip_code_fence("```yaml\n---\ntitle: x\n---\nbody\n```")
+        assert out.startswith("---")
+        assert out.rstrip().endswith("body")
+
+    def test_leaves_unfenced_text_untouched(self) -> None:
+        from src.agent_sdk.stage3_runner import _strip_code_fence
+
+        text = "---\ntitle: x\n---\nbody\n"
+        assert _strip_code_fence(text) == text
+
+    def test_preserves_inner_code_blocks(self) -> None:
+        from src.agent_sdk.stage3_runner import _strip_code_fence
+
+        out = _strip_code_fence(
+            "```\n---\nt: x\n---\nsee `code`:\n```py\nx=1\n```\n```"
+        )
+        assert out.startswith("---")
+        assert "```py" in out  # inner fence preserved
+
+    def test_opening_fence_without_close_is_untouched(self) -> None:
+        from src.agent_sdk.stage3_runner import _strip_code_fence
+
+        text = "```yaml\n---\ntitle: x\n---\nbody without trailing fence"
+        assert _strip_code_fence(text) == text
+
 
 # ── Integration: generate_content routes to revision ─────────────────────────
 

--- a/tests/test_malformed_article_guard.py
+++ b/tests/test_malformed_article_guard.py
@@ -170,6 +170,74 @@ class TestStripCodeFence:
         assert _strip_code_fence(text) == text
 
 
+class TestExtractArticle:
+    """Unit tests for the noisy-writer-output extractor."""
+
+    def test_strips_conversational_preamble_and_fence(self) -> None:
+        from src.agent_sdk.stage3_runner import _extract_article
+
+        raw = (
+            "Topic is fresh — no duplicate. I'll write directly.\n\n"
+            "---\n\n"  # stray markdown rule in the preamble
+            "```yaml\n"
+            '---\nlayout: post\ntitle: "X"\n---\n\nThe body.\n\n## References\n\n1. Y\n'
+            "```"
+        )
+        out = _extract_article(raw)
+        assert out.startswith("---\nlayout: post")
+        assert "The body." in out
+        assert not out.rstrip().endswith("```")
+
+    def test_leaves_clean_article_unchanged(self) -> None:
+        from src.agent_sdk.stage3_runner import _extract_article
+
+        clean = "---\ntitle: X\n---\n\nBody here.\n"
+        assert _extract_article(clean).strip() == clean.strip()
+
+    def test_prose_without_frontmatter_is_unchanged(self) -> None:
+        from src.agent_sdk.stage3_runner import _extract_article
+
+        prose = "I cannot write that article."
+        assert _extract_article(prose).strip() == prose
+
+    def test_run_stage3_recovers_preamble_wrapped_article(self) -> None:
+        """run_stage3 must recover an article buried under preamble + a fence."""
+        from src.agent_sdk.stage3_runner import run_stage3
+
+        valid = (
+            '---\nlayout: post\ntitle: "Test"\ndate: 2026-01-01\n'
+            'author: "Ouray Viney"\ncategories: ["Quality Engineering"]\n'
+            'description: "A test."\nimage: /assets/images/test.png\n'
+            'image_alt: "alt"\nimage_caption: "cap"\n---\n\n'
+            + " ".join(["word"] * 900)
+            + '\n\n## References\n\n1. Gartner, ["R"](https://example.com), 2024\n'
+            '2. Forrester, ["R"](https://example.com), 2024\n'
+            '3. IEEE, ["R"](https://example.com), 2024\n'
+        )
+        noisy = "Topic is fresh. I'll write now.\n\n---\n\n```yaml\n" + valid + "\n```"
+
+        with (
+            patch(
+                "src.agent_sdk.stage3_runner.build_research_brief", return_value="brief"
+            ),
+            patch(
+                "src.agent_sdk.stage3_runner._collect_text",
+                new=AsyncMock(
+                    side_effect=[
+                        (noisy, 0.01),
+                        ('{"title":"Chart","data":[{"metric":"A","value":1}]}', 0.005),
+                    ]
+                ),
+            ),
+            patch(
+                "src.agent_sdk.stage3_runner.render_chart",
+                return_value=Path("output/charts/test.png"),
+            ),
+        ):
+            result = asyncio.run(run_stage3("AI Testing"))
+            assert result.article.startswith("---")
+
+
 # ── Integration: generate_content routes to revision ─────────────────────────
 
 


### PR DESCRIPTION
## Why
The Stage 3 writer sometimes emits the whole article wrapped in a ```yaml code fence. The well-formed check requires the text to start with `---`, so it raised `MalformedArticleError` on otherwise valid articles — blocking the pipeline from producing an article. Found while running the free-stack pipeline end-to-end.

## Change
- `_strip_code_fence()` peels a single outermost fence wrapper. Inner code blocks preserved; an opening fence with no matching close left untouched.
- Run it **before** `_strip_duplicate_article` — a wrapping fence puts `\n---\nlayout:` right after the opener, which the duplicate detector would otherwise mistake for a second article and truncate.

## Tests
Prove-It (fence-wrapped valid article no longer raises) + 4 unit tests for the stripper. **12 passed, ruff clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)