### PR TITLE
fix(B-039): the merge gate must run the pinned toolchain, not the machine's

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -587,6 +587,66 @@ clone is green *and* honest about not having seen a real artifact.
 but not its text. Inferring headings from class names would be guessing at whatever CSS a
 given conversation emitted; promoting one is a one-character edit in the brief.
 
+### B-039 · The merge gate runs whatever toolchain the machine happens to have
+
+**Opened 2026-08-01**, found by `make ci-local` failing on a file the session never touched.
+
+ADR-0015 makes `make ci-local` *the* merge gate — there is no GitHub Actions, and `main` is
+unprotected. So the gate has to mean the same thing on every machine and in every shell. It
+does not. Every recipe resolves its tools from ambient `PATH`, not from the venv this repo
+pins, and line 51 (`.venv/bin/python scripts/mypy_baseline.py`) shows someone already hit
+this and patched the one line instead of the class.
+
+Three symptoms, all measured on 2026-08-01, not inferred:
+
+| Symptom | Measured |
+|---|---|
+| **The gate lints with an unpinned ruff.** `requirements-dev.txt` pins `ruff==0.14.10` *exactly*; the gate ran homebrew's **0.15.9** and demanded a reformat of `tests/test_mypy_baseline.py`, which no one had edited. | `ruff --version` → 0.15.9 ambient vs 0.14.10 in `.venv` |
+| **The gate cannot run in a clean shell at all.** Line 49 calls bare `python`, which does not exist on macOS outside an activated venv. | `make ci-local` → `/bin/sh: python: command not found`, Error 127 |
+| **The advisory mypy step reports a missing tool as a pass.** `(mypy scripts/ \|\| echo "advisory")` swallows exit 127 exactly like exit 1, so "mypy found 187 errors" and "mypy was never installed" print the same line. `mypy` and `bandit` are both absent from ambient `PATH` here. | `sh -c '(mypy scripts/ \|\| echo advisory)'` → `mypy: command not found` then the advisory text, exit 0 |
+
+The third is the serious one, and it is **B-031's complaint exactly**: a sensor that cannot
+distinguish "I ran and found problems" from "I never ran". The first is B-037's sibling — that
+item found four declarations of the Python version disagreeing with the interpreter actually
+running the suite; this is the same drift one level down, in the *tool* versions.
+
+**Fix:** put `.venv/bin` first on `PATH` for the whole Makefile, guard every tool-running
+target behind a `require-venv` check that fails loudly rather than falling through to ambient
+binaries, and split the mypy advisory into its own target that distinguishes exit >1 (did not
+run — fail the gate) from exit 1 (type errors — advisory, as intended).
+
+- [x] `make ci-local` resolves ruff, mypy, pytest, bandit and coverage from `.venv/bin`
+- [x] A missing venv fails with an instruction, instead of silently using ambient tools
+- [x] The mypy advisory step fails the gate when mypy did not run
+- [x] Regression tests that *execute* the Makefile against stub tools, not greps of its text
+
+**Scope:** S. **Files:** `Makefile`, `tests/test_ci_gate_is_reproducible.py`.
+
+**DONE 2026-08-01. The obvious fix did not work, and only a running test caught it.**
+
+`export PATH := $(CURDIR)/.venv/bin:$(PATH)` is the one-line fix everyone reaches for, it
+reads correctly, and `make showpath` confirms the exported value. It still left `ruff check .`
+running the ambient ruff. **GNU make 3.81 — what macOS ships — direct-execs any recipe line
+containing no shell metacharacters, and resolves the binary against make's own startup PATH
+rather than the exported one.** So `mypy ...; status=$$?` used the venv (it has a `;`, so a
+shell runs it) while `ruff check .` did not. The fix is to name `$(VENV_BIN)/<tool>`
+explicitly in every recipe; the `export PATH` stays, but only for what *child* processes
+look up.
+
+A grep-the-Makefile test would have passed the moment the plausible-looking line was
+written. The test that executes `make lint` against a stub `ruff` failed, which is the whole
+argument for behavioural sensors — and the **fourth** instance of the pattern in
+`skills/defect-prevention/SKILL.md`: asserting from a plausible reading instead of measuring.
+
+Verified from a bare shell (`env -i PATH=/usr/bin:/bin:/opt/homebrew/bin make ci-local`,
+no activated venv, no PATH prefix): green, 2,680 tests. Before this change that invocation
+died at step 3 with `python: command not found`.
+
+Mutation-checked, so the new sensor is not decorative: the old
+`(mypy … || echo "advisory")` form exits **0** against a `mypy` stub that exits 127; the new
+form exits non-zero. `make install` now creates the venv if it is absent, so require-venv's
+instruction points at a target that actually works from nothing.
+
 ### B-036 · Badge validation has no implementation — decide whether to restore it
 
 **Opened 2026-07-31**, found by B-031 doing its job.

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,38 @@
-.PHONY: install test lint format type-check quality ci-local clean help publish
+.PHONY: install test lint format type-check mypy-advisory quality ci-local clean help publish require-venv
+
+# B-039: ADR-0015 makes `make ci-local` THE merge gate — there is no GitHub Actions and
+# main is unprotected — so it has to mean the same thing on every machine and in every
+# shell. Resolving tools from ambient PATH broke that three ways, all measured 2026-08-01:
+# the gate linted with homebrew's ruff 0.15.9 while requirements-dev.txt pins ruff==0.14.10
+# exactly, and demanded a reformat of a file nobody had touched; bare `python` does not
+# exist on macOS outside an activated venv, so the gate died at step 3 with "command not
+# found"; and the advisory mypy step reported a *missing* mypy identically to one that ran
+# and found errors.
+#
+# Recipes name $(VENV_BIN)/<tool> EXPLICITLY. Exporting PATH is not enough and looks like
+# it is: GNU make 3.81 (what macOS ships) direct-execs any recipe line with no shell
+# metacharacters, and resolves the binary against its own startup PATH rather than the
+# exported one — so `ruff check .` silently kept using the ambient ruff while
+# `mypy ...; status=$$?` (has metacharacters, so a shell runs it) used the venv. The export
+# below still earns its place: it fixes the tools that *child* processes go looking for.
+VENV_BIN := $(CURDIR)/.venv/bin
+PY       := $(VENV_BIN)/python
+export PATH := $(VENV_BIN):$(PATH)
+
+# Fail loudly rather than falling through to whatever the machine happens to have. Every
+# tool-running target depends on this; `install` deliberately does not, because it is what
+# creates the venv.
+require-venv:
+	@test -x "$(PY)" || { \
+		echo "✗ no pinned toolchain at $(VENV_BIN)"; \
+		echo "  create it, then re-run:  make install"; \
+		exit 1; \
+	}
 
 # Default target
 help:
 	@echo "Available commands:"
