### PR TITLE
fix(B-008): one canonical slug for article, chart PNG, embed, and sidecar

### DIFF
--- a/src/agent_sdk/_shared.py
+++ b/src/agent_sdk/_shared.py
@@ -428,25 +428,32 @@ def _truncate_description(frontmatter: str, max_chars: int = 160) -> str:
     return frontmatter.replace(match.group(0), f"{prefix}{quote}{truncated}{quote}")
 
 
+def canonical_slug(article: str, fallback: str) -> str:
+    """The single slug shared by the article file, the chart PNG, the chart
+    embed, and the image-prompt sidecar (B-008).
+
+    Derived from the article's ``title`` frontmatter — the article's identity —
+    falling back to a kebab-cased ``fallback`` (the topic) when no title is
+    present. Using one derivation everywhere prevents a chart embed from pointing
+    at a PNG named from a different source (which broke in ``chart_only`` runs
+    where the hero ``image:`` field is empty).
+    """
+    match = re.search(r'^title:\s*["\']?(.+?)["\']?\s*$', article, re.MULTILINE)
+    source = match.group(1) if match else fallback
+    slug = re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
+    return slug or "article"
+
+
 def _auto_embed_chart(article: str) -> str:
     """Insert a chart embed before References if one is missing."""
     if "![" in article and "/assets/charts/" in article:
         return article
 
-    slug_match = re.search(r"image:\s*/assets/images/([^.\s]+)", article)
-    if slug_match:
-        slug = slug_match.group(1)
-    else:
-        # chart_only mode strips the hero ``image:`` frontmatter, so derive the
-        # slug from the title instead — otherwise the chart can never be
-        # embedded and the article fails the mandatory-chart validator.
-        title_match = re.search(r"title:\s*[\"']?(.+?)[\"']?\s*\n", article)
-        if not title_match:
-            return article
-        slug = (
-            re.sub(r"[^a-z0-9]+", "-", title_match.group(1).lower()).strip("-")
-            or "untitled"
-        )
+    if not re.search(r"^title:", article, re.MULTILINE):
+        # No title to derive a slug from — cannot name the chart; leave as-is
+        # (the mandatory-chart validator will flag it).
+        return article
+    slug = canonical_slug(article, "untitled")
 
     chart_embed = f"\n![Chart](/assets/charts/{slug}.png)\n"
 

