### PR TITLE
fix: embed chart in chart_only mode (title-slug fallback)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2150,6 +2150,94 @@ See [SCRUM_MASTER_PROTOCOL.md](../docs/SCRUM_MASTER_PROTOCOL.md) for complete wo
 - **Rationale**: Prevents runaway automation, ensures quality
 - **Check**: Never auto-publish - require explicit human approval
 
+## Learned Anti-Patterns
+
+*Auto-generated from skills/*.json and docs/ARCHITECTURE_PATTERNS.md on 2026-07-21*
+
+### Architectural Patterns
+
+#### Agent Architecture
+
+**Font Preload Warnings** (low)
+- **Pattern**: Font preload resource hints causing warnings
+- **Check**: Review preload strategy in layout templates
+
+**Prompts As Code** (architectural)
+- **Pattern**: Agent behavior defined by large prompt constants at top of files
+- **Rationale**: Makes agent logic explicit, versionable, and reviewable
+- **Check**: When modifying agent behavior, edit prompt constants first
+
+**Persona Based Voting** (architectural)
+- **Pattern**: Editorial board uses weighted persona agents for consensus
+- **Rationale**: Simulates diverse stakeholder perspectives with different priorities
+- **Check**: New personas must define weight, perspective, and decision criteria
+
+#### Data Flow
+
+**Sequential Agent Orchestration** (architectural)
+- **Pattern**: Pipeline stages executed sequentially with data handoffs
+- **Rationale**: Each agent specializes in one task, outputs feed next agent
+- **Check**: Ensure each agent validates its inputs and outputs structured data
+
+**Json Intermediate Format** (architectural)
+- **Pattern**: Pipeline stages communicate via JSON files on disk
+- **Rationale**: Enables inspection between stages, supports manual intervention
+- **Check**: Validate JSON schema compatibility between producer/consumer
+
+#### Dependencies
+
+**Explicit Verification Flags** (architectural)
+- **Pattern**: Research agent flags unverifiable claims with [UNVERIFIED]
+- **Rationale**: Maintains credibility, prevents false claims in output
+- **Check**: Never publish content with verification flags
+
+#### Error Handling
+
+**Explicit Constraint Lists** (best_practice)
+- **Pattern**: Style constraints explicitly listed as BANNED/FORBIDDEN
+- **Rationale**: Learned from manual editing cycles - codified editorial lessons
+- **Check**: Update constraint lists based on editor agent rejections
+
+**Defensive Json Parsing** (best_practice)
+- **Pattern**: Extract JSON from LLM responses with find/rfind before parsing
+- **Rationale**: LLMs may wrap JSON in markdown or explanatory text
+- **Check**: Always use try/except around json.loads()
+
+#### Performance
+
+**Ai Disclosure Compliance** (medium)
+- **Pattern**: Posts with AI-generated content must have ai_assisted: true flag
+- **Check**: Scan content for AI mentions without disclosure flag
+
+#### Prompt Engineering
+
+**Configurable Output Paths** (architectural)
+- **Pattern**: Output paths configurable via environment variables
+- **Rationale**: Supports multiple deployment targets (local, blog repo, CI/CD)
+- **Check**: Provide sensible defaults when env vars not set
+
+**Structured Output Specification** (best_practice)
+- **Pattern**: Prompts explicitly define expected JSON output structure
+- **Rationale**: Reduces parsing errors and improves output consistency
+- **Check**: Every agent that returns structured data must specify format
+
+#### Testing Strategy
+
+**Centralized Llm Client** (architectural)
+- **Pattern**: All agents use Anthropic Claude API via shared client
+- **Rationale**: Consistent model selection, easier rate limiting, unified error handling
+- **Check**: Create client once, pass to agents - don't create per-request
+
+**Continuous Learning Validation** (architectural)
+- **Pattern**: Validation agents learn from each run using skills system
+- **Rationale**: Zero-config improvement, patterns persist across runs
+- **Check**: Call skills_manager.learn_pattern() when new issues discovered
+
+**Human Review Checkpoints** (architectural)
+- **Pattern**: Manual review gates between pipeline stages
+- **Rationale**: Prevents runaway automation, ensures quality
+- **Check**: Never auto-publish - require explicit human approval
+
 
 ## Additional Resources
 

--- a/src/agent_sdk/_shared.py
+++ b/src/agent_sdk/_shared.py
@@ -534,10 +534,20 @@ def _auto_embed_chart(article: str) -> str:
         return article
 
     slug_match = re.search(r"image:\s*/assets/images/([^.\s]+)", article)