-	@echo "  make install      - Install dependencies and pre-commit hooks"
+	@echo "  make install      - Create the venv if needed, install dependencies and hooks"
 	@echo "  make test         - Run tests with coverage"
 	@echo "  make lint         - Run ruff linter"
 	@echo "  make format       - Format code with ruff"
@@ -13,29 +42,47 @@ help:
 	@echo "  make publish SLUG=<slug> - Promote an approved B-013 review draft to a post"
 	@echo "  make clean        - Remove cache files"
 
+# The one target that may not require the venv — it is what builds it. Creating it here
+# makes require-venv's instruction ("make install") true from a bare shell (B-039).
 install:
-	pip install -r requirements.txt
-	pip install -r requirements-dev.txt
-	pre-commit install --install-hooks
-	pre-commit install --hook-type pre-push
+	@test -x "$(PY)" || python3 -m venv .venv
+	$(VENV_BIN)/pip install -r requirements.txt
+	$(VENV_BIN)/pip install -r requirements-dev.txt
+	$(VENV_BIN)/pre-commit install --install-hooks
+	$(VENV_BIN)/pre-commit install --hook-type pre-push
 	@echo "✅ Installation complete"
 
 # B-031: threshold was 40 here and 70 in ci-local. One gate, one number — this
 # matches ci-local so a green `make test` means the same thing as a green gate.
-test:
-	pytest tests/ -v \
+test: require-venv
+	$(VENV_BIN)/pytest tests/ -v \
 		--cov=src --cov=scripts \
 		--cov-report=term-missing \
 		--cov-fail-under=70
 
-lint:
-	ruff check .
+lint: require-venv
+	$(VENV_BIN)/ruff check .
 
-format:
-	ruff format .
+format: require-venv
+	$(VENV_BIN)/ruff format .
 
