### PR TITLE
B-014: fix the chart correctness bug + validated palette

### DIFF
--- a/src/agent_sdk/_shared.py
+++ b/src/agent_sdk/_shared.py
@@ -80,11 +80,23 @@ GRAPHICS_AGENT_PROMPT = """
 You are a Data Visualization Specialist.
 Your goal is to take complex data and describe how it should be visualized.
 
-Create clear, accurate charts that follow Economist style guidelines:
-- Clean, minimalist design
-- Proper zone boundaries (red bar, title, chart, x-axis, source)
-- Inline labels instead of legends
-- High-quality export (PNG, 300 DPI)
+CRITICAL — one axis, one measure (a chart is a horizontal bar chart on ONE
+linear axis):
+- Every bar MUST be the same kind of measure on the same scale. NEVER mix a
+  percentage (e.g. 84) with a raw count (e.g. 150000) in the same chart — the
+  large value swallows the axis and the small bars vanish. If the article has
+  both, pick ONE coherent measure and drop the rest.
+- Choose the single measure that best advances the article's thesis (the point
+  the prose already makes), not a grab-bag of every number in the piece.
+- Keep the largest and smallest values within ~1 order of magnitude of each
+  other. If they aren't, they don't belong on the same chart.
+- Set each item's `unit` correctly: a count is not a percentage. Do not label a
+  raw number "%".
+
+Economist style:
+- Clean, minimalist design; inline labels instead of legends.
+- Proper zone boundaries (red bar, title, chart, x-axis, source).
+- High-quality export (PNG, 300 DPI).
 """
 
 

--- a/src/agent_sdk/chart_renderer.py
+++ b/src/agent_sdk/chart_renderer.py
@@ -71,8 +71,15 @@ def _resolve_color(name: str | None) -> str:
     return _NAMED_COLORS.get(name.lower(), _NAVY)
 
 
+# Max allowed ratio between the largest and smallest non-zero data value. ~3
+# orders of magnitude — generous enough to never reject a realistic chart, tight
+# enough to catch a raw count mixed in with percentages (B-014).
+_MAX_VALUE_SPAN = 1000
+
+
 def _validate_spec(spec: Any) -> None:
-    """Reject any spec that would crash matplotlib partway through render."""
+    """Reject any spec that would crash matplotlib partway through render, or
+    that would render a misleading chart (values spanning too many magnitudes)."""
     if not isinstance(spec, dict):
         raise ChartRenderError(f"spec must be a dict, got {type(spec).__name__}")
     title = spec.get("title")
@@ -91,6 +98,19 @@ def _validate_spec(spec: Any) -> None:
             raise ChartRenderError(
                 f"spec.data[{i}].value must be numeric, got {type(value).__name__}"
             )
+
+    # Reject values spanning too many orders of magnitude for one linear axis:
+    # the small bars collapse to invisible slivers (B-014 — a 150,000 count next
+    # to percentages 0–84 hid the headline finding). Fix the spec (one coherent
+    # measure), don't render a misleading chart. Zero values are excluded from
+    # the ratio; the guard only fires with ≥2 non-zero magnitudes.
+    magnitudes = [abs(item["value"]) for item in data if item["value"]]
+    if len(magnitudes) >= 2 and max(magnitudes) / min(magnitudes) > _MAX_VALUE_SPAN:
+        raise ChartRenderError(
+            f"spec.data values span too many orders of magnitude "
+            f"({max(magnitudes):g} vs {min(magnitudes):g}) for one linear axis — "
+            f"pick one coherent measure (see dataviz: one axis, one measure)"
+        )
 
 
 def render_chart(spec: dict, output_path: Path) -> Path:

--- a/src/agent_sdk/chart_renderer.py
+++ b/src/agent_sdk/chart_renderer.py
@@ -41,8 +41,12 @@ from typing import Any
 # every module import. Push that cost to render-time so tests that don't
 # render don't pay it.
 
-# Economist palette (matches scripts/generate_chart.py).
-_NAVY = "#17648d"
+# Economist palette. Navy + burgundy are the two categorical series colors; the
+# pair is validated colorblind-safe via the dataviz skill's validate_palette.js
+# (light, surface #f1f0e9: all checks PASS, worst-adjacent CVD ΔE 13.4). The
+# previous navy #17648d failed the chroma floor (0.097 < 0.1 — read gray), so it
+# was nudged to #0f5f92 (B-014).
+_NAVY = "#0f5f92"
 _RED = "#e3120b"
 _BURGUNDY = "#843844"
 _BG_COLOR = "#f1f0e9"

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -635,6 +635,10 @@ async def run_stage3(
         "JSON object with keys: title, subtitle, data (list of "
         "{metric, value, unit, color}), colors (navy/burgundy hex map), "
         "dimensions (width/height). No commentary, no markdown fences.\n\n"
+        "One axis, one measure: every data item must be the same kind of measure "
+        "on the same scale (all percentages, OR all counts — never mixed), within "
+        "~1 order of magnitude, with correct units. Pick the single measure that "
+        "best carries the article's argument.\n\n"
         f"Article excerpt:\n{article[:2500]}"
     )
     graphics_text, graphics_cost = await _collect_text(

--- a/tests/test_chart_renderer.py
+++ b/tests/test_chart_renderer.py
@@ -26,6 +26,39 @@ def _valid_spec() -> dict:
     }
 
 