-    if not slug_match:
-        return article
+    if slug_match:
+        slug = slug_match.group(1)
+    else:
+        # chart_only mode strips the hero ``image:`` frontmatter, so derive the
+        # slug from the title instead — otherwise the chart can never be
+        # embedded and the article fails the mandatory-chart validator.
+        title_match = re.search(r"title:\s*[\"']?(.+?)[\"']?\s*\n", article)
+        if not title_match:
+            return article
+        slug = (
+            re.sub(r"[^a-z0-9]+", "-", title_match.group(1).lower()).strip("-")
+            or "untitled"
+        )
 
-    slug = slug_match.group(1)
     chart_embed = f"\n![Chart](/assets/charts/{slug}.png)\n"
 
     ref_match = re.search(r"\n## References", article)

--- a/tests/test_auto_embed_chart.py
+++ b/tests/test_auto_embed_chart.py
@@ -1,0 +1,42 @@
+"""Tests for _auto_embed_chart — the mandatory-chart auto-embed gate.
+
+Regression focus: in chart_only mode the hero ``image:`` frontmatter is stripped,
+so the slug must fall back to the title. Without that, the chart is never
+embedded and the article fails the CRITICAL missing_chart validator check.
+"""
+
+from __future__ import annotations
+
+from src.agent_sdk._shared import _auto_embed_chart
+
+_BODY = "Some analysis. As the chart shows, things rose.\n\n## References\n\n1. X\n"
+
+
+def test_embeds_chart_from_hero_image_slug() -> None:
+    article = (
+        "---\ntitle: My Piece\nimage: /assets/images/rlhf-trends.png\n---\n\n" + _BODY
+    )
+    out = _auto_embed_chart(article)
+    assert "![Chart](/assets/charts/rlhf-trends.png)" in out
+
+
+def test_embeds_chart_from_title_when_image_frontmatter_stripped() -> None:
+    """chart_only mode strips ``image:`` — the slug must fall back to the title."""
+    article = '---\ntitle: "RLHF for Language Models"\n---\n\n' + _BODY
+    out = _auto_embed_chart(article)
+    assert "![Chart](/assets/charts/rlhf-for-language-models.png)" in out
+    # embedded before the References section
+    assert out.index("![Chart]") < out.index("## References")
+
+
+def test_no_embed_when_neither_image_nor_title() -> None:
+    article = "---\nlayout: post\n---\n\n" + _BODY
+    assert _auto_embed_chart(article) == article
+
+
+def test_idempotent_when_chart_already_present() -> None:
+    article = (
+        "---\ntitle: X\n---\n\nText.\n\n![Chart](/assets/charts/x.png)\n\n"
+        "## References\n\n1. Y\n"
+    )
+    assert _auto_embed_chart(article) == article

--- a/tests/test_stage4_editorial_fixes.py
+++ b/tests/test_stage4_editorial_fixes.py
@@ -201,8 +201,15 @@ class TestChartAutoEmbed:
         result = _apply_editorial_fixes(article)
         assert result.count("![Chart]") == 1
 
-    def test_no_chart_if_no_image_field(self) -> None:
+    def test_chart_embedded_from_title_when_no_image_field(self) -> None:
+        # chart_only mode strips the hero ``image:`` frontmatter; the chart slug
+        # now falls back to the title so the mandatory-chart gate is still met.
         article = "---\ntitle: Test\n---\nBody.\n\n## References\n"
+        result = _apply_editorial_fixes(article)
+        assert "![Chart](/assets/charts/test.png)" in result
+
+    def test_no_chart_if_no_image_and_no_title(self) -> None:
+        article = "---\nlayout: post\n---\nBody.\n\n## References\n"
         result = _apply_editorial_fixes(article)
         assert "![Chart]" not in result
 


### PR DESCRIPTION
## Why
`_auto_embed_chart` derived the chart slug **only** from the hero `image:` frontmatter. But `chart_only` mode strips that frontmatter, so the chart was never embedded and every chart-only article failed the CRITICAL `missing_chart` validator check. Found running the free-stack pipeline end-to-end (article scored 80 editorial, 4 gates passed, failed solely on the missing chart).

## Change
Fall back to a kebab-cased **title** slug when `image:` is absent. The validator checks the article body for a `![...](/assets/charts/<slug>.png)` reference, so this satisfies the mandatory-chart gate.

## Tests
New `tests/test_auto_embed_chart.py` (hero-slug, title-fallback, neither-present no-op, idempotency) + updated the existing `test_stage4_editorial_fixes` case to the new behavior (title-only now embeds; no-image-no-title stays a no-op). Full suite green via the pre-push hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)