-type-check:
-	mypy scripts/
+type-check: require-venv
+	$(VENV_BIN)/mypy scripts/
+
+# B-039: mypy exits 0 (clean), 1 (type errors found), and >1 for everything else — 2 for a
+# usage or internal error, 127 for "command not found". Only exit 1 is the known-red
+# backlog this step is allowed to wave through. The old form,
+# `(mypy scripts/ || echo "advisory")`, printed the same reassuring line for all of them,
+# so a mypy that never ran passed the gate. That is B-031's complaint exactly: a sensor
+# that cannot tell "I ran and found problems" from "I never ran".
+mypy-advisory: require-venv
+	@$(VENV_BIN)/mypy scripts/; status=$$?; \
+	if [ $$status -gt 1 ]; then \
+		echo "✗ mypy did not run (exit $$status) — a missing or broken tool must fail the gate, not pass it quietly (B-039)"; \
+		exit 1; \
+	elif [ $$status -eq 1 ]; then \
+		echo "⚠️  mypy advisory — repo-wide backlog is known-red (611 errors); NEW type errors are blocked per-commit by the baselined mypy hook (B-031, B-035 Task 2 — see docs/mypy-baseline.md)"; \
+	fi
 
 quality: format lint type-check test
 	@echo "✅ All quality checks passed!"
@@ -43,26 +90,26 @@ quality: format lint type-check test
 # Full pre-merge gate — reproduces every check the retired GitHub Actions
 # `Quality Gates CI` (ci.yml) enforced, so verification is local-first and
 # paywall-free (ADR-0015). main is unprotected: run this before you merge.
-ci-local:
-	@echo "── ruff format ──"        && ruff format --check .
-	@echo "── ruff lint ──"          && ruff check .
-	@echo "── bare-name imports ──"  && python scripts/check_bare_name_imports.py
-	@echo "── mypy (advisory) ──"    && (mypy scripts/ || echo "⚠️  mypy advisory — repo-wide backlog is known-red (611 errors); NEW type errors are blocked per-commit by the baselined mypy hook (B-031, B-035 Task 2 — see docs/mypy-baseline.md)")
-	@echo "── mypy baseline gate ──" && .venv/bin/python scripts/mypy_baseline.py --all
-	@echo "── tests + coverage ──"   && pytest tests/ \
+ci-local: require-venv
+	@echo "── ruff format ──"        && $(VENV_BIN)/ruff format --check .
+	@echo "── ruff lint ──"          && $(VENV_BIN)/ruff check .
+	@echo "── bare-name imports ──"  && $(PY) scripts/check_bare_name_imports.py
+	@echo "── mypy (advisory) ──"    && $(MAKE) --no-print-directory mypy-advisory
+	@echo "── mypy baseline gate ──" && $(PY) scripts/mypy_baseline.py --all
+	@echo "── tests + coverage ──"   && $(VENV_BIN)/pytest tests/ \
 		--cov=src --cov=scripts \
 		--cov-report=term-missing \
 		--cov-fail-under=70
-	@echo "── src/quality per-module coverage ──" && coverage report --include='src/quality/*' --fail-under=90
-	@echo "── security scan (bandit) ──" && bandit -r scripts/ \
+	@echo "── src/quality per-module coverage ──" && $(VENV_BIN)/coverage report --include='src/quality/*' --fail-under=90
+	@echo "── security scan (bandit) ──" && $(VENV_BIN)/bandit -r scripts/ \
 		--exclude '*/.venv/*,*/__pycache__/*,scripts/archived' \
 		--severity-level medium -q
-	@echo "── destructive-change guard ──" && python scripts/destructive_change_guard.py
+	@echo "── destructive-change guard ──" && $(PY) scripts/destructive_change_guard.py
 	@echo "✅ ci-local passed — you are the merge gate (main is unprotected)."
 
-publish:
+publish: require-venv
 	@if [ -z "$(SLUG)" ]; then echo "Usage: make publish SLUG=<slug>"; exit 2; fi
-	python -m scripts.promote_review --slug $(SLUG)
+	$(PY) -m scripts.promote_review --slug $(SLUG)
 
 clean:
 	find . -type d -name __pycache__ -exec rm -rf {} +

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -72,16 +72,36 @@ unfixed, both one-edit-away in the brief: semantic styling carried only by CSS c
 (`div.card-header`) becomes a plain paragraph, and an artifact with no `<a href>` produces a
 brief with no citations, which the writer path and `citation_verifier` will notice downstream.
 