--- a/src/agent_sdk/pipeline.py
+++ b/src/agent_sdk/pipeline.py
@@ -24,6 +24,7 @@ from src.agent_sdk._shared import (
     SearchProvidersEmptyError,
     SearchProvidersFailedError,
     _auto_embed_chart,
+    canonical_slug,
 )
 from src.agent_sdk.image_gate import ImageGateError, check_hero_image
 from src.agent_sdk.stage3_runner import (
@@ -512,11 +513,9 @@ def main() -> None:
 
 
 def _slug_from_article(article: str, fallback: str) -> str:
-    """Derive a filename slug from the article's title frontmatter (or topic)."""
-    match = re.search(r'^title:\s*["\']?(.+?)["\']?\s*$', article, re.MULTILINE)
-    source = match.group(1) if match else fallback
-    slug = re.sub(r"[^a-z0-9]+", "-", source.lower()).strip("-")
-    return slug or "article"
+    """Filename slug for the article — the single canonical slug (B-008), shared
+    with the chart PNG, chart embed, and image-prompt sidecar."""
+    return canonical_slug(article, fallback)
 
 
 def _run_end_to_end(

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -50,6 +50,7 @@ from src.agent_sdk._shared import (
     GRAPHICS_AGENT_PROMPT,
     BudgetExceededError,
     build_research_brief,
+    canonical_slug,
 )
 from src.agent_sdk._shared import (
     audit_article_stats as _audit_article_stats,
@@ -225,7 +226,6 @@ class Stage3Result:
     image_prompt: str = ""  # #403 slice 3: the prompt text itself
 
 
-_IMAGE_FIELD_PATTERN = re.compile(r"^image:\s*[^\n]*?/([^/\s]+)\.png", re.MULTILINE)
 _TITLE_FIELD_PATTERN = re.compile(r'^title:\s*["\']?(.*?)["\']?\s*$', re.MULTILINE)
 _IMAGE_ALT_PATTERN = re.compile(r'^image_alt:\s*["\']?(.*?)["\']?\s*$', re.MULTILINE)
 _IMAGE_CAPTION_PATTERN = re.compile(
@@ -247,19 +247,11 @@ def _extract_frontmatter_field(article: str, pattern: re.Pattern[str]) -> str:
 
 
 def _slug_for_chart(article: str, topic: str) -> str:
-    """Derive the slug to use when naming the chart PNG.
-
-    Preferred source is the article's frontmatter ``image:`` line, since
-    that's what the deploy script and the in-article chart reference both
-    point at. Falls back to a kebab-cased topic when the writer omitted
-    the image field (slice 2 makes that optional). Slice 3 will replace
-    this with a single canonical slug derivation."""
-    match = _IMAGE_FIELD_PATTERN.search(article)
-    if match:
-        return match.group(1)
-    # Conservative kebab-case: lowercase, ASCII alnum + hyphens only.
-    safe = re.sub(r"[^a-z0-9]+", "-", topic.lower()).strip("-")
-    return safe or "untitled"
+    """Slug for the chart PNG + image-prompt sidecar — the single canonical slug
+    (B-008), shared with the article file and the in-article chart embed so they
+    can never point at different filenames. Derived from the article title,
+    falling back to the topic."""
+    return canonical_slug(article, topic)
 
 
 _INLINE_HEADING_PATTERN = re.compile(r"[ \t]+(##+ +[A-Z][^\n]*)")

--- a/tests/test_auto_embed_chart.py
+++ b/tests/test_auto_embed_chart.py
@@ -12,12 +12,14 @@ from src.agent_sdk._shared import _auto_embed_chart
 _BODY = "Some analysis. As the chart shows, things rose.\n\n## References\n\n1. X\n"
 
 
-def test_embeds_chart_from_hero_image_slug() -> None:
+def test_embeds_chart_from_canonical_title_slug() -> None:
+    # B-008: the embed uses the canonical title slug (matching the chart PNG and
+    # the article filename), NOT the hero image field.
     article = (
         "---\ntitle: My Piece\nimage: /assets/images/rlhf-trends.png\n---\n\n" + _BODY
     )
     out = _auto_embed_chart(article)
-    assert "![Chart](/assets/charts/rlhf-trends.png)" in out
+    assert "![Chart](/assets/charts/my-piece.png)" in out
 
 
 def test_embeds_chart_from_title_when_image_frontmatter_stripped() -> None:

--- a/tests/test_canonical_slug.py
+++ b/tests/test_canonical_slug.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""B-008: one canonical slug across the article file, chart PNG, and image-prompt
+sidecar. In chart_only runs the hero `image:` field is empty, and the chart slug
+used to fall back to the *topic* while the article file and chart embed used the
+*title* — so the embed could point at a PNG that doesn't exist."""
+
+from __future__ import annotations
+
+from src.agent_sdk.pipeline import _slug_from_article
+from src.agent_sdk.stage3_runner import _slug_for_chart
+
+_CHART_ONLY_ARTICLE = (
+    '---\ntitle: "The Real Title"\nimage: ""\n---\n\n## Body\n\nSome text.\n'
+)
+
+
+def test_chart_and_article_slug_agree_when_image_absent() -> None:
+    # The chart PNG/sidecar slug and the article-file slug must be identical.
+    chart = _slug_for_chart(_CHART_ONLY_ARTICLE, "unrelated-topic")
+    article = _slug_from_article(_CHART_ONLY_ARTICLE, "unrelated-topic")
+    assert chart == article == "the-real-title"
+
+
+def test_both_fall_back_to_the_same_slug_without_a_title() -> None:
+    text = "no frontmatter at all"
+    assert _slug_for_chart(text, "My Topic!") == _slug_from_article(text, "My Topic!")

--- a/tests/test_pipeline_handshake.py
+++ b/tests/test_pipeline_handshake.py
@@ -30,7 +30,7 @@ def _fake_stage3(
     return Stage3Result(
         topic="test topic",
         article=(
-            "---\nlayout: post\ntitle: T\n"
+            "---\nlayout: post\ntitle: Test Slug\n"
             "image: /assets/images/test-slug.png\n"
             "image_alt: alt\nimage_caption: cap\n---\n\nBody.\n"
         ),

--- a/tests/test_stage3_chart_rendering.py
+++ b/tests/test_stage3_chart_rendering.py
@@ -13,17 +13,20 @@ from src.agent_sdk.stage3_runner import _slug_for_chart, run_stage3
 # ── slug derivation ──────────────────────────────────────────────────
 
 
-def test_slug_extracted_from_image_field_in_frontmatter() -> None:
+def test_slug_comes_from_title_not_image_field() -> None:
+    # B-008: the chart slug is the canonical title-based slug — NOT the hero
+    # image field (which conflated the chart with the hero image and diverged
+    # from the article filename).
     article = (
-        "---\nlayout: post\ntitle: x\n"
+        '---\nlayout: post\ntitle: "The Real Headline"\n'
         "image: /assets/images/three-people-and-a-fleet.png\n"
         "---\n\nBody."
     )
-    assert _slug_for_chart(article, "Some topic") == "three-people-and-a-fleet"
+    assert _slug_for_chart(article, "Some topic") == "the-real-headline"
 
 
-def test_slug_falls_back_to_kebab_topic_when_no_image_field() -> None:
-    article = "---\nlayout: post\ntitle: x\n---\n\nBody."
+def test_slug_falls_back_to_kebab_topic_when_no_title() -> None:
+    article = "---\nlayout: post\n---\n\nBody."  # no title
     assert (
         _slug_for_chart(article, "Product Team Composition (Agentic AI)")
         == "product-team-composition-agentic-ai"
@@ -35,7 +38,8 @@ def test_slug_strips_leading_and_trailing_hyphens() -> None:
 
 
 def test_slug_handles_topic_with_only_non_alnum() -> None:
-    assert _slug_for_chart("---\nlayout: post\n---\n\n", "!!!") == "untitled"
+    # No title, topic kebabs to empty -> canonical default.
+    assert _slug_for_chart("---\nlayout: post\n---\n\n", "!!!") == "article"
 
 
 # ── wire-up: run_stage3 produces chart_path ──────────────────────────
@@ -92,7 +96,9 @@ def test_run_stage3_renders_chart_png_to_output_charts_dir(
     result = asyncio.run(run_stage3("test topic"))
 
     assert result.chart_path is not None
-    assert result.chart_path == Path("output/charts/test-chart-slug.png")
+    # B-008: chart PNG is named from the title ("Test") — the canonical slug —
+    # not the hero image field.
+    assert result.chart_path == Path("output/charts/test.png")
     assert result.chart_path.exists()
     assert result.chart_path.stat().st_size > 0
 

--- a/tests/test_stage4_editorial_fixes.py
+++ b/tests/test_stage4_editorial_fixes.py
@@ -186,7 +186,7 @@ class TestChartAutoEmbed:
 
     def test_chart_inserted_before_references(self) -> None:
         article = (
-            "---\nimage: /assets/images/my-slug.png\n---\n"
+            "---\ntitle: My Slug\nimage: /assets/images/my-slug.png\n---\n"
             "Article body.\n\n## References\n\n1. Source"
         )
         result = _apply_editorial_fixes(article)
@@ -195,7 +195,7 @@ class TestChartAutoEmbed:
 
     def test_chart_not_doubled_if_present(self) -> None:
         article = (
-            "---\nimage: /assets/images/my-slug.png\n---\n"
+            "---\ntitle: My Slug\nimage: /assets/images/my-slug.png\n---\n"
             "Body.\n\n![Chart](/assets/charts/my-slug.png)\n\n## References\n"
         )
         result = _apply_editorial_fixes(article)
@@ -215,7 +215,7 @@ class TestChartAutoEmbed:
 
     def test_chart_appended_if_no_references_section(self) -> None:
         article = (
-            "---\nimage: /assets/images/my-slug.png\n---\n"
+            "---\ntitle: My Slug\nimage: /assets/images/my-slug.png\n---\n"
             "Article body with no references."
         )
         result = _apply_editorial_fixes(article)


### PR DESCRIPTION
## What & why

Fixes B-008: the article filename, the rendered chart PNG, the in-body `![Chart]` embed, and the image-prompt sidecar could diverge because each derived its slug from a different source (title vs. hero `image:` field vs. resume arg). In `chart_only` mode the hero `image:` frontmatter is stripped, so the chart could silently fail to embed or embed at a slug that didn't match the PNG on disk.

## Change

- Add `canonical_slug(article, fallback)` in `_shared.py` — one title-based slug (topic fallback) used everywhere.
- `_auto_embed_chart`, `_slug_for_chart` (stage3), and `_slug_from_article` (pipeline) all delegate to it.
- Regression tests assert the article slug == chart slug == embed slug for a `chart_only` article.
- Align two pre-existing fixtures whose title/slug pairs were internally inconsistent under the old behaviour.

## Verification

`make ci-local` green: 2224 passed / 8 skipped, coverage 79.49% (≥70), `src/quality` 97% (≥90), bandit clean, destructive-change guard clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)