### PR TITLE
B-012: opt-in --brief to feed a deep-research brief to the writer

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -26,7 +26,16 @@ _(none)_
 
 ## Todo
 
-### B-012 · Opt-in `deep-brief` research mode (spec'd — prototype validated)
+### B-012 · Opt-in `deep-brief` research mode (BUILT — live acceptance run pending)
+
+> **✅ CODE DONE.** `--brief <file>` wired end-to-end (`pipeline.load_brief_file`
+> strips refuted claims → `run_pipeline`/`run_stage3` `brief_override` skips the
+> research step); documented opt-in/heavy in the runbook; `claude_web` stays
+> default. Tested (`tests/test_deep_brief.py`) + `make ci-local` green. The one
+> remaining acceptance criterion — a real deep-research → article run — is a
+> token-heavy owner-run step (deep-research ~2M tokens), left opt-in by design.
+
+
 
 Wire the `deep-research` harness as an **opt-in** research path for flagship
 posts; `claude_web` stays the everyday default. **Prototype (2026-07-22) settled

--- a/docs/keyless-pipeline-runbook.md
+++ b/docs/keyless-pipeline-runbook.md
@@ -46,6 +46,22 @@ Exit `0` = publication validator passed (publish-ready); `1` = validator issues;
 `2` = research failed (retry, or you are on `deterministic` — switch to
 `claude_web`).
 