+## B-039 — the merge gate now runs the pinned toolchain
+
+**Fixed 2026-08-01.** `make ci-local` resolved its tools from ambient `PATH`, so the gate did
+not mean the same thing twice: it linted with homebrew's ruff 0.15.9 while
+`requirements-dev.txt` pins `ruff==0.14.10` exactly, it could not run at all in a shell
+without an activated venv (bare `python`), and its advisory mypy step printed the same
+reassuring line for "found 187 errors" and "mypy is not installed".
+
+Every recipe now names `$(VENV_BIN)/<tool>` explicitly, `require-venv` fails with an
+instruction instead of falling through to ambient binaries, `make install` creates the venv
+if it is missing, and `mypy-advisory` is its own target that fails the gate on exit >1.
+
+**The trap, worth knowing before you touch the Makefile:** `export PATH := …/.venv/bin:$(PATH)`
+does *not* do the job on its own, however right it looks. GNU make 3.81 (what macOS ships)
+direct-execs recipe lines with no shell metacharacters and resolves them against its own
+startup PATH — so `ruff check .` kept using ambient ruff while `mypy …; status=$$?` used the
+venv. `tests/test_ci_gate_is_reproducible.py` executes `make` against stub binaries for
+exactly this reason; a grep of the Makefile would have passed on the broken fix. Recorded as
+the fourth instance in `skills/defect-prevention/SKILL.md`.
+
+Verified from a bare shell — `env -i PATH=/usr/bin:/bin:/opt/homebrew/bin make ci-local` —
+green at 2,680 tests, where that same invocation previously died at step 3.
+
 ## State in one paragraph
 