+def _mixed_scale_spec() -> dict:
+    """The exact flaky-tests failure (B-014): five percentages plus a raw
+    150,000 count on one linear axis — the count (mislabelled '%') swallowed the
+    scale and the headline 84% collapsed to an invisible sliver."""
+    return {
+        "title": "The Invisible Payroll Tax",
+        "subtitle": "Cost of flaky tests, selected industrial studies",
+        "data": [
+            {"metric": "Google CI signal skewed", "value": 84, "unit": "%"},
+            {"metric": "Jira frontend build failures", "value": 21, "unit": "%"},
+            {"metric": "Total productive dev time", "value": 2.5, "unit": "%"},
+            {"metric": "Dev time repairing", "value": 1.3, "unit": "%"},
+            {"metric": "Dev time investigating", "value": 1.1, "unit": "%"},
+            {"metric": "Atlassian dev-hours/yr", "value": 150000, "unit": "%"},
+        ],
+    }
+
+
+def test_values_spanning_many_orders_of_magnitude_are_rejected() -> None:
+    """B-014 Prove-It: a spec whose values span too many orders of magnitude for
+    one linear axis must be rejected before render — not silently produce a chart
+    where the small values are invisible."""
+    with pytest.raises(ChartRenderError, match="orders of magnitude|one .*axis|coherent"):
+        render_chart(_mixed_scale_spec(), Path("/tmp/should-not-be-written.png"))
+
+
+def test_normal_scale_spec_still_renders(tmp_path: Path) -> None:
+    """Guard rail: a spec whose values are within a sane range is unaffected."""
+    out = tmp_path / "ok.png"
+    render_chart(_valid_spec(), out)  # values 0..1 — well within span
+    assert out.exists()
+
+
 def _png_dimensions(path: Path) -> tuple[int, int]:
     """Read width, height from a PNG header without depending on Pillow.
 

--- a/tests/test_chart_renderer.py
+++ b/tests/test_chart_renderer.py
@@ -48,7 +48,9 @@ def test_values_spanning_many_orders_of_magnitude_are_rejected() -> None:
     """B-014 Prove-It: a spec whose values span too many orders of magnitude for
     one linear axis must be rejected before render — not silently produce a chart
     where the small values are invisible."""
-    with pytest.raises(ChartRenderError, match="orders of magnitude|one .*axis|coherent"):
+    with pytest.raises(
+        ChartRenderError, match="orders of magnitude|one .*axis|coherent"
+    ):
         render_chart(_mixed_scale_spec(), Path("/tmp/should-not-be-written.png"))
 
 


### PR DESCRIPTION
Fixes the graphics-stage bug the dataviz prototype exposed: the flaky-tests chart plotted five percentages (0–84) next to a raw 150,000 count on one linear axis, so the count swallowed the scale, the headline **84% collapsed to an invisible sliver**, and the count was mislabeled "150000 %". Spec: `docs/specs/B-014-chart-redesign.md`.

Three slices (TDD):

1. **Correctness guard** (`chart_renderer._validate_spec`) — reject a spec whose largest/smallest non-zero value ratio exceeds 1000× *before* render, so a misleading chart is never produced. **Prove-It test:** the exact broken spec → `ChartRenderError` (RED before, GREEN after); a normal-scale spec still renders.
2. **Root cause** — the graphics-agent prompts (`GRAPHICS_AGENT_PROMPT` + the per-call prompt) now require one coherent measure that carries the article's thesis, same scale (~1 order of magnitude), correct units.
3. **Validated palette** — the navy failed the dataviz chroma-floor check (read gray); nudged to `#0f5f92` so the navy+burgundy pair passes `validate_palette.js` (computed, not eyeballed). Rounded bar-ends deferred (marginal value, FancyBbox rewrite).

**Verified:** `make ci-local` green — 2219 passed, 79.51% coverage, bandit + destructive-guard pass. No token cost (local compute). Scope held to PNG/matplotlib — **not** an SVG/interactive switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)