### PR TITLE
perf(B-041) + docs(B-040): bound the hero's spend; spec the review-gate calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,8 @@ temp_blog_repo/
 # committed. tests/test_html_to_brief.py picks up whatever is here and skips cleanly
 # when there is nothing. The README explaining the drop point IS tracked.
 docs/research/samples/*.html
+
+# ...and the brief converted from one. Same content, same reason. Other briefs in
+# docs/research/ are committed normally; only ones derived from a local-only artifact
+# are ignored, one line each.
+docs/research/sre-quality-governance.md

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -721,13 +721,59 @@ The constants are not arbitrary; the comments record that 240s and $0.40 were "e
 independently fatal". The problem is not the ceiling, it is that **a 10× duration swing is
 invisible in the only place anyone would look for it.**
 
-- [ ] Record hero draw seconds, attempt count and timeout count as their own ledger fields
-- [ ] Decide whether a timed-out first attempt should retry at all, given the measured note
-      that "the critique does NOT converge" and each redraw "cost ~8 minutes and bought nothing"
-- [ ] Once attributable, state the honest range in the runbook: typical vs timeout path
+- [x] Record hero draw seconds, attempt count and timeout count as their own ledger fields
+- [x] Decide whether a timed-out first attempt should retry at all
+- [x] Bound the aggregate, not just each call
+- [ ] Once several runs carry `hero_*` fields, state the honest range in the runbook:
+      typical vs timeout path
 
-**Scope:** S. **Files:** `src/agent_sdk/hero_author.py`, `src/agent_sdk/pipeline.py`,
-`docs/keyless-pipeline-runbook.md`.
+**Scope:** S. **Files:** `src/agent_sdk/hero_author.py`, `src/agent_sdk/stage3_runner.py`,
+`src/agent_sdk/pipeline.py`, `tests/test_hero_author.py`.
+
+**FIXED 2026-08-01, and the run that prompted it settled the design question.**
+
+The run finished while this item was being written, and it is the whole argument:
+
+| | |
+|---|---|
+| Wall clock | **31.8 min** — twice the previous record |
+| Cost | $1.01, of which $0.18 graphics |
+| Hero attempt 1 | timed out at 600s |
+| Hero attempt 2 | **also timed out at 600s**, carrying the "return a simpler drawing with fewer, larger shapes" instruction |
+| Hero produced | **none** |
+
+So **20 of the 31.8 minutes bought nothing**, and the article is unpublishable — the blog
+requires a resolvable `image:`. It also retires the open question: the shrink-the-ask retry
+does not work. One timeout is a diagnosis, not a transient.
+
+That reframed the fix. An aggregate budget of 1200s would have changed this run by **zero
+seconds** (2 × 600 = 1200 exactly). The ceiling has to make the second full-price attempt
+*impossible*, not merely capped:
+
+- `_HERO_TOTAL_BUDGET_S = 900` — one measured successful draw (454s) plus its critique (180s)
+  plus slack, and equal to the longest *complete* pipeline run ever recorded.
+- `_MIN_USEFUL_DRAW_S = 450` — no observed successful draw has finished faster than 454s.
+
+Those two numbers separate the retry cases by arithmetic rather than by a special case, which
+is why the fix is small. A **rejected** attempt returns in seconds and leaves the budget
+almost intact, so it retries exactly as before. A **timed-out** attempt has consumed 600s by
+definition, leaving 300s — under the floor — so it stops. Cheap signal, retry; expensive
+silence, stop.
+
+Worst case: **46 min → 15 min.** This run's failure mode: **20 min → 10 min.**
+
+**And the folklore was not baseless after all.** The earlier correction — "no recorded run
+exceeds 15.4 minutes" — was true of the ledger, and the ledger was the wrong instrument: it
+had only ever recorded runs where the hero landed. "~35 minutes" was a real memory of the
+timeout path that nothing had ever written down. Both halves were right, which is exactly the
+case for the `hero_*` fields: the ledger now distinguishes the two populations it was
+silently averaging.
+
+**Found in passing, and it may explain the thin ledger.** A value orjson cannot serialise
+does not fail the write loudly — `pipeline.py` catches it and logs "cost log write failed
+(non-fatal)", so the entire row disappears. Five rows across four months of runs is suspicious
+on its own. `_numeric()` now coerces at the boundary; whether earlier rows were lost this way
+is unverified and worth a look before anyone trends this data.
 
 ### B-036 · Badge validation has no implementation — decide whether to restore it
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -647,6 +647,88 @@ Mutation-checked, so the new sensor is not decorative: the old
 form exits non-zero. `make install` now creates the venv if it is absent, so require-venv's
 instruction points at a target that actually works from nothing.
 
+### B-040 · Calibrate the editorial review gate so it can be promoted
+
+**Opened 2026-08-01.** Spec: `docs/specs/review-gate-calibration.md` — **awaiting LGTM.**
+
+ADR-0018 Decision 3 keeps `blog-post-review` advisory and says "promote to blocking once a
+false-positive rate is known." **Nothing has ever produced that number.** The gate has run
+exactly once, by hand, on one article — and that run contained a near-false-positive (a
+summarised Graphite fetch would have reported a false G2 failure on a correct figure). So the
+only instrument that catches fidelity defects the deterministic evaluator provably cannot
+(88% PASS vs 51 BLOCK on the same article) is frozen by a missing measurement.
+
+Reviewed against Anthropic's [Demystifying evals for AI
+agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents), the eval
+surface is lopsided in one specific way: **code-based graders are strong** (`article_evaluator`
+at 841 records, `publication_validator`, `_shared.py`, `skill_eval`), and the one model-based
+grader **has no ground truth to be checked against**. `logs/article_evals.json` is production
+monitoring, not an eval set. The guide's instruction — *"20-50 simple tasks drawn from real
+failures"* — is satisfiable today at **finding** granularity: ADR-0018 enumerates 10 labelled
+fidelity defects plus the 1 labelled near-false-positive.
+
+- [ ] ~25 cases, ≥40% negatives, each traceable to a real article or a real finding
+- [ ] Report false-positive and false-negative rates **separately, with `n`** — never averaged
+- [ ] Keyless judge via the Agent SDK; case selection and arithmetic deterministic
+- [ ] Sufficient for the owner to answer ADR-0018 Decision 3
+
+**Build after n≈5 real reviews**, which accrue free from the B-013 review stage the owner
+already performs — the only added cost is recording, per gate, whether he agreed. The harness
+design depends on what those runs show: a gate that blocks everything needs threshold tuning,
+one that passes everything needs anchor revision (ADR-0018's own warning: "scores clustering
+above 85 would mean the rubric is broken rather than the pipeline"). Different tools.
+
+**Scope:** M. **Files:** `scripts/calibrate_review_gate.py`, `docs/evals/review-gate/`,
+`tests/test_calibrate_review_gate.py`.
+
+**Shipped 2026-08-01 alongside the spec, because waiting corrupts the baseline:**
+
+- [x] **G5 added to the machine-readable verdict block.** ADR-0018 Decision 2 says G5 was
+      amended "into the machine-readable verdict block". It reached `SKILL.md:165` but **not**
+      `REVIEW_PROMPT.md:85` — the file actually pasted into a review session — nor the rubric
+      card. Every review until now silently dropped the result of the gate that exists
+      *because* a reversed DORA statistic passed the other four.
+- [x] **Runbook cost/duration figures replaced with the recorded range** (see B-041).
+
+### B-041 · The hero draw's worst case is 3× the longest run ever recorded, and nothing attributes it
+
+**Opened 2026-08-01**, found by the owner asking whether "~35 minutes" was ludicrous. It was
+— but not in the direction either of us assumed.
+
+`logs/agent_sdk_costs.jsonl` has recorded `wall_seconds` and per-stage cost **since
+2026-04-26**, and no recorded run exceeds **15.4 minutes**; four of the five are under 5. The
+"~$1 and ~35 minutes" in `docs/HANDOFF.md` and the runbook was folklore contradicted by the
+repo's own data. **The instrument existed and went unread** while its contradiction was
+repeated in two documents — and this session quoted it back to the owner and defended it
+before checking. That is the `defect-prevention` surface-reading class again, in a session
+that had just added an entry to it.
+
+The real finding is underneath. A run started 2026-08-01 blew past every recorded figure, and
+the log says why:
+
+```
+WARNING src.agent_sdk.hero_author: Hero attempt 1/2 timed out after 600s
+```
+
+`hero_author.py`: `_DRAW_TIMEOUT_S = 600`, `_MAX_STRUCTURAL_ATTEMPTS = 2`,
+`_MAX_CRITIQUE_RETRIES = 1` → **2 redraws × 2 attempts × 600s = 40 minutes of hero drawing
+alone**, before critique (2 × 180s). A *successful* draw is measured at 454s. So the pipeline
+has two utterly different durations — ~4 minutes when the hero lands first try, up to ~46
+when it does not — and the ledger cannot distinguish them, because the hero sits inside
+`stage3_seconds` with no sub-timing.
+
+The constants are not arbitrary; the comments record that 240s and $0.40 were "each
+independently fatal". The problem is not the ceiling, it is that **a 10× duration swing is
+invisible in the only place anyone would look for it.**
+
+- [ ] Record hero draw seconds, attempt count and timeout count as their own ledger fields
+- [ ] Decide whether a timed-out first attempt should retry at all, given the measured note
+      that "the critique does NOT converge" and each redraw "cost ~8 minutes and bought nothing"
+- [ ] Once attributable, state the honest range in the runbook: typical vs timeout path
+
+**Scope:** S. **Files:** `src/agent_sdk/hero_author.py`, `src/agent_sdk/pipeline.py`,
+`docs/keyless-pipeline-runbook.md`.
+
 ### B-036 · Badge validation has no implementation — decide whether to restore it
 
 **Opened 2026-07-31**, found by B-031 doing its job.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -27,7 +27,18 @@ python scripts/html_to_brief.py ~/Downloads/conversation.html --slug ai-code-rev
 IS_SANDBOX=1 python -m src.agent_sdk.pipeline "<topic>" --brief docs/research/ai-code-review.md
 ```
 
-~$1 and ~35 minutes for the run. Then **deploy to review, never straight to `_posts/`** — see
+**Cost and duration, from the ledger rather than from memory.** `logs/agent_sdk_costs.jsonl`
+records `wall_seconds` and per-stage cost for every run and has since April. Across the five
+recorded runs: **3.4–15.4 minutes, $0.25–$1.31**. Only one exceeded 5 minutes, and that one
+spent $0.88 of its $1.31 on live research, which `--brief` skips entirely. The figure this
+file used to quote — "~$1 and ~35 minutes" — was folklore contradicted by the repo's own
+data; a 2026-08-01 session repeated it back to the owner before checking. Read the ledger:
+
+```bash
+.venv/bin/python -c "import json;[print(r['timestamp'][:10], round(r['wall_seconds']/60,1),'min', '\$'+str(round(r['total_cost_usd'],2))) for r in map(json.loads, open('logs/agent_sdk_costs.jsonl'))]"
+```
+
+Then **deploy to review, never straight to `_posts/`** — see
 the publishing section below. `--mode` is required (B-028).
 
 **Why it is a converter and not a claim-extractor**, so a fresh session does not re-derive it:

--- a/docs/evals/review-gate/README.md
+++ b/docs/evals/review-gate/README.md
@@ -1,0 +1,53 @@
+# Review-gate calibration cases (B-040)
+
+Ground truth for `skills/blog-post-review`. Each file is one case: a passage, the gate it
+tests, the verdict a domain expert would reach, and why.
+
+**Spec:** `docs/specs/review-gate-calibration.md`. **Runner:** not built yet — these accrue
+first, deliberately (see the spec's sequencing section). Adding cases costs nothing and is
+the input the harness design depends on.
+
+## The rules that make this a calibration set rather than a pile of examples
+
+1. **Every case comes from a real article or a real review finding.** `source:` records
+   which. An invented case measures the imagination of whoever wrote it.
+2. **Roughly half must be negatives** — correct passages the gate must *not* flag. A set
+   containing only real defects optimises a one-sided detector that looks excellent right up
+   until it blocks everything. `expected: pass` cases are the ones that catch that, and they
+   are the half the evidence base started with almost none of.
+3. **Two domain experts must reach the same verdict independently.** If a case is arguable,
+   it is noise in the metric, not a hard case. Cut it or sharpen it.
+4. **`why:` is not optional.** A verdict without a reason cannot be re-adjudicated when the
+   rubric changes, which is the whole point of keeping them.
+
+## Where these came from
+
+**`review-queue-throughput-tax`** — the 2026-07-29 review that produced ADR-0018: BLOCK at
+51/100 on ten fidelity defects, against 88% PASS from the deterministic evaluator. Includes
+the one labelled *near-false-positive*: a summarised fetch of the Graphite source would have
+reported a false G2 failure on a figure that is correct and is Graphite's own published
+number. That case is worth more than any of the true positives, because false positives are
+what block promotion to blocking.
+
+**`testing-shortcuts-migration-deadline`** — generated 2026-08-01 from an owner artifact that
+contained **zero citations**. The writer sourced the piece itself and fabricated freely; the
+deterministic evaluator scored it **76** and the publication validator **passed** it. It
+reproduced ADR-0018's chart finding exactly, one day after the ADR was accepted. Unplanned,
+and better material than anything designed on purpose.
+
+## Format
+
+```yaml
+id: g2-baseline-measures-something-else   # kebab-case, gate-prefixed, unique
+gate: G2                                  # G1..G5, or a rubric dimension name
+expected: fail                            # fail | pass | unverified
+source: review-queue-throughput-tax       # provenance — never "invented"
+passage: >-
+  The verbatim text under review.
+why: >-
+  What a domain expert would say, in one or two sentences.
+```
+
+`unverified` exists because of the spec's second open question: a G1 case where the source is
+real but unreachable at review time is neither a clean pass nor a clean fail, and folding it
+either way distorts the false-positive rate.

--- a/docs/evals/review-gate/cases/g1-references-carry-no-locators.yaml
+++ b/docs/evals/review-gate/cases/g1-references-carry-no-locators.yaml
@@ -1,0 +1,16 @@
+id: g1-references-carry-no-locators
+gate: G1
+expected: fail
+source: testing-shortcuts-migration-deadline
+passage: >-
+  ## References
+  1. TSB Bank PLC. Annual Report and Accounts 2018. TSB Banking Group, 2019.
+  2. Capers Jones. Software Assessments, Benchmarks, and Best Practices.
+     Addison-Wesley Professional, 2010.
+  3. Nicole Forsgren, Jez Humble, and Gene Kim. Accelerate. IT Revolution Press, 2018.
+why: >-
+  Three references, zero URLs or DOIs. Each names a real work, so this is not
+  fabrication, but nothing here resolves to a locatable document without the reader
+  doing the search themselves — which is what G1 exists to prevent. The publication
+  year on the Jones title should also be checked; that edition is widely catalogued
+  as 2000, not 2010.

--- a/docs/evals/review-gate/cases/g2-chart-shows-something-other-than-claimed.yaml
+++ b/docs/evals/review-gate/cases/g2-chart-shows-something-other-than-claimed.yaml
@@ -1,0 +1,14 @@
+id: g2-chart-shows-something-other-than-claimed
+gate: G2
+expected: fail
+source: testing-shortcuts-migration-deadline
+passage: >-
+  As the chart below illustrates, undetected defects do not flow linearly into
+  rework. They accumulate across integration layers until a critical threshold
+  triggers systemic production failures.
+why: >-
+  The chart is a static four-bar comparison of rework share by test-coverage level.
+  It contains no time axis, no accumulation, no threshold and no non-linearity, so
+  it cannot illustrate any of the three properties the sentence attributes to it.
+  This is ADR-0018's chart finding reproduced exactly — "a chart referenced as
+  showing figures it does not contain" — one day after that ADR was accepted.

--- a/docs/evals/review-gate/cases/g2-invented-programme-scale.yaml
+++ b/docs/evals/review-gate/cases/g2-invented-programme-scale.yaml
@@ -1,0 +1,13 @@
+id: g2-invented-programme-scale
+gate: G2
+expected: fail
+source: testing-shortcuts-migration-deadline
+passage: >-
+  On a programme staffed by several hundred engineers, an unplanned rework load
+  absorbing forty percent of development capacity is the equivalent of losing more
+  than a hundred engineers mid-sprint.
+why: >-
+  The 40% is faithful to the brief. The programme size is not — nothing in the brief
+  or the references establishes "several hundred engineers", and the arithmetic that
+  follows depends entirely on it. A correct calculation over an invented denominator
+  reads as evidence and is not.

--- a/docs/evals/review-gate/cases/g2-loop-description-is-faithful.yaml
+++ b/docs/evals/review-gate/cases/g2-loop-description-is-faithful.yaml
@@ -1,0 +1,17 @@
+id: g2-loop-description-is-faithful
+gate: G2
+expected: pass
+source: testing-shortcuts-migration-deadline
+passage: >-
+  When schedule pressure rises, the first sacrifice is almost invariably testing and
+  automation effort. Fewer test gates create an immediate perception of higher
+  feature velocity, which registers in sprint reviews as migration progress, which
+  briefly relieves the schedule pressure that triggered the cut. Formal causal loop
+  analysis labels this Loop B1 — a balancing loop that delivers genuine, if
+  temporary, relief.
+why: >-
+  A NEGATIVE case. This is a faithful restatement of the source brief's Loop B1,
+  including its polarity and its "short-term illusion" framing, adding no quantities
+  and no attribution. A gate that flags this is over-firing on unquantified
+  reasoning, which is exactly the false positive that would make the gate unusable
+  as a blocker.

--- a/docs/evals/review-gate/cases/g2-motive-attributed-to-a-named-executive.yaml
+++ b/docs/evals/review-gate/cases/g2-motive-attributed-to-a-named-executive.yaml
@@ -1,0 +1,14 @@
+id: g2-motive-attributed-to-a-named-executive
+gate: G2
+expected: fail
+source: testing-shortcuts-migration-deadline
+passage: >-
+  TSB Bank's chief executive Paul Pester ran precisely this playbook in April 2018,
+  accelerating a platform migration onto Sabadell's new core banking system over a
+  single weekend.
+why: >-
+  The verifiable facts are right — TSB, Pester, Sabadell, the April 2018 weekend
+  cutover. The claim attached to them is not: "ran precisely this playbook" asserts
+  that testing was cut for schedule velocity, and the cited source (TSB's Annual
+  Report and Accounts 2018) does not support that motive. A real, named person
+  carrying an unsupportable attribution is the most damaging shape this defect takes.

--- a/docs/evals/review-gate/cases/g4-fabricated-chart-figures.yaml
+++ b/docs/evals/review-gate/cases/g4-fabricated-chart-figures.yaml
@@ -1,0 +1,15 @@
+id: g4-fabricated-chart-figures
+gate: G4
+expected: fail
+source: testing-shortcuts-migration-deadline
+passage: >-
+  Chart "The rework tax — engineering capacity consumed by defect rework, by
+  test-coverage level": No test automation 62%, Manual tests only 46%,
+  Unit tests only 28%, Full test pyramid 12%.
+why: >-
+  All four figures are invented. The research brief this article was written from
+  contained exactly one number ("up to 40% of engineering capacity") and no
+  citations at all; none of the three references reports capacity-by-coverage-level
+  data. The chart presents fabricated values with an axis and a measured-sounding
+  subtitle. This is the highest-severity class: a reader cannot distinguish it from
+  a real dataset.

--- a/docs/evals/review-gate/cases/g4-fabricated-sprint-ratio.yaml
+++ b/docs/evals/review-gate/cases/g4-fabricated-sprint-ratio.yaml
@@ -1,0 +1,14 @@
+id: g4-fabricated-sprint-ratio
+gate: G4
+expected: fail
+source: testing-shortcuts-migration-deadline
+passage: >-
+  A programme that cuts two sprints of testing to capture perceived velocity
+  typically surrenders six to eight sprints of migration progress to the rework
+  spiral that follows.
+why: >-
+  No source in the article, and nothing in the brief, supports a 2-to-6-or-8 sprint
+  ratio. "Typically" asserts a distribution over programmes that no cited work
+  reports. The surrounding paragraph cites Capers Jones for a 10-20x defect-cost
+  multiplier, which is a different quantity entirely and cannot be transformed into
+  this one.

--- a/docs/evals/review-gate/cases/g5-the-brief-carried-no-datable-citations.yaml
+++ b/docs/evals/review-gate/cases/g5-the-brief-carried-no-datable-citations.yaml
@@ -1,0 +1,18 @@
+id: g5-the-brief-carried-no-datable-citations
+gate: G5
+expected: pass
+source: testing-shortcuts-migration-deadline
+passage: >-
+  Nicole Forsgren, Jez Humble, and Gene Kim's Accelerate research, which analysed
+  survey data from more than 2,000 technology teams across four years, found that
+  high-performing engineering teams invest consistently in comprehensive automated
+  testing.
+why: >-
+  A NEGATIVE case for G5 specifically. Accelerate (2018) is a book, not an annually
+  re-run report, so there is no later edition from the same publisher revising the
+  finding — the DORA reports that succeeded it are a different publication line.
+  G5 must not fire merely because a citation is old; supersession is the test, not
+  age. Note this case is a G5 pass while the same passage's "2,000 technology teams"
+  is a separate, weaker G2 question (the usual figure is ~23,000 responses across
+  ~2,000 organisations) — kept apart deliberately, per the guide's one-judge-per-
+  dimension rule.

--- a/docs/keyless-pipeline-runbook.md
+++ b/docs/keyless-pipeline-runbook.md
@@ -62,6 +62,39 @@ stripped automatically). **This is opt-in and heavy** — one deep-research run 
 ~2M tokens and can hit your session limit — so `claude_web` stays the everyday
 default; reserve `--brief` for the pieces that warrant it.
 
+### ⚠ `--brief` with an uncited artifact will manufacture citations
+
+**Measured 2026-08-01, on the first real B-038 run.** The brief was converted from an owner
+research artifact that contained **zero `<a href>` and one unsourced statistic**. `--brief`
+skips the research step, so the writer received an argument with no evidence — and filled the
+gap itself. The article came back with:
+
+- a chart carrying **four invented percentages** (62/46/28/12%) presented with an axis and a
+  measured-sounding subtitle, where the brief had contained exactly one number;
+- prose describing that chart as showing accumulation and a threshold it does not plot —
+  ADR-0018's chart finding reproduced exactly, one day after that ADR was accepted;
+- a **named real executive** given a motive the cited annual report cannot support;
+- a fabricated ratio ("cuts two sprints … *typically* surrenders six to eight");
+- three references, **zero URLs**.
+
+`article_evaluator` scored it **76** and the publication validator **passed** it, because
+counting checks can see "chart embedded: yes" and "3 references cited" and nothing further.
+That is the 88%-vs-51 gap of ADR-0018, live.
+
+**The tool did what it was asked.** The defect is upstream: an artifact with no evidence is
+not a research brief, it is an argument. Before running `--brief`:
+
+```bash
+grep -c 'href=' <artifact>.html      # zero links is the warning sign
+grep -c '](http' docs/research/<slug>.md   # and in the converted brief
+```
+
+If that returns 0, either add sources to the artifact first — `docs/research/artifact-sourcing-prompt.md`
+is a prompt to paste back into the conversation that produced it — or expect to review the
+output as fabrication-until-proven-otherwise. **Never publish such a run without the
+`blog-post-review` gate.** The eight labelled defects from this run are now calibration cases
+in `docs/evals/review-gate/cases/` (B-040).
+
 ### What a run actually costs — read the ledger, do not quote a remembered figure
 
 `logs/agent_sdk_costs.jsonl` records `wall_seconds`, `stage3_seconds` and per-stage cost for

--- a/docs/keyless-pipeline-runbook.md
+++ b/docs/keyless-pipeline-runbook.md
@@ -62,6 +62,27 @@ stripped automatically). **This is opt-in and heavy** — one deep-research run 
 ~2M tokens and can hit your session limit — so `claude_web` stays the everyday
 default; reserve `--brief` for the pieces that warrant it.
 
+### What a run actually costs — read the ledger, do not quote a remembered figure
+
+`logs/agent_sdk_costs.jsonl` records `wall_seconds`, `stage3_seconds` and per-stage cost for
+every run, and has since 2026-04-26. Across the five recorded runs:
+
+| | Wall clock | Total cost | Research share |
+|---|---|---|---|
+| Range | **3.4 – 15.4 min** | **$0.25 – $1.31** | $0.00 – $0.88 |
+| Typical (`--brief`, research skipped) | 3.4 – 4.8 min | $0.25 – $0.49 | $0.00 |
+| The one live-research run | 15.4 min | $1.31 | $0.88 |
+
+```bash
+.venv/bin/python -c "import json;[print(r['timestamp'][:10], round(r['wall_seconds']/60,1),'min', '\$'+str(round(r['total_cost_usd'],2))) for r in map(json.loads, open('logs/agent_sdk_costs.jsonl'))]"
+```
+
+`docs/HANDOFF.md` and this runbook used to say "~$1 and ~35 minutes". No recorded run has
+ever come close to 35 minutes. A 2026-08-01 session quoted that number back to the owner and
+defended it before checking the ledger sitting in `logs/`. **The instrument existed; nobody
+read it.** That is a worse failure than not measuring, because the folklore number is the one
+everybody repeats. If a run feels slow, add its row and compare — do not estimate.
+
 ## 2. Publish (keyless — free GitHub token, opens a PR you review)
 
 ```bash
@@ -81,8 +102,8 @@ token needs only `Contents` + `Pull requests` write on `oviney/blog` — no AI k
 |-------|-----------|------------|
 | Research | `claude_web` → `query()` + WebSearch/WebFetch | none (subscription) |
 | Writer + Graphics | Stage 3 `query()` | none (subscription) |
-| Hero image | skipped in `chart_only` | none |
-| Vision alt/caption | not invoked in `chart_only` (hero only) | none (subscription) |
+| Hero image | Stage 3 draws it as SVG itself (B-016b) | none (subscription) |
+| Vision alt/caption | Stage 3 `query()` over the drawn hero | none (subscription) |
 | Quality gates + validator | deterministic Python | none |
 
 ## Honest limitations

--- a/docs/research/artifact-sourcing-prompt.md
+++ b/docs/research/artifact-sourcing-prompt.md
@@ -1,0 +1,98 @@
+# Prompt: make a research artifact citable before it becomes a brief
+
+Paste this back into the **same Claude.ai conversation that produced the HTML artifact**, so
+it still has the argument in context. It asks for the same analysis re-emitted with resolvable
+sources attached, rather than a fresh piece of research.
+
+## Why this exists
+
+Measured on 2026-08-01, the first real B-038 run. The artifact
+(`sre-quality-governance-guide.html`) contained **zero `<a href>` and one unsourced
+statistic**. `--brief` skips the research step, so the writer received an argument with no
+evidence and supplied its own: a chart with four invented percentages, prose describing that
+chart as showing something it does not plot, a named real executive given a motive his
+company's annual report cannot support, and three references with no URLs. The deterministic
+evaluator scored it 76 and the publication validator passed it.
+
+The generator was not at fault. **An artifact with no evidence is an argument, not a research
+brief**, and the pipeline cannot tell the difference. Fixing it downstream means catching
+fabrication after it happens; fixing it here means it never happens.
+
+The five constraints below are the `blog-post-review` gates (G1–G5, `skills/blog-post-review/`)
+stated as authoring instructions. An artifact that satisfies them arrives at the review stage
+already able to pass it.
+
+---
+
+## The prompt
+
+> This artifact is going to become the research brief for a published article, and every
+> claim in it will be checked against its source by an adversarial reviewer. Right now it
+> cannot survive that, because it carries no citations — so anything downstream that needs
+> evidence will invent it.
+>
+> Re-emit this artifact with sources attached. **Keep the analysis as it is** — the structure,
+> the argument, the loops, the conclusions. I am not asking you to re-research the topic or
+> change your mind about it. I am asking you to show your evidence, and to be explicit about
+> where there isn't any.
+>
+> For every claim that carries weight, attach a **resolvable URL** — a primary source where
+> one exists (the study, the report, the filing, the docs), not a secondary write-up about it.
+> Then hold each one to these five rules:
+>
+> 1. **It resolves.** Every statistic, percentage, dollar figure, dated event and named study
+>    links to a document I can open. A citation I have to go and find is not a citation.
+> 2. **It says what I say it says.** The source must support *that specific claim*, at that
+>    scope and sample. If a figure comes with an offsetting clause — "X rose 25%, but Y fell"
+>    — quote both halves. Dropping the second half is the single most common way a true
+>    sentence becomes a false one.
+> 3. **The arithmetic is shown.** Any calculation, ratio, extrapolation or cost model: show
+>    the working and state the denominator. Don't assert that it checks out.
+> 4. **Nothing is invented.** No quotes, people, companies, studies or metrics that cannot be
+>    distinguished from real ones. **If you cannot source something, do not drop it and do not
+>    soften it into a vaguer version of itself** — keep the claim and mark it unsourced. That
+>    is far more useful to me than a confident sentence I have to catch later.
+> 5. **It is still current.** For anything from a publication that re-runs — annual reports,
+>    industry surveys, vendor benchmarks, DORA, Stack Overflow — check whether a later edition
+>    revises, reverses or narrows the finding, and cite the latest. Say so if it changed.
+>
+> Two things I need in addition to the prose:
+>
+> **A short table of real, sourced figures suitable for one chart** — three to six rows,
+> each with its number, what it measures, and its source URL. If no such data exists for this
+> topic, **say that plainly instead of assembling something plausible.** An honest "there is no
+> quantitative dataset behind this argument" is a useful finding; a fabricated chart is the
+> worst thing you can hand me.
+>
+> **A final section titled "Unsourced — do not publish as fact"**, listing every claim you
+> could not attach a source to, including any that are load-bearing. Do not quietly delete
+> them; I would rather know the argument rests on them.
+>
+> Output the whole thing as a single HTML artifact, as before.
+
+---
+
+## What to do with the result
+
+```bash
+# 1. Save the new artifact (samples are gitignored — local only)
+mv ~/Downloads/<file>.html docs/research/samples/<topic>.html
+
+# 2. Convert
+python scripts/html_to_brief.py docs/research/samples/<topic>.html --slug <slug> --force
+
+# 3. Check it actually has sources now — this is the whole point
+grep -c '](http' docs/research/<slug>.md      # expect > 0
+
+# 4. Move the "Unsourced" section under the brief's own `## Refuted / unverified`
+#    heading. load_brief_file strips everything from that heading to EOF, so those
+#    claims are excluded by construction rather than by the writer's discretion.
+#    The converter demotes source headings by one level, so the artifact's own
+#    heading will NOT be stripped automatically — this move is manual and deliberate.
+
+# 5. Generate
+python -m src.agent_sdk.pipeline "<topic>" --brief docs/research/<slug>.md
+```
+
+Then deploy to review — never straight to `_posts/` — per the publishing workflow in
+`CLAUDE.md`.

--- a/docs/research/samples/README.md
+++ b/docs/research/samples/README.md
@@ -17,6 +17,21 @@ docs/research/samples/platform-eng-adoption.html
 
 Nothing else needs to change. The converter and its tests discover whatever is here.
 
+## Check it has sources before you run the pipeline on it
+
+**Measured 2026-08-01:** an artifact here with zero `<a href>` produced an article with a
+fabricated chart, an unsupportable attribution to a named executive, and three reference
+entries carrying no URLs — because `--brief` skips research, so the writer had no evidence and
+supplied its own. The deterministic evaluator scored it 76 and passed it.
+
+```bash
+grep -c 'href=' docs/research/samples/<file>.html   # zero is the warning sign
+```
+
+If it returns 0, paste `docs/research/artifact-sourcing-prompt.md` back into the conversation
+that produced the artifact and re-export. An artifact with no evidence is an argument, not a
+research brief, and nothing downstream can tell the difference.
+
 ## Why real samples, not invented ones
 
 The tests can run on synthetic fixtures, and v1 ships with three (headings-and-prose,

--- a/docs/specs/review-gate-calibration.md
+++ b/docs/specs/review-gate-calibration.md
@@ -1,0 +1,243 @@
+# Spec — Calibrating the editorial review gate (B-040)
+
+**Status:** DRAFT — awaiting owner LGTM · **Opened:** 2026-08-01
+**Blocks:** ADR-0018 Decision 3 (advisory → blocking)
+**Reference:** [Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents) (Anthropic, engineering blog)
+
+## Objective
+
+ADR-0018 adopted `skills/blog-post-review` and deliberately kept it **advisory**:
+
+> Run the gate in advisory mode first, blocking later. … It does not automatically block a
+> publish until calibration data exists. … Promote to blocking once a false-positive rate is
+> known.
+
+**Nothing has ever produced that number.** The gate has been executed exactly once, by hand,
+on one article. So the most capable instrument in the pipeline — the only one that catches
+fidelity defects the deterministic evaluator provably cannot — is frozen in advisory mode by
+a measurement nobody has taken.
+
+This spec defines that measurement. **It is not a plan to make the gate blocking.** It
+produces the evidence that decision needs; the decision stays the owner's.
+
+### Why this and not something else
+
+Reviewing the repo against the Anthropic evals guide, the eval surface is lopsided in a
+specific way:
+
+| Guide's requirement | This repo |
+|---|---|
+| Code-based graders | **Strong** — `article_evaluator` (5 dimensions, 841 records), `publication_validator`, `_shared.py` gates, `skill_eval` |
+| Model-based grader | Exists — `blog-post-review`, 5 gates + 6 weighted dimensions |
+| "LLM-as-judge graders should be closely calibrated with human experts" | **Absent.** n=1, and that run contained a near-false-positive |
+| A fixed eval set with known verdicts | **Absent.** `logs/article_evals.json` is 841 rows of *production monitoring*, not an eval set |
+| Balanced positive **and** negative cases | Present in exactly one file (`skills/economist-writing/eval.yaml`) |
+| Capability vs regression evals | Not distinguished |
+
+The gap is not "we need more graders". It is that the one judgment-based grader has no ground
+truth to be checked against, so it cannot be trusted, improved, or promoted.
+
+## What "calibration" means here, precisely
+
+Not "does the rubric score articles well." That is unfalsifiable. Calibration is **agreement
+between the rubric's verdict and the owner's verdict, per gate, on the same input.**
+
+Ground truth is the owner's judgement. The guide is explicit that human graders establish
+ground truth and that model graders must be checked against them — a rubric cannot calibrate
+itself, and an LLM cannot supply the ground truth for an LLM judge (that is the ADR-0018
+failure mode one level up).
+
+Two numbers come out, and they are not symmetric in cost:
+
+- **False-positive rate** — the gate fails something the owner would have passed. This is the
+  number ADR-0018 blocks on, because a blocking gate with false positives stops good articles
+  and trains the owner to override it, which destroys the gate.
+- **False-negative rate** — the gate passes something the owner would have failed. Cheaper
+  today, because a human still approves every publish. It becomes the important number only
+  *after* promotion to blocking.
+
+## Design
+
+### The unit of work is a finding, not an article
+
+This is the load-bearing design decision. The obvious approach — collect 20–50 articles with
+verdicts — is not available: the repo has 2 generated articles and 26 published ones, and
+producing more costs a pipeline run each.
+
+But the guide's actual instruction is **"20-50 simple tasks drawn from real failures"** — and
+real failures already exist at finding granularity:
+
+- **10 labelled fidelity defects** from the one real review (ADR-0018 enumerates them: a
+  9-hour baseline described as measuring something it does not, a predictor attributed to a
+  ranking that does not contain it, an organisation-level conclusion imported into a paper
+  reporting no organisation-level outcome, a statistic with its offsetting clause deleted, a
+  chart referenced as showing figures it does not contain, …)
+- **1 labelled near-false-positive** — the summarised Graphite fetch that would have produced
+  a false G2 failure on a figure that is correct and is Graphite's own published number. This
+  one case is worth more than the ten positives, because it is the only direct evidence about
+  the failure mode that actually blocks promotion.
+
+Each becomes a case: **passage + gate + expected verdict + why**. A case is small, unambiguous
+and cheap, and one article yields ten of them.
+
+### Balance is not optional
+
+The guide's web-search example makes the point: a set containing only cases where the agent
+*should* fire optimises a one-sided detector. A gate evaluated only on real defects will
+appear excellent right up until it blocks everything.
+
+So roughly **half the set must be negatives** — correct passages, mined from the 26 published
+articles, where the expected verdict is *pass*. These are the cases that detect an over-eager
+judge, and they are the ones today's evidence base has exactly one of.
+
+Target: **~25 cases, ~10 positive / ~15 negative.** The guide notes small sets suffice early
+because effect sizes are large. Twenty-five is enough to distinguish "fires on nothing" from
+"fires on everything"; it is not enough for a confidence interval, and the report must say so.
+
+### Isolated judge per gate
+
+The guide recommends grading "each dimension with an isolated LLM-as-judge rather than using
+one to grade all dimensions." `REVIEW_PROMPT.md` currently grades 5 gates and 6 weighted
+dimensions in one 99-line pass.
+
+**v1 does not change the rubric.** It runs the gate **as accepted on 2026-07-31**, so the
+baseline measures the artefact the owner approved. Splitting into isolated per-gate judges is
+a *second* experiment, run against that baseline, and it is the natural first use of the
+harness rather than a precondition for it. Changing the instrument and measuring it in the
+same step would leave neither result interpretable.
+
+### Deterministic where possible, model-based where necessary
+
+Case selection, bookkeeping, agreement arithmetic and the report are plain Python — no LLM.
+The judge is the only model-based component, invoked keyless via the Agent SDK per Operating
+Constraint #3. This keeps the harness re-runnable at zero marginal cost, which is the
+property that decides whether it gets run twice.
+
+## Commands
+
+```bash
+# Run the whole calibration set and write a report
+python scripts/calibrate_review_gate.py --cases docs/evals/review-gate/ --out logs/review_gate_calibration.json
+
+# Re-run a single gate's cases while iterating on the rubric
+python scripts/calibrate_review_gate.py --gate G5
+
+# Report only, from the last run (no model calls)
+python scripts/calibrate_review_gate.py --report
+```
+
+## Project structure
+
+```
+docs/evals/review-gate/cases/*.yaml   # one file per case: passage, gate, expected, why
+docs/evals/review-gate/README.md      # how to add a case; the balance rule
+scripts/calibrate_review_gate.py      # runner + agreement arithmetic + report
+tests/test_calibrate_review_gate.py   # tests of the harness, with the judge stubbed
+logs/review_gate_calibration.json     # append-only; one row per calibration run
+```
+
+Case format:
+
+```yaml
+id: g2-baseline-measures-something-else
+gate: G2
+expected: fail
+source: review-queue-throughput-tax   # provenance — a real failure, not an invention
+passage: >-
+  The 9-hour baseline shows review latency is dominated by queue depth.
+why: >-
+  The cited study's 9-hour figure measures time-to-first-comment, not total latency.
+  The claim overstates the source's scope. ADR-0018 finding 3.
+```
+
+## Testing strategy
+
+TDD per `agent-skills:test-driven-development`. `tests/test_calibrate_review_gate.py`,
+deterministic, **no model calls in the test suite** — the judge is stubbed, so the tests
+exercise the harness and the arithmetic, not Claude:
+
+- Agreement arithmetic is correct for hand-computed fixtures, including the degenerate cases
+  (all-pass, all-fail, empty)
+- False-positive and false-negative rates are reported **separately**, never averaged into a
+  single "accuracy" that hides which direction the gate errs in
+- A case file missing `expected` or `why` is rejected loudly rather than skipped
+- The set's positive/negative balance is reported on every run, so drifting to one-sided is
+  visible
+- `n` is reported alongside every rate; a rate from fewer than 20 cases is labelled
+  provisional in the output itself
+- Re-running with the judge stubbed to a fixed verdict reproduces byte-identical arithmetic
+
+## Boundaries
+
+- **Always:** report false positives and false negatives separately, with `n`; keep case
+  provenance (a case is drawn from a real failure or a real published article, never invented);
+  keep the harness keyless and re-runnable.
+- **Ask first:** any change to `rubric.md` or `REVIEW_PROMPT.md` scoring — those are the
+  instrument under test, and ADR-0018 is one day old; promoting the gate to blocking.
+- **Never:** use an LLM to generate ground-truth verdicts (that is the failure mode this
+  measures); average the two error rates into one number; report a rate without `n`; let the
+  harness edit the rubric it is measuring.
+
+## Success criteria
+
+- [ ] `python scripts/calibrate_review_gate.py` runs the full set keyless and writes a report
+- [ ] The report states, separately and with `n`: false-positive rate, false-negative rate,
+      per-gate agreement, and the positive/negative balance of the set
+- [ ] ≥20 cases, ≥40% of them negatives, every one traceable to a real article or a real finding
+- [ ] The output is sufficient to answer ADR-0018 Decision 3 — i.e. the owner can read it and
+      decide promote / do not promote / fix the rubric first
+- [ ] `make ci-local` green; ≥80% coverage on the new module
+- [ ] No new dependency, no key, no network beyond the judge's own source fetching
+
+## Not in scope for v1
+
+- **pass@k / pass^k.** The guide positions these for mature agents measuring small
+  improvements. Five recorded pipeline runs and one gate execution is not that.
+- **Promoting the gate to blocking.** This produces the evidence; ADR-0018 Decision 3 stays
+  the owner's call.
+- **Splitting the rubric into isolated per-gate judges.** The obvious first experiment *after*
+  a baseline exists, not before.
+- **A dashboard.** `logs/review_gate_calibration.json` is append-only; reading it is a
+  one-liner. `skills/observability` already claims a `quality_dashboard.json` that does not
+  exist — adding a second unread artefact is the wrong direction.
+- **Re-measuring the deterministic evaluator.** The 88%-vs-51 spread is measured, documented
+  and accepted. Nothing further to learn.
+
+## Sequencing — why this is specced now and built later
+
+The harness design depends on data the repo does not yet have. If the gate BLOCKs everything,
+the useful work is threshold tuning. If it passes everything, ADR-0018's own warning applies —
+"scores clustering above 85 would mean the rubric is broken rather than the pipeline" — and
+the useful work is anchor revision. Those are different tools.
+
+**Build after n≈5 real reviews.** Those accrue for free: every article already goes to the
+unlisted review URL for owner approval (B-013 / B-028), so the only added cost is the owner
+recording, per gate, whether they agreed. One line per run. Shipping becomes data collection
+instead of a separate project.
+
+Until then this spec sits here, and the two prerequisites below ship immediately because
+waiting on them corrupts the data the baseline is made of.
+
+## Prerequisites shipped alongside this spec (2026-08-01)
+
+1. **G5 added to the machine-readable verdict block in `REVIEW_PROMPT.md` and the rubric
+   card.** ADR-0018 Decision 2 states G5 was amended "into the machine-readable verdict
+   block"; it reached `SKILL.md:165` but **not** `REVIEW_PROMPT.md:85`, which is the file
+   actually pasted into a review session. Every review run until now would have silently
+   dropped G5's result — the gate that exists precisely because a reversed DORA statistic
+   passed the other four.
+2. **The runbook's cost/duration figures replaced with the recorded range.** `HANDOFF.md` and
+   the runbook said "~$1 and ~35 minutes"; `logs/agent_sdk_costs.jsonl` has recorded
+   `wall_seconds` per run since April and no run has exceeded **15.4 minutes**. The instrument
+   existed and went unread while its folklore contradiction got repeated in two documents.
+
+## Open questions
+
+1. **Who writes the negative cases?** Mining ~15 correct passages from the 26 published
+   articles is mechanical but needs judgement about what "correct" means. Proposed: the agent
+   drafts them with provenance, the owner spot-checks a sample rather than all fifteen.
+2. **Does a G1 UNVERIFIED count as a false positive** when the source is real but unreachable
+   at review time? The rubric says "unverified is not false, but this blog cannot ship an
+   unverified number" — defensible as policy, but it will inflate the false-positive rate
+   against a human who would fetch the source a second time. Proposed: count it as a distinct
+   third outcome, `unverified`, and report it separately rather than folding it either way.

--- a/skills/blog-post-review/REVIEW_PROMPT.md
+++ b/skills/blog-post-review/REVIEW_PROMPT.md
@@ -82,7 +82,7 @@ Then a fenced JSON block so the pipeline can gate automatically:
 {
   "verdict": "",
   "weighted_score": 0,
-  "gates": {"G1": "", "G2": "", "G3": "", "G4": ""},
+  "gates": {"G1": "", "G2": "", "G3": "", "G4": "", "G5": ""},
   "dimensions": {"evidence": 0, "falsifiability": 0, "thesis": 0, "actionability": 0, "voice": 0, "craft": 0},
   "blocking_findings": [],
   "reviewer_confidence_pct": 0

--- a/skills/blog-post-review/rubric-card.html
+++ b/skills/blog-post-review/rubric-card.html
@@ -187,6 +187,11 @@
         <div class="nm">No fabrication</div>
         <div class="fw">No invented quotes, people, companies, metrics, or studies. Indistinguishable counts as invented.</div>
       </div>
+      <div class="gate">
+        <div class="id">G5</div>
+        <div class="nm">Evidence currency</div>
+        <div class="fw">Per claim, not per reference list: has the same publisher since revised, reversed, or narrowed the finding the argument rests on?</div>
+      </div>
     </div>
     <p class="stripnote">One gate failure blocks publication regardless of weighted score</p>
   </section>

--- a/src/agent_sdk/hero_author.py
+++ b/src/agent_sdk/hero_author.py
@@ -30,6 +30,7 @@ import asyncio
 import json
 import logging
 import re
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -64,6 +65,39 @@ _MAX_CRITIQUE_RETRIES = 1
 #: 240s, $0.40) were each independently fatal.
 _DRAW_TIMEOUT_S = 600
 _CRITIQUE_TIMEOUT_S = 180
+
+#: B-041: the ceiling above bounds a *call*. Nothing bounded the hero. Composed,
+#: the loops permitted ``2 redraws x 2 structural attempts x 600s`` = **40 minutes
+#: of drawing** before critique — against a measured successful draw of 454s and a
+#: longest-ever whole-pipeline run of 15.4 minutes. A run on 2026-08-01 hit that
+#: path live and was still going at 27 minutes.
+#:
+#: The 2026-08-01 run settled what a retry after a timeout is worth: attempt 1
+#: timed out at 600s, attempt 2 — carrying the "return a simpler drawing with
+#: fewer, larger shapes" instruction — **also timed out at 600s**, and the run
+#: produced no hero at all. Twenty minutes, nothing to show, and an article the
+#: blog cannot publish because ``image:`` is required.
+#:
+#: So the ceiling is set to make that second full-price attempt impossible rather
+#: than merely capped: 900s is one measured successful draw (454s) plus its
+#: critique (180s) plus slack, and equals the longest *complete* pipeline run ever
+#: recorded. Failure now costs 600s and stops.
+_HERO_TOTAL_BUDGET_S = 900
+
+#: No observed successful draw has ever completed in under 454s. Beginning one
+#: with less than this remaining buys a guaranteed timeout at full price, so the
+#: floor sits just under the measurement.
+#:
+#: This is what separates the two retry cases, and the distinction is the whole
+#: fix: a *rejected* attempt returns quickly and leaves plenty of budget, so it is
+#: retried as before. A *timed-out* attempt has consumed 600s by definition,
+#: leaving 300s — below this floor — so it is not retried. Cheap signal, retry;
+#: expensive silence, stop.
+_MIN_USEFUL_DRAW_S = 450
+
+#: Indirection so the budget is testable with a fake clock instead of by waiting
+#: twenty minutes for the thing it exists to prevent.
+_now = time.monotonic
 
 #: Thinking consumes turns, so a one-turn cap fails with "Reached maximum number
 #: of turns (1)" before any text arrives. Measured working value: 3.
@@ -167,12 +201,20 @@ class HeroResult:
             which includes the case where the critique could not run at all.
         error: Why no hero exists. Empty when ``path`` is set.
         cost_usd: Total subscription cost of the attempts.
+        seconds: Wall clock spent on the whole hero — B-041. Without it a 10x
+            duration swing hides inside ``stage3_seconds``.
+        attempts: Drawing calls made, including ones that timed out.
+        timeouts: How many of those attempts hit their allowance. A run with
+            ``timeouts > 0`` is on the expensive path and should be read as such.
     """
 
     path: Path | None
     critique: str = ""
     error: str = ""
     cost_usd: float = 0.0
+    seconds: float = 0.0
+    attempts: int = 0
+    timeouts: int = 0
 
 
 def _extract_svg(text: str) -> str:
@@ -200,8 +242,13 @@ def _parse_verdict(text: str) -> list[str]:
     return [str(d).strip() for d in defects if str(d).strip()]
 
 
-async def _draw(prompt: str, model: str) -> tuple[str, float]:
-    """One bounded drawing call. Raises on timeout so the caller can retry."""
+async def _draw(prompt: str, model: str, *, timeout: float) -> tuple[str, float]:
+    """One bounded drawing call. Raises on timeout so the caller can retry.
+
+    ``timeout`` is whatever the hero's remaining budget allows, never simply
+    ``_DRAW_TIMEOUT_S`` — that constant bounds a call, and B-041 was about the
+    aggregate.
+    """
     return await asyncio.wait_for(
         _collect_text(
             prompt,
@@ -210,8 +257,113 @@ async def _draw(prompt: str, model: str) -> tuple[str, float]:
             max_turns=_DRAW_MAX_TURNS,
             max_budget_usd=_DRAW_BUDGET_USD,
         ),
-        timeout=_DRAW_TIMEOUT_S,
+        timeout=timeout,
     )
+
+
+@dataclass
+class _Budget:
+    """The aggregate wall-clock ceiling for one hero (B-041).
+
+    Every draw and critique spends from the same pot, so retries compose into a
+    bounded total instead of multiplying. Also carries the counters that make the
+    spend attributable afterwards — the swing was invisible before because the
+    hero sits inside ``stage3_seconds`` with no sub-timing.
+    """
+
+    started: float
+    attempts: int = 0
+    timeouts: int = 0
+
+    @property
+    def spent(self) -> float:
+        return _now() - self.started
+
+    @property
+    def remaining(self) -> float:
+        return _HERO_TOTAL_BUDGET_S - self.spent
+
+    def can_draw(self) -> bool:
+        """False when what is left cannot plausibly produce a drawing."""
+        return self.remaining >= _MIN_USEFUL_DRAW_S
+
+    def draw_timeout(self) -> float:
+        return min(_DRAW_TIMEOUT_S, self.remaining)
+
+
+async def _draw_valid_svg(
+    brief: str, carry_forward: str, model: str, budget: _Budget
+) -> tuple[str, str, float]:
+    """Draw until the structural gate accepts, attempts run out, or budget does.
+
+    Returns ``(svg, last_error, cost)``. An empty ``svg`` means no structurally
+    valid drawing was produced and ``last_error`` says why.
+    """
+    last_error = ""
+    cost = 0.0
+
+    for attempt in range(_MAX_STRUCTURAL_ATTEMPTS):
+        if not budget.can_draw():
+            last_error = (
+                f"hero budget exhausted after {budget.spent:.0f}s of "
+                f"{_HERO_TOTAL_BUDGET_S}s — not starting an attempt that cannot finish"
+            )
+            logger.warning("%s", last_error)
+            break
+
+        prompt = f"Draw the hero illustration.\n\n{brief}"
+        if carry_forward:
+            prompt += (
+                "\n\nA previous attempt was rejected for these composition "
+                f"faults — fix them specifically:\n{carry_forward}"
+            )
+        if last_error:
+            prompt += (
+                f"\n\nYour previous SVG failed validation: {last_error}\n"
+                "Return corrected SVG source only."
+            )
+
+        allowance = budget.draw_timeout()
+        budget.attempts += 1
+        try:
+            text, call_cost = await _draw(prompt, model, timeout=allowance)
+        except TimeoutError:
+            # Retryable: a stalled generation is not a reason to give up, but it
+            # must not hang. Shrink the ask on the way round.
+            budget.timeouts += 1
+            last_error = (
+                f"generation exceeded {allowance:.0f}s — return a simpler "
+                "drawing with fewer, larger shapes"
+            )
+            logger.warning(
+                "Hero attempt %s/%s timed out after %.0fs (%.0fs of %ss budget left)",
+                attempt + 1,
+                _MAX_STRUCTURAL_ATTEMPTS,
+                allowance,
+                max(budget.remaining, 0),
+                _HERO_TOTAL_BUDGET_S,
+            )
+            continue
+        except Exception as exc:  # noqa: BLE001 - degrade, never crash Stage 3
+            logger.warning("Hero authoring call failed: %s", exc)
+            return "", str(exc), cost
+        cost += call_cost
+
+        candidate = _extract_svg(text)
+        try:
+            check_hero_svg(candidate)
+        except HeroSvgError as exc:
+            last_error = str(exc)
+            logger.info(
+                "Hero attempt %s/%s rejected: %s",
+                attempt + 1,
+                _MAX_STRUCTURAL_ATTEMPTS,
+                last_error,
+            )
+            continue
+        return candidate, "", cost
+
+    return "", last_error, cost
 
 
 async def _author(brief: str, slug: str, images_dir: Path, model: str) -> HeroResult:
@@ -219,64 +371,39 @@ async def _author(brief: str, slug: str, images_dir: Path, model: str) -> HeroRe
     png_path = images_dir / f"{slug}-hero.preview.png"
     cost = 0.0
     carry_forward = ""
+    budget = _Budget(started=_now())
+
+    def done(**kwargs: object) -> HeroResult:
+        """Every exit reports the spend, so B-041's swing stays attributable."""
+        return HeroResult(
+            cost_usd=cost,
+            seconds=budget.spent,
+            attempts=budget.attempts,
+            timeouts=budget.timeouts,
+            **kwargs,  # type: ignore[arg-type]
+        )
 
     for redraw in range(_MAX_CRITIQUE_RETRIES + 1):
-        # ── structural loop ────────────────────────────────────────────
-        svg = ""
-        last_error = ""
-        for attempt in range(_MAX_STRUCTURAL_ATTEMPTS):
-            prompt = f"Draw the hero illustration.\n\n{brief}"
-            if carry_forward:
-                prompt += (
-                    "\n\nA previous attempt was rejected for these composition "
-                    f"faults — fix them specifically:\n{carry_forward}"
-                )
-            if last_error:
-                prompt += (
-                    f"\n\nYour previous SVG failed validation: {last_error}\n"
-                    "Return corrected SVG source only."
-                )
-            try:
-                text, call_cost = await _draw(prompt, model)
-            except TimeoutError:
-                # Retryable: a stalled generation is not a reason to give up, but
-                # it must not hang. Shrink the ask on the way round.
-                last_error = (
-                    f"generation exceeded {_DRAW_TIMEOUT_S}s — return a simpler "
-                    "drawing with fewer, larger shapes"
-                )
-                logger.warning(
-                    "Hero attempt %s/%s timed out after %ss",
-                    attempt + 1,
-                    _MAX_STRUCTURAL_ATTEMPTS,
-                    _DRAW_TIMEOUT_S,
-                )
-                continue
-            except Exception as exc:  # noqa: BLE001 - degrade, never crash Stage 3
-                logger.warning("Hero authoring call failed: %s", exc)
-                return HeroResult(path=None, error=str(exc), cost_usd=cost)
-            cost += call_cost
-
-            candidate = _extract_svg(text)
-            try:
-                check_hero_svg(candidate)
-            except HeroSvgError as exc:
-                last_error = str(exc)
-                logger.info(
-                    "Hero attempt %s/%s rejected: %s",
-                    attempt + 1,
-                    _MAX_STRUCTURAL_ATTEMPTS,
-                    last_error,
-                )
-                continue
-            svg = candidate
-            break
+        svg, last_error, call_cost = await _draw_valid_svg(
+            brief, carry_forward, model, budget
+        )
+        cost += call_cost
 
         if not svg:
-            return HeroResult(path=None, error=last_error, cost_usd=cost)
+            return done(path=None, error=last_error)
 
         images_dir.mkdir(parents=True, exist_ok=True)
         svg_path.write_text(svg)
+
+        # A hero is on disk and structurally valid. The critique is additional
+        # value, not a precondition, so it never spends past the ceiling.
+        if budget.remaining < _CRITIQUE_TIMEOUT_S:
+            logger.warning(
+                "Hero budget spent (%.0fs of %ss) — keeping the drawing, skipping critique",
+                budget.spent,
+                _HERO_TOTAL_BUDGET_S,
+            )
+            return done(path=svg_path)
 
         # ── compositional loop ─────────────────────────────────────────
         defects = await _critique(svg_path, png_path, model)
@@ -290,7 +417,7 @@ async def _author(brief: str, slug: str, images_dir: Path, model: str) -> HeroRe
             logger.info("Hero framing: %s", observation)
 
         if not defects:
-            return HeroResult(path=svg_path, cost_usd=cost)
+            return done(path=svg_path)
 
         carry_forward = "\n".join(f"- {d}" for d in defects)
         # `redraw` is 0-based and the last pass has no redraw left, so report
@@ -308,7 +435,7 @@ async def _author(brief: str, slug: str, images_dir: Path, model: str) -> HeroRe
     # and hand the critique back so the CLI can exit non-zero. Shipping silently
     # would rely on a warning nobody reads; discarding it would report the wrong
     # fault ("hero image not set") for a composition problem.
-    return HeroResult(path=svg_path, critique=carry_forward, cost_usd=cost)
+    return done(path=svg_path, critique=carry_forward)
 
 
 async def _critique(svg_path: Path, png_path: Path, model: str) -> list[str]:

--- a/src/agent_sdk/pipeline.py
+++ b/src/agent_sdk/pipeline.py
@@ -85,6 +85,26 @@ class PipelineResult:
     article_chars: int
     hero_critique: str = ""
     hero_error: str = ""
+    # B-041: hero spend, surfaced in the cost ledger so the duration swing is
+    # attributable instead of hidden inside stage3_seconds.
+    hero_seconds: float = 0.0
+    hero_attempts: int = 0
+    hero_timeouts: int = 0
+
+
+def _numeric(source: object, name: str) -> float:
+    """Read a numeric metric off a Stage 3 result, tolerating test doubles.
+
+    ``getattr`` on a ``MagicMock`` returns another ``MagicMock`` rather than the
+    default, and these values reach the JSON cost ledger — where an unserialisable
+    value does not fail loudly, it makes the whole row vanish into a "cost log
+    write failed (non-fatal)" warning. Anything that is not a real number becomes
+    zero.
+    """
+    value = getattr(source, name, 0.0)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return 0.0
+    return float(value)
 
 
 def load_brief_file(path: str | Path) -> str:
@@ -201,6 +221,13 @@ async def run_pipeline(
         # image_prompt above.
         hero_critique=getattr(stage3, "hero_critique", ""),
         hero_error=getattr(stage3, "hero_error", ""),
+        # ...but these reach the JSON cost ledger, and `getattr` on a MagicMock
+        # returns another MagicMock rather than the default, which orjson cannot
+        # serialise. Coerce, so a test double degrades to zero instead of
+        # silently killing the whole ledger write (B-041).
+        hero_seconds=_numeric(stage3, "hero_seconds"),
+        hero_attempts=int(_numeric(stage3, "hero_attempts")),
+        hero_timeouts=int(_numeric(stage3, "hero_timeouts")),
     )
     wall_seconds = result.stage3_seconds + result.stage4_seconds
     try:
@@ -313,6 +340,12 @@ def _append_cost_log(result: PipelineResult, total_wall_seconds: float) -> None:
         "stage3_seconds": result.stage3_seconds,
         "stage4_seconds": result.stage4_seconds,
         "wall_seconds": total_wall_seconds,
+        # B-041: the hero dominates duration and used to hide inside
+        # stage3_seconds, so a 4-minute run and a 20-minute one were
+        # indistinguishable here. `hero_timeouts > 0` means the expensive path.
+        "hero_seconds": result.hero_seconds,
+        "hero_attempts": result.hero_attempts,
+        "hero_timeouts": result.hero_timeouts,
         "editorial_score": result.editorial_score,
         "gates_passed": result.gates_passed,
         "publication_validator_passed": result.publication_validator_passed,

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -349,6 +349,12 @@ class Stage3Result:
         ""  # B-016b: unresolved composition defects (CLI exits non-zero)
     )
     hero_error: str = ""  # B-016b: why no hero exists (empty when hero_path is set)
+    # B-041: the hero's own spend. It dominates the run's duration and used to be
+    # invisible inside `wall_seconds`, so a 4-minute run and a 20-minute one were
+    # indistinguishable in the ledger.
+    hero_seconds: float = 0.0
+    hero_attempts: int = 0
+    hero_timeouts: int = 0
     #: B-024: the requested research mode yielded nothing and the deterministic
     #: providers supplied the brief. The article is sourced differently from the
     #: one commissioned, so the reviewer must be told rather than left to infer it.
@@ -913,6 +919,9 @@ async def run_stage3(
     hero_path: Path | None = None
     hero_critique = ""
     hero_error = ""
+    hero_seconds = 0.0
+    hero_attempts = 0
+    hero_timeouts = 0
     if image_prompt:
         # Imported at call time: hero_author needs _collect_text from this module,
         # so a module-level import here would be a cycle.
@@ -927,6 +936,20 @@ async def run_stage3(
             model=graphics_model,
         )
         hero_path, hero_critique, hero_error = hero.path, hero.critique, hero.error
+        hero_seconds, hero_attempts, hero_timeouts = (
+            hero.seconds,
+            hero.attempts,
+            hero.timeouts,
+        )
+        # B-041: log the hero's own spend. A timed-out attempt costs its full
+        # allowance and produces nothing, and the difference between a 4-minute
+        # run and a 20-minute one is entirely here.
+        logger.info(
+            "Hero: %.0fs, %s attempt(s), %s timeout(s)",
+            hero_seconds,
+            hero_attempts,
+            hero_timeouts,
+        )
         if hero_path:
             logger.info("Drew hero: %s", hero_path)
         else:
@@ -960,6 +983,9 @@ async def run_stage3(
         hero_path=hero_path,
         hero_critique=hero_critique,
         hero_error=hero_error,
+        hero_seconds=hero_seconds,
+        hero_attempts=hero_attempts,
+        hero_timeouts=hero_timeouts,
     )
 
 

--- a/tests/test_hero_author.py
+++ b/tests/test_hero_author.py
@@ -438,3 +438,173 @@ class TestCallableFromAnEventLoop:
             brief=_BRIEF, slug="s", images_dir=tmp_path
         )
         assert result.path is not None
+
+
+class TestTheHeroWorkIsBounded:
+    """B-041: the per-call timeout bounded a *call*; nothing bounded the hero.
+
+    ``2 redraws x 2 structural attempts x 600s`` = 40 minutes of drawing before
+    critique, on a call whose measured successful duration is 454s — and it was
+    invisible, because the hero sits inside ``stage3_seconds`` with no sub-timing.
+    A run on 2026-08-01 hit that path live. These tests pin the aggregate ceiling
+    with a fake clock, so they cost milliseconds rather than the thing they bound.
+    """
+
+    @pytest.fixture
+    def clock(self, monkeypatch: pytest.MonkeyPatch) -> list[float]:
+        """A monotonic clock the test advances by hand. ``clock[0]`` is 'now'."""
+        now = [0.0]
+        monkeypatch.setattr(hero_author, "_now", lambda: now[0])
+        return now
+
+    @pytest.fixture
+    def timing_out_draw(
+        self, monkeypatch: pytest.MonkeyPatch, clock: list[float]
+    ) -> list[float]:
+        """Every draw burns its whole allowance and yields nothing. Records the
+        timeout each call was given, which is the thing the budget must shrink."""
+        given: list[float] = []
+
+        async def _draw(
+            prompt: str, model: str, *, timeout: float
+        ) -> tuple[str, float]:
+            given.append(timeout)
+            clock[0] += timeout
+            raise TimeoutError
+
+        monkeypatch.setattr(hero_author, "_draw", _draw)
+        return given
+
+    def test_the_worst_case_is_bounded_by_the_total_budget(
+        self,
+        tmp_path: Path,
+        clock: list[float],
+        timing_out_draw: list[float],
+        _no_render: None,
+    ) -> None:
+        hero_author.author_hero_svg(brief=_BRIEF, slug="s", images_dir=tmp_path)
+
+        assert clock[0] <= hero_author._HERO_TOTAL_BUDGET_S
+
+    def test_that_ceiling_is_far_below_the_old_unbounded_worst_case(self) -> None:
+        # What the composition used to permit, before any critique time.
+        old_worst_case = (
+            (hero_author._MAX_CRITIQUE_RETRIES + 1)
+            * hero_author._MAX_STRUCTURAL_ATTEMPTS
+            * hero_author._DRAW_TIMEOUT_S
+        )
+
+        assert old_worst_case >= 2400  # 40 minutes, the defect
+        assert old_worst_case / 2 >= hero_author._HERO_TOTAL_BUDGET_S
+
+    def test_a_draw_is_not_started_when_it_cannot_finish(
+        self,
+        tmp_path: Path,
+        clock: list[float],
+        timing_out_draw: list[float],
+        _no_render: None,
+    ) -> None:
+        hero_author.author_hero_svg(brief=_BRIEF, slug="s", images_dir=tmp_path)
+
+        # Every call must have been given enough time to plausibly succeed;
+        # starting one with less buys a guaranteed timeout.
+        assert all(t >= hero_author._MIN_USEFUL_DRAW_S for t in timing_out_draw)
+
+    def test_the_last_call_is_capped_by_what_is_left_not_by_the_per_call_timeout(
+        self,
+        tmp_path: Path,
+        clock: list[float],
+        timing_out_draw: list[float],
+        _no_render: None,
+    ) -> None:
+        hero_author.author_hero_svg(brief=_BRIEF, slug="s", images_dir=tmp_path)
+
+        assert timing_out_draw, "expected at least one draw"
+        assert sum(timing_out_draw) <= hero_author._HERO_TOTAL_BUDGET_S
+
+    def test_exhausting_the_budget_degrades_instead_of_raising(
+        self,
+        tmp_path: Path,
+        clock: list[float],
+        timing_out_draw: list[float],
+        _no_render: None,
+    ) -> None:
+        # Stage 3 must never crash on a hero problem.
+        result = hero_author.author_hero_svg(
+            brief=_BRIEF, slug="s", images_dir=tmp_path
+        )
+
+        assert result.path is None
+        assert result.error
+
+    def test_it_reports_how_long_it_took_and_how_many_attempts_it_burned(
+        self,
+        tmp_path: Path,
+        clock: list[float],
+        timing_out_draw: list[float],
+        _no_render: None,
+    ) -> None:
+        # B-041's second half: a 10x duration swing must never again be invisible.
+        result = hero_author.author_hero_svg(
+            brief=_BRIEF, slug="s", images_dir=tmp_path
+        )
+
+        assert result.seconds > 0
+        assert result.attempts == len(timing_out_draw)
+        assert result.timeouts == len(timing_out_draw)
+
+    def test_the_happy_path_is_unchanged_and_costs_one_call(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, clock: list[float]
+    ) -> None:
+        monkeypatch.setattr(hero_author, "render_to_png", lambda svg, png: None)
+        recorder = _Recorder([_GOOD_SVG])
+        monkeypatch.setattr(hero_author, "_collect_text", recorder)
+
+        result = hero_author.author_hero_svg(
+            brief=_BRIEF, slug="s", images_dir=tmp_path
+        )
+
+        assert result.path is not None, result.error
+        assert result.attempts == 1
+        assert result.timeouts == 0
+
+    def test_a_timed_out_attempt_is_not_retried_at_full_price(
+        self,
+        tmp_path: Path,
+        clock: list[float],
+        timing_out_draw: list[float],
+        _no_render: None,
+    ) -> None:
+        """The 2026-08-01 regression, pinned.
+
+        Attempt 1 timed out at 600s; attempt 2 carried the "draw something
+        simpler" instruction and timed out at 600s too. Twenty minutes, no hero,
+        and an article the blog cannot publish because `image:` is required.
+        One timeout is a diagnosis, not a transient.
+        """
+        result = hero_author.author_hero_svg(
+            brief=_BRIEF, slug="s", images_dir=tmp_path
+        )
+
+        assert result.timeouts == 1, "a second full-price attempt was paid for"
+        assert clock[0] <= hero_author._DRAW_TIMEOUT_S
+
+    def test_a_rejected_attempt_is_still_retried(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, clock: list[float]
+    ) -> None:
+        """The other half of the distinction: rejection is cheap, so it retries.
+
+        Bounding the aggregate must not silently disable the structural retry —
+        a rejected draw returns in seconds and leaves the budget almost intact.
+        """
+        monkeypatch.setattr(hero_author, "render_to_png", lambda svg, png: None)
+        recorder = _Recorder([_BAD_SVG, _GOOD_SVG])
+        monkeypatch.setattr(hero_author, "_collect_text", recorder)
+
+        result = hero_author.author_hero_svg(
+            brief=_BRIEF, slug="s", images_dir=tmp_path
+        )
+
+        assert result.path is not None, result.error
+        assert result.attempts == 2
+        assert result.timeouts == 0


### PR DESCRIPTION
Two things, in the order they were found.

## B-041 — the hero's total spend was unbounded (perf)

The user asked whether "~35 minutes" for one article was ludicrous. Chasing that figure found the ledger contradicted it, and then a live run found what the ledger had never recorded:

| | |
|---|---|
| Wall clock | **31.8 min** — twice the previous record |
| Hero attempt 1 | timed out at 600s |
| Hero attempt 2 | **also timed out at 600s**, carrying the "draw something simpler" instruction |
| Hero produced | **none** |

**20 of the 31.8 minutes bought nothing**, and the article is unpublishable because the blog requires a resolvable `image:`.

The per-call timeout bounded a *call*. Nothing bounded the hero: `2 redraws × 2 attempts × 600s` permitted **40 minutes of drawing**, against a measured successful draw of 454s.

An aggregate budget alone was not enough — my first cut set it to 1200s, which would have changed this run **by zero seconds** (2 × 600 = 1200 exactly). The ceiling has to make the second full-price attempt impossible:

```
_HERO_TOTAL_BUDGET_S = 900   one measured draw (454s) + critique (180s) + slack
_MIN_USEFUL_DRAW_S   = 450   no observed successful draw finished faster
```

These separate the retry cases by arithmetic, not a special case. A **rejected** attempt returns in seconds and leaves the budget intact, so it retries as before. A **timed-out** attempt has consumed 600s by definition, leaving 300s — under the floor — so it stops. *Cheap signal, retry; expensive silence, stop.*

**Worst case 46 min → 15 min. This run's failure mode 20 min → 10 min.**

Plus the other half: `HeroResult` carries `seconds`/`attempts`/`timeouts`, plumbed into `logs/agent_sdk_costs.jsonl`. The swing used to hide inside `stage3_seconds`.

Tests use a fake clock, so pinning a 15-minute ceiling costs milliseconds.

## B-040 — spec the review-gate calibration (no implementation)

Reviewed the eval surface against [Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents). Code-based grading is strong; the one **model-based** grader has no ground truth, so it cannot be trusted, improved, or promoted — and ADR-0018 Decision 3 already blocks on exactly that ("promote to blocking once a false-positive rate is known"). Nobody has produced the number.

Spec only. Build after n≈5 real reviews, which accrue free from the B-013 review stage. Two prerequisites ship now because waiting corrupts the baseline:

- **G5 in the machine-readable verdict block.** ADR-0018 says it was added; it reached `SKILL.md:165` but **not** `REVIEW_PROMPT.md:85`, the file actually pasted into a review. Every review until now silently dropped the gate that exists because a reversed DORA statistic passed the other four.
- **Runbook cost/duration figures** replaced with the recorded range.

## Verification

`make ci-local` green — **2,689 passed, 9 skipped**, 81% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)