-Two work streams are open, stacked, and **both are complete and green**. The **article-two
-defect stream** sits on `fix/article-two-run-defects` (PR #459 → `main`): B-028 Tasks 1–2,
-B-029 and the editorial-review-gate artifacts all landed 2026-07-31, and `main` has been
-merged in, so the conflict that was blocking the stack is gone. The **harness engineering
-stream** sits on `harness/close-the-sensor-loop` (PR #460 → #459) with B-030 … B-035.
-`make ci-local` passes on both. Nothing is broken and nothing is loose on disk.
-
-**Merge #459 first, then #460.**
+**Both stacked streams merged to `main` on 2026-08-01 and their branches are deleted.**
+PR #459 (article-two defects: B-028 Tasks 1–2, B-029, the editorial-review-gate artifacts)
+and PR #460 (harness engineering: B-030 … B-035, plus B-038) are in. Merge commits, not
+rebases — #459 carried a merge of `main`, which GitHub refuses to rebase. `make ci-local` is
+green on `main` at 2,680 tests. No open PRs. Nothing is loose on disk.
 
 ## Branches and PRs
 

--- a/skills/defect-prevention/SKILL.md
+++ b/skills/defect-prevention/SKILL.md
@@ -130,6 +130,7 @@ second:
 | A hero image had a clipped top card | a four-line border-pixel check | a $0.49 redraw that fixed nothing (B-027) |
 | `.gitignore` left `defect_tracker.json` untracked, so three defects existed on one laptop only | `git ls-files` | a whole backlog item, opened and withdrawn (~~B-025~~) |
 | `backup/integration-test-20260728` was "the only copy" of the auth work | `git branch --contains 73e73c0` | three days of caution shaping B-023's framing |
+| `export PATH := $(CURDIR)/.venv/bin:$(PATH)` makes `make` use the pinned toolchain | `make lint` against a stub `ruff` that prints a marker | none — a behavioural test caught it before it shipped (B-039) |
 
 The shape is identical every time. An observation arrives that *looks* like
 evidence — a thumbnail, a `git add` hint about a directory pattern, a branch name
@@ -148,8 +149,22 @@ If you cannot name such a command, say so explicitly and mark the claim as
 unverified rather than asserting it. This is cheap: all three commands above are
 sub-second, and all three were available at the moment the claim was made.
 
+**The fourth instance is the one to study, because the surface reading was a *fix*,
+not a defect.** `export PATH := $(CURDIR)/.venv/bin:$(PATH)` is the obvious way to
+point a Makefile at a pinned venv, it reads correctly, and `make showpath` prints
+the exported value — three independent signals all agreeing. It still did not work:
+GNU make 3.81 direct-execs any recipe line with no shell metacharacters and resolves
+the binary against its own startup PATH, so `ruff check .` kept using the ambient
+ruff while `mypy …; status=$$?` used the venv. Nothing short of running a recipe
+against a stub binary would have shown that.
+
+So the rule extends: **a fix that looks right is a claim too.** Name the command that
+would show it does not work, and prefer a test that *executes* the thing over one that
+reads it. A grep asserting the Makefile "contains the PATH line" would have passed on
+a change that fixed nothing, and the gate would have stayed silently broken.
+
 This is a *habit*, not a `check_all()` rule — there is no artefact to pattern-match
-against. It is recorded here because three instances make it a class, not an
+against. It is recorded here because four instances make it a class, not an
 accident.
 
 ## Red Flags

--- a/tests/test_ci_gate_is_reproducible.py
+++ b/tests/test_ci_gate_is_reproducible.py
@@ -1,0 +1,160 @@
+"""Tests that `make ci-local` is reproducible (B-039).
+
+ADR-0015 makes `make ci-local` the merge gate — there is no GitHub Actions and `main` is
+unprotected — so the gate has to mean the same thing on every machine and in every shell.
+It did not: every recipe resolved its tools from ambient ``PATH``, so the gate linted with
+an unpinned ruff, could not run without an activated venv, and reported a *missing* mypy
+identically to a mypy that ran and found errors.
+
+These tests **execute** the Makefile in a throwaway directory against stub tools. A grep of
+the Makefile's text would pass the moment someone wrote the right-looking line; running it
+is the only thing that proves which binary actually wins.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+MAKEFILE = REPO_ROOT / "Makefile"
+
+#: A PATH with no venv on it, so anything the gate finds it found ambiently.
+BARE_PATH = "/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin"
+
+
+def write_stub(path: Path, *, prints: str = "", exit_code: int = 0) -> None:
+    """Write an executable shell stub that announces itself and exits as told."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"#!/bin/sh\n{f'echo {prints}' if prints else ''}\nexit {exit_code}\n"
+    )
+    path.chmod(0o755)
+
+
+def run_make(target: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run one make target in an isolated directory with no venv on PATH."""
+    return subprocess.run(
+        ["make", "--no-print-directory", target],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": BARE_PATH},
+    )
+
+
+@pytest.fixture
+def sandbox(tmp_path: Path) -> Path:
+    """A directory holding only the repo's Makefile."""
+    shutil.copy(MAKEFILE, tmp_path / "Makefile")
+    return tmp_path
+
+
+class TestTheGateUsesThePinnedVenv:
+    """`requirements-dev.txt` pins `ruff==0.14.10`; ambient ruff was 0.15.9 and formatted
+    differently. The pin is meaningless if the gate does not run the pinned binary."""
+
+    def test_a_venv_tool_wins_over_the_ambient_one(self, sandbox: Path) -> None:
+        write_stub(sandbox / ".venv" / "bin" / "python")
+        write_stub(sandbox / ".venv" / "bin" / "ruff", prints="THE-VENV-RUFF-RAN")
+
+        result = run_make("lint", sandbox)
+
+        assert result.returncode == 0, result.stderr
+        assert "THE-VENV-RUFF-RAN" in result.stdout
+
+    def test_the_test_target_also_uses_the_venv(self, sandbox: Path) -> None:
+        write_stub(sandbox / ".venv" / "bin" / "python")
+        write_stub(sandbox / ".venv" / "bin" / "pytest", prints="THE-VENV-PYTEST-RAN")
+
+        result = run_make("test", sandbox)
+
+        assert "THE-VENV-PYTEST-RAN" in result.stdout
+
+
+class TestAMissingVenvFailsLoudly:
+    """Falling through to ambient tools is how the gate silently changed meaning."""
+
+    def test_ci_local_refuses_to_start_without_a_venv(self, sandbox: Path) -> None:
+        result = run_make("ci-local", sandbox)
+
+        assert result.returncode != 0
+        assert "venv" in (result.stdout + result.stderr).lower()
+
+    def test_it_fails_before_running_any_check_rather_than_part_way(
+        self, sandbox: Path
+    ) -> None:
+        result = run_make("ci-local", sandbox)
+
+        assert "── ruff format ──" not in result.stdout
+
+    def test_the_message_says_how_to_fix_it(self, sandbox: Path) -> None:
+        result = run_make("ci-local", sandbox)
+
+        assert "make install" in result.stdout + result.stderr
+
+    def test_install_creates_the_venv_rather_than_requiring_it(
+        self, sandbox: Path
+    ) -> None:
+        # Chicken-and-egg: `make install` must not require the thing it installs into,
+        # or require-venv's instruction would send you to a target that also refuses.
+        # Dry-run, so this asserts what install *would* do without installing anything.
+        result = subprocess.run(
+            ["make", "--no-print-directory", "--dry-run", "install"],
+            cwd=sandbox,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PATH": BARE_PATH},
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert "python3 -m venv .venv" in result.stdout
+        assert "/.venv/bin/pip install" in result.stdout
+
+
+class TestTheMypyAdvisoryCannotMaskAMissingTool:
+    """B-031's complaint: a sensor that cannot tell "I ran and found problems" from
+    "I never ran". `(mypy ... || echo advisory)` swallowed exit 127 exactly like exit 1."""
+
+    @pytest.fixture
+    def sandbox_with_python(self, sandbox: Path) -> Path:
+        write_stub(sandbox / ".venv" / "bin" / "python")
+        return sandbox
+
+    def test_clean_mypy_passes(self, sandbox_with_python: Path) -> None:
+        write_stub(sandbox_with_python / ".venv" / "bin" / "mypy", exit_code=0)
+
+        result = run_make("mypy-advisory", sandbox_with_python)
+
+        assert result.returncode == 0, result.stderr
+
+    def test_type_errors_stay_advisory(self, sandbox_with_python: Path) -> None:
+        write_stub(sandbox_with_python / ".venv" / "bin" / "mypy", exit_code=1)
+
+        result = run_make("mypy-advisory", sandbox_with_python)
+
+        assert result.returncode == 0, result.stderr
+        assert "advisory" in result.stdout
+
+    def test_a_mypy_that_could_not_run_fails_the_gate(
+        self, sandbox_with_python: Path
+    ) -> None:
+        # 127 is "command not found"; 2 is a mypy usage/internal error. Neither is
+        # "the codebase is known-red", which is the only thing the advisory excuses.
+        write_stub(sandbox_with_python / ".venv" / "bin" / "mypy", exit_code=127)
+
+        result = run_make("mypy-advisory", sandbox_with_python)
+
+        assert result.returncode != 0
+        assert "advisory" not in result.stdout.replace("mypy (advisory)", "")
+
+    def test_a_mypy_crash_fails_the_gate_too(self, sandbox_with_python: Path) -> None:
+        write_stub(sandbox_with_python / ".venv" / "bin" / "mypy", exit_code=2)
+
+        result = run_make("mypy-advisory", sandbox_with_python)
+
+        assert result.returncode != 0


### PR DESCRIPTION
`make ci-local` is the merge gate (ADR-0015 — no GitHub Actions, `main` unprotected), so it has to mean the same thing on every machine and in every shell. It did not: every recipe resolved its tools from ambient `PATH`.

## Three symptoms, all measured

| Symptom | Evidence |
|---|---|
| Lints with an unpinned ruff | `requirements-dev.txt` pins `ruff==0.14.10`; the gate ran homebrew's **0.15.9** and demanded a reformat of an untouched file |
| Cannot run in a clean shell | bare `python` doesn't exist on macOS outside an activated venv → `Error 127` at step 3 |
| The advisory mypy step passes a missing tool | `(mypy \|\| echo advisory)` swallows exit 127 exactly like exit 1 — "found 187 errors" and "not installed" print the same line |

The third is B-031's complaint exactly: a sensor that can't tell *"I ran and found problems"* from *"I never ran"*.

## The fix

Recipes name `$(VENV_BIN)/<tool>` explicitly; `require-venv` fails with an instruction rather than falling through to ambient binaries; `make install` creates the venv so that instruction works from nothing; `mypy-advisory` is its own target that fails on exit >1 and still waves through exit 1.

## The trap — worth reading before touching the Makefile

`export PATH := $(CURDIR)/.venv/bin:$(PATH)` is the obvious one-liner, it reads correctly, and `make showpath` confirms the exported value. **It still left `ruff check .` on the ambient ruff.** GNU make 3.81 (what macOS ships) direct-execs any recipe line with no shell metacharacters and resolves the binary against make's own startup PATH — which is why `mypy ...; status=$$?` used the venv and `ruff check .` did not.

So `tests/test_ci_gate_is_reproducible.py` **executes** `make` against stub binaries instead of grepping the Makefile. A grep would have passed on the broken fix. Mutation-checked: the old advisory form exits 0 against a `mypy` stub that exits 127; the new form does not.

## Verification

- `env -i PATH=/usr/bin:/bin:/opt/homebrew/bin make ci-local` — no activated venv, no PATH prefix — **green, 2,680 tests**. That same invocation previously died at step 3.
- 10 new tests, all behavioural.
- Recorded as the fourth instance in `skills/defect-prevention/SKILL.md`, and the first where the surface reading was a *fix* rather than a defect claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)