+### Opt-in: `--brief` for flagship posts (B-012)
+
+For a cornerstone post where sourcing quality matters most, run the
+`deep-research` harness first to produce a verified, cited brief
+(`docs/research/<slug>.md`), then hand it to the writer:
+
+```bash
+IS_SANDBOX=1 python -m src.agent_sdk.pipeline "<topic>" \
+    --image-mode chart_only --brief docs/research/<slug>.md
+```
+
+`--brief` skips the research step and uses that file (refuted claims are
+stripped automatically). **This is opt-in and heavy** — one deep-research run is
+~2M tokens and can hit your session limit — so `claude_web` stays the everyday
+default; reserve `--brief` for the pieces that warrant it.
+
 ## 2. Publish (keyless — free GitHub token, opens a PR you review)
 
 ```bash

--- a/src/agent_sdk/pipeline.py
+++ b/src/agent_sdk/pipeline.py
@@ -96,6 +96,20 @@ class PipelineResult:
     article_chars: int
 
 
+def load_brief_file(path: str | Path) -> str:
+    """Load an opt-in deep-research brief for the writer, EXCLUDING refuted claims.
+
+    B-012: a deep-research brief (``docs/research/<slug>.md``) carries a
+    ``## Refuted / unverified`` section listing claims the adversarial check
+    killed. Those must never reach the writer, so this drops that section (from
+    its heading to the next top-level ``##`` heading or EOF); the verified claims
+    and sources pass through unchanged.
+    """
+    text = Path(path).read_text()
+    text = re.sub(r"(?ms)^##\s+Refuted\b.*?(?=^##\s|\Z)", "", text)
+    return text.strip() + "\n"
+
+
 async def run_pipeline(
     topic: str,
     writer_budget_usd: float | None = 0.30,
@@ -104,6 +118,7 @@ async def run_pipeline(
     graphics_model: str = DEFAULT_GRAPHICS_MODEL,
     image_mode: Literal["chart_only", "hero"] = "hero",
     research_mode: Literal["deterministic", "deep", "claude_web"] = "deterministic",
+    brief_override: str | None = None,
 ) -> PipelineResult:
     """Generate one article through the Agent SDK pipeline.
 
@@ -123,6 +138,7 @@ async def run_pipeline(
         writer_model=writer_model,
         graphics_model=graphics_model,
         research_mode=research_mode,
+        brief_override=brief_override,
     )
     article_for_stage4 = stage3.article
     if image_mode == "chart_only":
@@ -408,6 +424,17 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--brief",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Opt-in (B-012): use a pre-built deep-research brief file "
+            "(docs/research/<slug>.md) as the writer's research instead of "
+            "running --research-mode. Refuted claims are stripped. For flagship "
+            "posts — the deep-research harness is heavy; claude_web is the default."
+        ),
+    )
+    parser.add_argument(
         "--image-mode",
         choices=("hero", "chart_only"),
         default="hero",
@@ -464,6 +491,7 @@ def main() -> None:
             writer_model=args.writer_model,
             graphics_model=args.graphics_model,
             research_mode=args.research_mode,
+            brief_override=load_brief_file(args.brief) if args.brief else None,
         )
         return
 
@@ -500,6 +528,7 @@ def _run_end_to_end(
     graphics_model: str,
     research_mode: str,
     image_mode: str = "chart_only",
+    brief_override: str | None = None,
 ) -> None:
     """Run the full pipeline end-to-end (no handshake) and write the finished
     article. With ``--research-mode claude_web`` this is fully keyless — Stage 3
@@ -519,6 +548,7 @@ def _run_end_to_end(
                 graphics_model=graphics_model,
                 image_mode=image_mode,
                 research_mode=research_mode,
+                brief_override=brief_override,
             )
         )
     except (SearchProvidersFailedError, SearchProvidersEmptyError) as exc:

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -496,6 +496,7 @@ async def run_stage3(
     writer_model: str = DEFAULT_WRITER_MODEL,
     graphics_model: str = DEFAULT_GRAPHICS_MODEL,
     research_mode: str = "deterministic",
+    brief_override: str | None = None,
 ) -> Stage3Result:
     """Generate one article via the Agent SDK and return captured metrics.
 
@@ -527,20 +528,27 @@ async def run_stage3(
     # env overrides the argument. An unrecognised value fails closed to
     # deterministic (a typo must not silently disable the expensive deep path or
     # the keyless path) and is logged so operators can confirm.
-    resolved_research_mode = os.environ.get("RESEARCH_MODE", research_mode)
-    if resolved_research_mode not in ("deterministic", "deep", "claude_web"):
-        logger.warning(
-            "Unrecognised research mode %r; using deterministic",
-            resolved_research_mode,
-        )
-        resolved_research_mode = "deterministic"
-    logger.info("Research mode: %s", resolved_research_mode)
-    if resolved_research_mode == "deep":
-        research_brief, research_cost = await build_deep_research_brief(topic)
-    elif resolved_research_mode == "claude_web":
-        research_brief, research_cost = await build_claude_web_brief(topic)
+    if brief_override is not None:
+        # B-012: opt-in --brief — a pre-built deep-research brief (refuted claims
+        # already stripped by pipeline.load_brief_file) is used verbatim; the
+        # research step is skipped entirely (no cost).
+        research_brief, research_cost = brief_override, 0.0
+        logger.info("Research: using supplied --brief (%d chars)", len(research_brief))
     else:
-        research_brief, research_cost = build_research_brief(topic), 0.0
+        resolved_research_mode = os.environ.get("RESEARCH_MODE", research_mode)
+        if resolved_research_mode not in ("deterministic", "deep", "claude_web"):
+            logger.warning(
+                "Unrecognised research mode %r; using deterministic",
+                resolved_research_mode,
+            )
+            resolved_research_mode = "deterministic"
+        logger.info("Research mode: %s", resolved_research_mode)
+        if resolved_research_mode == "deep":
+            research_brief, research_cost = await build_deep_research_brief(topic)
+        elif resolved_research_mode == "claude_web":
+            research_brief, research_cost = await build_claude_web_brief(topic)
+        else:
+            research_brief, research_cost = build_research_brief(topic), 0.0
     logger.info("Research brief: %d chars", len(research_brief))
 
     style_context = _fetch_style_context(topic)

--- a/tests/test_deep_brief.py
+++ b/tests/test_deep_brief.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""B-012: opt-in deep-brief research mode — load a deep-research brief file for
+the writer, EXCLUDING refuted claims (they must never reach the writer)."""
+
+from __future__ import annotations
+
+from src.agent_sdk.pipeline import load_brief_file
+
+_BRIEF = """# Research brief — Does X?
+
+## Verified claims
+
+1. **A real, verified finding.**
+   — [example.com](https://example.com) · verified 3-0
+
+## Refuted / unverified — DO NOT USE without re-checking
+
+- ✗ A discredited claim that must not reach the writer.
+- ✗ Another walked-back number.
+
+## Sources
+
+- [example.com](https://example.com)
+"""
+
+
+def test_confirmed_claims_are_kept(tmp_path) -> None:
+    p = tmp_path / "brief.md"
+    p.write_text(_BRIEF)
+    out = load_brief_file(p)
+    assert "A real, verified finding" in out
+    assert "example.com" in out  # sources retained
+
+
+def test_refuted_claims_are_excluded(tmp_path) -> None:
+    p = tmp_path / "brief.md"
+    p.write_text(_BRIEF)
+    out = load_brief_file(p)
+    assert "discredited" not in out
+    assert "walked-back" not in out
+    assert "Refuted" not in out
+
+
+def test_brief_without_refuted_section_is_returned_whole(tmp_path) -> None:
+    p = tmp_path / "brief.md"
+    p.write_text("# Brief\n\n## Verified claims\n\n1. Only good claims here.\n")
+    out = load_brief_file(p)
+    assert "Only good claims here" in out


### PR DESCRIPTION
Wires the deep-research prototype in as an **opt-in** path (never the default), per `docs/specs/B-012-deep-brief-research-mode.md`.

- **`pipeline.load_brief_file(path)`** reads a `docs/research/<slug>.md` brief and **strips the `## Refuted / unverified` section** — refuted claims must never reach the writer (safety-critical; TDD'd).
- **`brief_override`** threaded `run_pipeline` → `run_stage3`: when set, used verbatim, research step skipped (no cost).
- **`--brief PATH`** CLI flag (chart_only path). Runbook documents it as opt-in/heavy for flagship posts; `claude_web` stays the everyday default.

**Why opt-in:** the prototype proved the value (refuted the walked-back Accenture numbers, 19 verified claims) *and* the cost (~2M tokens / hit the session limit).

**Verified:** `make ci-local` green — 2222 passed, 79.5% coverage. The one remaining acceptance criterion (a real deep-research → article run) is a token-heavy owner-run step, opt-in by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)