### PR TITLE
feat(B-043): a sensor cannot ship until something proves it can fail

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -822,8 +822,13 @@ that kept B-040 at spec-only applies. Spec first.
 
 ### B-043 · No sensor ships without a proof it can fail
 
-**Opened 2026-08-01.** Spec: `docs/specs/sensor-proof-of-teeth.md` — **awaiting LGTM.**
+**Opened 2026-08-01. DONE 2026-08-01.** Spec: `docs/specs/sensor-proof-of-teeth.md`.
 **Absorbs B-040** as its inferential-sensor arm.
+
+**Shipped:** `scripts/check_sensor_proofs.py` runs as a `make ci-local` step,
+`docs/sensors/register.yaml` holds 20 entries (**19 proved, 0 unproved, 1 report-only**), and
+`tests/test_check_sensor_proofs.py` carries the checker's own proof of teeth. Two sensors that
+had **zero** tests now have 26 between them.
 
 The 2026-07-29 SE Radio 730 assessment graded this repo *guide-maximal, sensor-disconnected*;
 B-030 … B-035 fixed the wiring. **The next failure mode is that nothing validates the sensors
@@ -854,18 +859,43 @@ constraint #1 ("NO new API keys. Ever.") had zero computational backing until B-
 was a review stage that existed as prose while the tool default bypassed it. A rule nothing
 enforces gets skipped.
 
-- [ ] `scripts/check_sensor_proofs.py` in `make ci-local`, failing on an unregistered sensor
-- [ ] `docs/sensors/register.yaml` covering all 13, `proof: none` allowed as a recorded baseline
-- [ ] `lint_adrs` and `check_bare_name_imports` proved first — the two real gaps
-- [ ] The three hand-run mutation proofs exist as tests, not shell history
-- [ ] The checker has its own proof of teeth
+- [x] `scripts/check_sensor_proofs.py` in `make ci-local`, failing on an unregistered sensor
+- [x] `docs/sensors/register.yaml` covering all of them, `proof: none` allowed as a recorded
+      baseline — **not needed in the end**, every discovered sensor got a real proof
+- [x] `lint_adrs` and `check_bare_name_imports` proved first — the two real gaps
+- [x] The three hand-run mutation proofs exist as tests, not shell history
+- [x] The checker has its own proof of teeth
 
 **Scope:** M. **Files:** `scripts/check_sensor_proofs.py`, `docs/sensors/register.yaml`,
 `tests/test_check_sensor_proofs.py`.
 
-**Open question for the owner, because it sets the gate's scope:** what counts as a sensor?
-Proposed — anything whose non-zero exit can block a commit, push, `ci-local`, or publish. That
-includes `publication_validator` and excludes `article_evaluator`, which scores but does not gate.
+**Discovery reads the wiring, not filenames.** The checker parses the `Makefile`,
+`.pre-commit-config.yaml`, `.claude/settings.json` and the publish entrypoints, and demands a
+register entry for every in-repo script they invoke. A `scripts/*_guard.py` glob would have been
+gameable by renaming and blind to anything added under another name — and the whole complaint
+about B-031 is that fixing four sensors *by name* left a fifth to be found.
+
+**Verified in situ, because a fixture passing is not the claim.** Adding a recipe invoking a new
+script to the real `Makefile` made the real gate exit 1 naming it; reverting restored green. This
+is B-039's third lesson applied to its own successor — `export PATH :=` looked right, `make
+showpath` confirmed it, and only running a recipe against a stub binary showed it did nothing.
+
+**The limit is stated, not papered over.** The checker verifies a proof *exists and runs*; it
+cannot verify a proof is *genuine* — `assert True` under an honest-sounding test name would pass.
+Mutation-testing the mutation tests is where the value curve goes flat, so the `mutation:` field
+exists instead, to make genuineness a one-glance review-time check.
+
+**Open question ANSWERED — what counts as a sensor.** The proposal was right in substance and
+wrong in one word: "non-zero exit" is the wrong test, because **every harness hook exits 0 by
+design** and refuses via JSON. Measured, `guard_constraints` denies a tool call and `session_gate`
+blocks a turn, while `post_edit_sensor` and `session_context` return only `additionalContext`.
+Adopted: *a sensor is anything a gate site invokes that can **refuse** — deny a tool call, block a
+turn, or exit non-zero.* Both named cases resolve as proposed and both were checked, not assumed:
+`publication_validator` is **in** (imported by both publish entrypoints, its verdict stops a
+publish); `article_evaluator` is **out** (zero gate-site references anywhere — it scored the
+fabricated article 76 while the validator passed it, which is precisely a score and not a gate).
+Note it *is* on `destructive_change_guard`'s `CRITICAL_FILES`: being protected from being gutted
+is not the same as being a sensor. Full reasoning in the spec's open-questions section.
 
 ### B-036 · Badge validation has no implementation — decide whether to restore it
 

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ ci-local: require-venv
 		--exclude '*/.venv/*,*/__pycache__/*,scripts/archived' \
 		--severity-level medium -q
 	@echo "── destructive-change guard ──" && $(PY) scripts/destructive_change_guard.py
+	@echo "── sensor proofs ──"           && $(PY) scripts/check_sensor_proofs.py
 	@echo "✅ ci-local passed — you are the merge gate (main is unprotected)."
 
 publish: require-venv

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -3,43 +3,98 @@
 Written for a fresh session after `/clear`. `BACKLOG.md` stays the source of record; this file
 is the "where were we" note a new session reads first, then overwrites when it goes stale.
 
-**Read next, in this order:** this file → `docs/specs/sensor-proof-of-teeth.md` (**B-043 is the
-next work**) → `docs/reviews/harness-engineering-assessment-2026-07-29.md` for the framework it
-sits in → `BACKLOG.md`.
+**Read next, in this order:** this file → `BACKLOG.md` → `docs/reviews/harness-engineering-assessment-2026-07-29.md`
+for the framework the last four items sit in.
 
-**Session of 2026-08-01 is closed out.** PRs #459, #460, #461 and #462 all merged; `main` is
-clean with no open PRs; `make ci-local` green at **2,689 tests**. B-038, B-039, B-040 and B-041
-landed. B-042 and B-043 are specced and open.
+**Session of 2026-08-01 is closed out.** PRs #459 … #462 merged; B-038 … B-041 landed. **B-043
+is now built** (branch `harness/sensor-proof-of-teeth`). **B-042 is the next work**, and it is
+the one item that is specced only as a backlog entry rather than a full spec.
 
-## The next work: B-043 — no sensor ships without a proof it can fail
+## B-043 — BUILT 2026-08-01. No sensor ships without a proof it can fail
 
-**Spec: `docs/specs/sensor-proof-of-teeth.md`, awaiting LGTM.** Per `CLAUDE.md`, no
-implementation begins until that lands.
+**Spec: `docs/specs/sensor-proof-of-teeth.md`** (status IMPLEMENTED; its open questions are now
+answered with measurements rather than left hanging).
+
+| | |
+|---|---|
+| `scripts/check_sensor_proofs.py` | the gate — a `make ci-local` step |
+| `docs/sensors/register.yaml` | 20 entries: **19 proved, 0 unproved, 1 report-only** |
+| `tests/test_check_sensor_proofs.py` | 33 tests, incl. the checker's own proof of teeth |
 
 **The one-line argument, so a fresh session does not re-derive it.** The 2026-07-29 assessment
 graded this repo *guide-maximal, sensor-disconnected*. B-030 … B-035 fixed the wiring — sensors
 now fire in the agent's loop. 2026-08-01 produced four independent proofs that **nothing
-validates the sensors themselves**:
+validates the sensors themselves**: a fifth inert sensor found after B-031 fixed four (B-039),
+one that had never run (B-040), one that was biased (B-041), and one whose setpoint manufactured
+the defect it prevents (B-042). **B-031 fixed four named sensors; it did not fix the class.**
 
-| | Kind of failure |
-|---|---|
-| B-039 | A **fifth** inert sensor, found after B-031 fixed four |
-| B-040 | A sensor that **never runs**, with no ground truth |
-| B-041 | A **biased** sensor — the ledger recorded only successful runs |
-| B-042 | A sensor whose **setpoint manufactured the defect** it prevents |
+### The three things worth knowing before you touch it
 
-**B-031 fixed four named sensors; it did not fix the class.**
+1. **Discovery reads the wiring, not filenames.** The checker parses the `Makefile`,
+   `.pre-commit-config.yaml`, `.claude/settings.json` and the publish entrypoints, and fails
+   until every in-repo script they invoke has a register entry. A `scripts/*_guard.py` glob would
+   have been gameable by renaming and blind to a sensor added under any other name — and the
+   whole complaint about B-031 is that fixing four sensors *by name* left a fifth to find.
+   **So: add a sensor to any of those four files and `make ci-local` goes red until you register
+   it.** That is the feature, not a snag.
+2. **It was verified in situ, not only against fixtures.** Adding a recipe invoking a new script
+   to the real `Makefile` made the real gate exit 1 naming it; reverting restored green. B-039's
+   third lesson applied to its own successor — `export PATH :=` looked right and did nothing.
+3. **What it cannot do is stated in its own docstring.** It verifies a proof *exists and runs*.
+   It cannot verify a proof is *genuine*: `assert True` under an honest-sounding name passes.
+   Mutation-testing the mutation tests is where the value curve goes flat. The `mutation:` field
+   is the substitute — it makes genuineness a one-glance review check. **Do not build toward
+   closing that hole.**
 
-**The design constraint that decides the whole build: the fix must be a sensor, not a guide.**
-Writing "every sensor must have a teeth test" into a `SKILL.md` reproduces exactly what this
-repo was graded down for — constraint #1 had zero computational backing until B-030, and B-028
-was a review stage that existed as prose while the tool's default bypassed it. A rule nothing
-enforces gets skipped.
+### What counts as a sensor — answered, and the proposal needed one correction
 
-**B-040 is absorbed** as the inferential arm: computational sensors are proved by mutation,
+The proposed definition said *"anything whose **non-zero exit** can block a commit, push,
+`ci-local`, or a publish"*. Measured, non-zero exit is the wrong test: **every harness hook exits
+0 by design**, so a broken hook cannot brick the session, and they refuse via JSON instead.
+`guard_constraints` returns `permissionDecision: "deny"` and `session_gate` returns
+`decision: "block"`; `post_edit_sensor` and `session_context` return only `additionalContext`.
+
+> Adopted: **a sensor is anything a gate site invokes that can *refuse*** — deny a tool call,
+> block a turn, or exit non-zero.
+
+Both named cases resolved as proposed, both checked rather than assumed. `publication_validator`
+is **in**. `article_evaluator` is **out** — zero gate-site references anywhere; it scored the
+fabricated article 76 while the validator passed it, which is exactly what "scores but does not
+gate" looks like. It *is* on `destructive_change_guard`'s `CRITICAL_FILES`, and being protected
+from being gutted is not the same as being a sensor — do not conflate the two lists.
+
+**B-040 stays absorbed** as the inferential arm: computational sensors are proved by mutation,
 inferential ones by labelled cases. Eight already exist in `docs/evals/review-gate/cases/`.
 `docs/specs/review-gate-calibration.md` remains the detailed design and its sequencing is
-unchanged — build after n≈5 real reviews.
+unchanged — **build after n≈5 real reviews**, which accrue free from the B-013 review stage.
+The inferential runner was deliberately not built.
+
+### The three hand-run mutation proofs are now tests
+
+Two already survived in tests written for other reasons — the `(mypy || echo advisory)` exit-127
+one and the `export PATH` vs stub-`ruff` one, both in `tests/test_ci_gate_is_reproducible.py`.
+**The third did not**: nothing mutated `CHROME_TAGS` to prove the no-drop invariant would notice.
+It is now `tests/test_html_to_brief.py::TestTheNoDropInvariantHasTeeth`.
+
+Two sensors had **zero** tests and now have 26 between them: `tests/test_lint_adrs.py` (16, one
+governance defect planted per rule) and `tests/test_check_bare_name_imports.py` (10).
+
+One inherited proof was quietly weak and got tightened: `test_schema_validation_rejects_invalid`
+asserted `pytest.raises((ValueError, Exception))`, which passes on *any* error — a typo in the
+fixture would have satisfied it. That is B-039's defect in miniature, in a test.
+
+## The next work: B-042 — the mandatory-chart gate
+
+**Specced only as a `BACKLOG.md` entry, not a full spec.** Per `CLAUDE.md`, write the spec first;
+it changes a CRITICAL gate carrying a stated editorial standard, and the same reasoning that kept
+B-040 at spec-only applies.
+
+**B-043 deliberately does not fix it**, and the reason is worth keeping: `missing_chart` **fires
+correctly**. The defect is its *setpoint* — a chart is mandatory even when the research carries no
+chartable data, so the pipeline invented four percentages to comply. A proof of teeth cannot catch
+a wrong setpoint, which is the taxonomy gap the spec's open question 3 names and leaves for its own
+ADR. The `publication_validator` register entry carries a note saying so, so the next reader of
+the register meets the limit rather than inferring it.
 
 ## Blocked on the owner, not on code
 

--- a/docs/sensors/register.yaml
+++ b/docs/sensors/register.yaml
@@ -1,0 +1,284 @@
+# The sensor register (B-043) — no sensor ships without a proof it can fail.
+#
+# Checked by `scripts/check_sensor_proofs.py`, which runs in `make ci-local`.
+# Spec: `docs/specs/sensor-proof-of-teeth.md`.
+#
+# WHY THIS FILE EXISTS. The 2026-07-29 harness assessment graded this repo
+# guide-maximal and sensor-disconnected. B-030…B-035 fixed the wiring. Then a
+# single day produced four independent proofs that nothing validated the sensors
+# themselves: a fifth inert sensor (B-039), one that had never run (B-040), one
+# that was biased (B-041), and one whose setpoint manufactured the defect it
+# prevents (B-042). B-031 fixed four sensors by name; it did not fix the class.
+#
+# THE CONTRACT.
+#   * A script is a sensor when a gate site invokes it. Gate sites are read from
+#     the wiring — the Makefile, .pre-commit-config.yaml, .claude/settings.json,
+#     and the publish entrypoints — never guessed from filenames. Add a sensor to
+#     any of those and this gate fails until it is registered here.
+#   * `regulates` says what defect it catches. `mutation` says what its proof
+#     breaks to make it fire. Both exist so a reviewer can check the claim against
+#     the test in one glance, without reading the whole file.
+#   * `proof` names a test that exists and runs. `none` is a legitimate baseline
+#     with a recorded `reason`, and the count of those is the burndown
+#     (`python scripts/check_sensor_proofs.py --list`). `n/a` marks something a
+#     gate site wires in that cannot block anything.
+#
+# THE LIMIT, STATED RATHER THAN PAPERED OVER. The checker verifies a proof exists
+# and runs. It cannot verify the proof is genuine — a test named
+# `test_gutting_a_critical_file_is_caught` whose body is `assert True` would pass.
+# Closing that hole means mutation-testing the mutation tests, which is where the
+# value curve goes flat. Genuineness is a review-time concern; `mutation:` is what
+# makes it a one-glance review.
+
+sensors:
+  # ── merge gate (make ci-local) ────────────────────────────────────────────
+
+  - id: bare_name_imports
+    script: scripts/check_bare_name_imports.py
+    regulates: >-
+      Bare-name imports of scripts/ modules. `from llm_client import call_llm`
+      resolves through sys.path, so any module of that name anywhere on the path
+      silently wins — the CVE-377-adjacent module-spoofing class. ADR-0010
+      mandates the fully-qualified form.
+    proof: tests/test_check_bare_name_imports.py::TestItFiresOnTheDefectItExistsFor::test_a_bare_from_import_is_caught
+    mutation: >-
+      Plant `from llm_client import call_llm` in a fixture tree alongside a real
+      scripts/llm_client.py, run the guard, assert exit 1 — with the
+      fully-qualified form as the control.
+
+  - id: destructive_change_guard
+    script: scripts/destructive_change_guard.py
+    regulates: >-
+      A critical file gutted rather than edited — the characteristic AI-agent
+      failure where a file is rewritten from scratch and the tests pass because
+      the tests went with it.
+    proof: tests/test_destructive_change_guard.py::TestItCatchesARealGutting::test_gutting_a_critical_file_is_caught
+    mutation: >-
+      In a real git repo, truncate a file on CRITICAL_FILES from 100 lines to a
+      stub, run the guard, assert it blocks and reports 99%. Real git rather than
+      mocked diff stats: B-039's third finding was a fix that looked right and did
+      nothing, and mocking the plumbing would assume away exactly that.
+
+  - id: mypy_baseline
+    script: scripts/mypy_baseline.py
+    regulates: >-
+      New type errors, while grandfathering the 30 pre-existing ones in
+      docs/mypy-baseline.md. The baseline is a count, not a mute — raising a
+      number to unblock a commit fails the suite instead.
+    proof: tests/test_mypy_baseline.py::TestCheck::test_new_error_in_baselined_file_blocks
+    mutation: >-
+      Report one more error in a baselined file than its grandfathered count and
+      assert the check blocks; a file at or below its baseline is the control.
+
+  - id: sensor_proof_gate
+    script: scripts/check_sensor_proofs.py
+    regulates: >-
+      Sensors added without a proof they can fail — this file's own contract. A
+      sensor that cannot fail is worse than none, because it reads as coverage.
+    proof: tests/test_check_sensor_proofs.py::TestItsOwnProofOfTeeth::test_a_wired_sensor_absent_from_the_register_fails
+    mutation: >-
+      Point the checker at a fixture tree whose Makefile runs a sensor absent from
+      the register and assert it fails; registering that same sensor is the
+      control. A checker that cannot fail is the joke B-043 exists to prevent.
+
+  - id: ci_gate_toolchain
+    script: Makefile
+    regulates: >-
+      The merge gate resolving its tools from ambient PATH, so it means something
+      different on every machine. ADR-0015 makes `make ci-local` THE gate — there
+      is no GitHub Actions and main is unprotected.
+    proof: tests/test_ci_gate_is_reproducible.py::TestTheGateUsesThePinnedVenv::test_a_venv_tool_wins_over_the_ambient_one
+    mutation: >-
+      Run `make lint` in a sandbox against a stub .venv/bin/ruff that prints a
+      marker, on a PATH with no venv, and assert the venv copy won. `export PATH :=`
+      passes a grep of the Makefile and fails this: GNU make 3.81 direct-execs
+      metacharacter-free recipe lines against its own startup PATH.
+
+  - id: mypy_advisory_step
+    script: Makefile
+    regulates: >-
+      An advisory step that cannot tell "I ran and found problems" from "I never
+      ran". The old `(mypy || echo advisory)` printed the same reassuring line for
+      both, which is how a fifth inert sensor survived B-031.
+    proof: tests/test_ci_gate_is_reproducible.py::TestTheMypyAdvisoryCannotMaskAMissingTool::test_a_mypy_that_could_not_run_fails_the_gate
+    mutation: >-
+      Run the step against a stub mypy exiting 127 and assert the gate fails;
+      exit 1 (real type errors) staying advisory is the control.
+
+  # ── pre-commit / pre-push ─────────────────────────────────────────────────
+
+  - id: adr_lint
+    script: scripts/lint_adrs.py
+    regulates: >-
+      ADR governance per skills/adr-governance/SKILL.md — one canonical location,
+      one number per ADR, a status from a closed set, an mkdocs entry, and
+      supersession links that point both ways.
+    proof: tests/test_lint_adrs.py::TestItFiresOnEachGovernanceDefect::test_a_duplicate_number_is_caught
+    mutation: >-
+      Add a second ADR numbered 0001 to a fixture tree and assert the lint reports
+      a duplicate. This happened for real: ADR-0018 was renumbered from 0016 after
+      main landed a different 0016 while the draft sat on disk. Nine sibling tests
+      cover the other rules, each planting one defect.
+
+  - id: arch_review
+    script: scripts/pre_commit_arch_check.py
+    regulates: >-
+      Architectural anti-patterns in staged Python — ADR-002 direct LLM imports,
+      unprotected json.loads, hardcoded secrets, and print() used for errors.
+    proof: tests/test_pre_commit_arch_check.py::TestCheckHardcodedSecrets::test_api_key_assignment_flagged
+    mutation: >-
+      Write a file assigning a literal API key and assert the check flags it;
+      the os.environ form is the control.
+
+  - id: badge_validation
+    script: scripts/validate_badges.py
+    regulates: >-
+      README badges that outlive what they describe (BUG-023). Two pointed at
+      GitHub Actions workflows ADR-0015 deleted, so the front page claimed CI this
+      project deliberately does not have — for months, while the hook meant to
+      catch it was `|| true`.
+    proof: tests/test_validate_badges.py::TestExitCodes::test_stale_badge_exits_non_zero
+    mutation: >-
+      Point a badge at a workflow file that does not exist and assert a non-zero
+      exit; a badge matching a real workflow is the control.
+
+  - id: skill_anatomy
+    script: scripts/validate_skills.py
+    regulates: >-
+      SKILL.md frontmatter and required sections (docs/skill-anatomy.md), so the
+      guide layer stays structurally checkable rather than free prose.
+    proof: tests/test_validate_skills.py::TestMainExitCodes::test_nonzero_exit_when_any_fails
+    mutation: >-
+      Write a SKILL.md whose frontmatter name disagrees with its directory and
+      assert a non-zero exit; a well-formed skill is the control.
+
+  - id: agent_yaml_validation
+    script: scripts/agent_loader.py
+    regulates: >-
+      Agent YAML configs drifting from agents/schema.json (ADR-0001), which would
+      surface as a runtime failure mid-pipeline rather than at commit time.
+    proof: tests/test_agent_loader.py::test_schema_validation_rejects_invalid
+    mutation: >-
+      Load an agent YAML missing a schema-required field and assert it is
+      rejected; the valid config is the control.
+
+  # ── the agent's own loop (.claude/settings.json, B-030) ───────────────────
+
+  - id: constraint_guard
+    script: scripts/hooks/guard_constraints.py
+    regulates: >-
+      CLAUDE.md constraints #1-#3 and the B-028 review stage, as PreToolUse denies
+      rather than prose. Constraint #1 — "NO new API keys. Ever." — is the most
+      emphatic sentence in the repo and had zero computational backing until this
+      hook existed.
+    proof: tests/test_harness_hooks.py::TestForbiddenKeyGuard::test_denies_introducing_a_forbidden_key
+    mutation: >-
+      Feed it a command that assigns a forbidden key and assert a deny; feeding it
+      a command that merely greps for the same key must NOT deny, because a guard
+      calibrated to block reads gets switched off within a day.
+
+  - id: session_gate
+    script: scripts/hooks/session_gate.py
+    regulates: >-
+      A turn ending on a red tree. Blocks once per session — an unconditional Stop
+      hook is a session trap — on lint over changed files or the tests that cover
+      them.
+    proof: tests/test_harness_hooks.py::TestLintAndTestsCompose::test_red_tests_block_even_when_lint_is_clean
+    mutation: >-
+      Present failing tests with clean lint and assert it blocks, and the mirror
+      case with red lint and clean tests; both clean is the control. Every
+      degraded path (timeout, pytest missing, no match) must NOT block.
+
+  - id: post_edit_sensor
+    script: scripts/hooks/post_edit_sensor.py
+    regulates: >-
+      Lint and complexity findings on a file the agent just wrote, fed back into
+      context while it still has the context to fix them. It reports rather than
+      blocks, but it can still fail to notice, which is what its proof tests.
+    proof: tests/test_harness_hooks.py::TestPostEditSensor::test_reports_complexity_back_to_the_agent
+    mutation: >-
+      Write a file with an over-complex function and assert the sensor reports it
+      back; a clean file producing no feedback is the control.
+
+  - id: session_context
+    script: scripts/hooks/session_context.py
+    regulates: >-
+      Nothing. It injects the five constraints, the branch and the open backlog at
+      SessionStart.
+    proof: n/a
+    reason: >-
+      It returns additionalContext and cannot deny a call or fail a gate, so there
+      is no "can it fail?" to answer — it is an informant, not a sensor. It is
+      nonetheless covered by tests/test_harness_hooks.py::TestSessionContext.
+
+  # ── the publish path — highest blast radius ───────────────────────────────
+
+  - id: publication_validator
+    script: scripts/publication_validator.py
+    regulates: >-
+      Everything standing between a draft and the live blog: frontmatter, dates,
+      categories, word count, image metadata, references, placeholder text and
+      unresolved verification flags. Run by both publish entrypoints as the
+      acceptance oracle.
+    proof: tests/test_publication_validator.py::TestPublicationValidatorContent::test_placeholder_text_rejected
+    mutation: >-
+      Take a valid article, insert "TODO: write this section" into the body, and
+      assert it is rejected with the placeholder_text check named. Roughly twenty
+      sibling tests mutate one field each the same way.
+      NOTE — B-042: missing_chart fires CORRECTLY and is still a defect, because
+      its setpoint requires a chart even when the research carries no data. A
+      proof of teeth cannot catch a wrong setpoint. That is B-042's item, not this
+      register's, and is the taxonomy gap the spec's open question 3 names.
+
+  - id: unreviewed_publish_guard
+    script: scripts/deploy_to_blog.py
+    regulates: >-
+      Publishing without the B-013 live review stage. `--mode` used to default to
+      `post`, so the documented command bypassed review with no warning — which is
+      how article two was published unreviewed (B-028). It also refuses an article
+      still carrying the `<!-- HERO IMAGE` reviewer comment (BUG-065, ADR-0017).
+    proof: tests/test_deploy_mode_required.py::TestModeIsRequired::test_missing_mode_exits_non_zero
+    mutation: >-
+      Invoke the parser with no --mode and assert a non-zero exit naming both
+      choices; each explicit mode parsing is the control. Asserting no default is
+      configured is the part that would catch a re-introduced default.
+
+  - id: promote_review
+    script: scripts/promote_review.py
+    regulates: >-
+      An approved review draft being promoted to _posts/ despite failing the
+      validator. This is the last gate before a permanent slug — there are no
+      redirects on the blog.
+    proof: tests/test_promote_review.py::TestPromote::test_validation_failure_blocks_publish
+    mutation: >-
+      Make the validator reject the draft and assert the promotion is blocked and
+      nothing is pushed; the passing draft is the control.
+
+  # ── runtime invariants ────────────────────────────────────────────────────
+
+  - id: no_drop_invariant
+    script: scripts/html_to_brief.py
+    regulates: >-
+      Research content silently lost converting a Claude HTML artifact to a brief.
+      A lost paragraph is invisible downstream — the article simply never mentions
+      it — so the converter diffs its own output on every run rather than only in
+      the suite.
+    proof: tests/test_html_to_brief.py::TestTheNoDropInvariantHasTeeth::test_dropping_a_content_tag_is_reported
+    mutation: >-
+      Add `table` to CHROME_TAGS so the converter discards tabular content, and
+      assert the invariant reports the lost words; the hand-run version of this on
+      2026-08-01 reported 48. The control is the same fixture unmutated. The
+      expected word set is computed from SPEC_CHROME_TAGS hardcoded in the test
+      rather than imported, so the expectation cannot move with the mutation.
+
+  - id: complexity_sensor
+    script: scripts/complexity_sensor.py
+    regulates: >-
+      Unregulated complexity, the characteristic AI-code failure mode (B-032).
+      Emits a judgment call rather than a hard block, with recorded overrides in
+      docs/harness-overrides.md so a suppression is visible at review time.
+    proof: tests/test_complexity_sensor.py::TestScanPaths::test_flags_an_over_complex_function
+    mutation: >-
+      Scan a file containing a function over the ruff.toml max-complexity and
+      assert it is flagged; a clean file is the control, and a recorded override
+      must remove the finding from the report rather than from the scan.

--- a/docs/specs/sensor-proof-of-teeth.md
+++ b/docs/specs/sensor-proof-of-teeth.md
@@ -1,6 +1,6 @@
 # Spec — No sensor ships without a proof it can fail (B-043)
 
-**Status:** DRAFT — awaiting owner LGTM · **Opened:** 2026-08-01
+**Status:** IMPLEMENTED 2026-08-01 (LGTM'd the same day) · **Opened:** 2026-08-01
 **Absorbs:** B-040 (review-gate calibration) as the inferential-sensor arm
 **Framework:** `docs/reviews/harness-engineering-assessment-2026-07-29.md` (SE Radio 730,
 Birgitta Boeckeler on harness engineering)
@@ -159,12 +159,21 @@ TDD per `agent-skills:test-driven-development`. Deterministic, keyless, no netwo
 
 ## Success criteria
 
-- [ ] `scripts/check_sensor_proofs.py` runs in `make ci-local` and fails on an unregistered sensor
-- [ ] Every sensor script in `scripts/` appears in `docs/sensors/register.yaml`
-- [ ] `lint_adrs.py` and `check_bare_name_imports.py` — the two with **zero** tests — get proofs first
-- [ ] The three mutation proofs run by hand on 2026-08-01 exist as tests, not as shell history
-- [ ] The checker has its own proof of teeth
-- [ ] `make ci-local` green; ≥80% coverage on the new module; no new dependency, no key, no network
+- [x] `scripts/check_sensor_proofs.py` runs in `make ci-local` and fails on an unregistered sensor
+      — verified *in situ*, not only against fixtures: adding a recipe invoking a new script to
+      the real `Makefile` made the real gate exit 1 naming it; reverting restored green
+- [x] Every sensor script in `scripts/` appears in `docs/sensors/register.yaml` — 20 entries,
+      16 found by discovery and 4 declared (see open question 1)
+- [x] `lint_adrs.py` and `check_bare_name_imports.py` — the two with **zero** tests — get proofs
+      first: `tests/test_lint_adrs.py` (16 tests, one governance defect planted per rule) and
+      `tests/test_check_bare_name_imports.py` (10)
+- [x] The three mutation proofs run by hand on 2026-08-01 exist as tests, not as shell history.
+      Two already survived in `test_ci_gate_is_reproducible.py`; the CHROME_TAGS/no-drop one did
+      **not** and is now `TestTheNoDropInvariantHasTeeth`
+- [x] The checker has its own proof of teeth — `TestItsOwnProofOfTeeth`, four tests, both
+      directions of the mutation
+- [x] `make ci-local` green; **93%** coverage on the new module; no new dependency (PyYAML was
+      already a requirement), no key, no network
 
 ## Implementation order
 
@@ -190,13 +199,67 @@ TDD per `agent-skills:test-driven-development`. Deterministic, keyless, no netwo
 
 ## Open questions
 
-1. **What counts as a sensor?** Proposed: anything whose non-zero exit or emitted issue can
-   block a commit, a push, `ci-local`, or a publish. That includes `publication_validator` and
-   excludes `article_evaluator` (it scores, it does not gate). Worth the owner's ruling, because
-   it sets the register's boundary and therefore the gate's scope.
-2. **Do pre-commit hooks count separately from the scripts they invoke?** A hook can be inert
-   while its script is fine — `validate_badges` was `|| true` for exactly that reason. Leaning
-   yes, as register entries with the hook id as `id`.
-3. **B-042 has no home in this taxonomy.** A sensor with the wrong setpoint is neither inert nor
-   inaccurate; it works, and the system is worse for it. Boeckeler's framework does not name it.
-   Worth an ADR on its own, separate from this spec.
+### 1. What counts as a sensor? — ANSWERED 2026-08-01, measured
+
+**The proposed definition was right in substance and wrong in one word.** It said *"anything
+whose **non-zero exit** can block a commit, a push, `ci-local`, or a publish"*. Measured against
+the repo, non-zero exit is the wrong test, because **every harness hook exits 0, always** — by
+design, so a broken hook cannot brick the session. They refuse via JSON instead:
+
+| Wired into `.claude/settings.json` | How it refuses | Sensor? |
+|---|---|---|
+| `guard_constraints.py` | `permissionDecision: "deny"` — refuses the tool call | **yes** |
+| `session_gate.py` | `decision: "block"` — refuses the turn ending | **yes** |
+| `post_edit_sensor.py` | `additionalContext` only | **no — it reports** |
+| `session_context.py` | `additionalContext` only | **no — it reports** |
+
+So the operative test is **"can it refuse?"**, not "can it exit non-zero". Adopted definition:
+
+> A **sensor** is anything a **gate site** invokes that can refuse — deny a tool call, block a
+> turn, or exit non-zero. **Gate sites** are the `Makefile`, `.pre-commit-config.yaml`,
+> `.claude/settings.json`, and the publish entrypoints.
+
+**This is enforced, not asserted.** `check_sensor_proofs.py` *reads* those four files and demands
+a register entry for every in-repo script it finds. Discovery from wiring rather than from a
+filename pattern is the load-bearing choice: `scripts/*_guard.py` would be gameable by renaming
+and blind to a sensor added under any other name.
+
+**The two named cases resolve as proposed, both confirmed by measurement:**
+
+- **`publication_validator` — in.** Imported by *both* publish entrypoints and run as the
+  acceptance oracle; an `is_valid=False` stops the publish. Discovery finds it via the publish
+  path without it being named anywhere in the checker.
+- **`article_evaluator` — out.** Grepped for across the Makefile, pre-commit config, harness
+  settings and the publish path: **zero gate-site references.** It scores and nothing reads the
+  score as a verdict — which is exactly how it scored the fabricated article **76** while the
+  validator passed it. A score is not a gate.
+
+  *Worth stating so the two lists are never conflated:* `article_evaluator.py` **is** on
+  `destructive_change_guard`'s `CRITICAL_FILES`. Being protected from being gutted is not the
+  same as being a sensor, and it does not earn a register entry.
+
+**One thing the definition alone does not cover, so the register carries it explicitly.** Four
+real sensors are invoked by no gate site: the `Makefile`'s own toolchain resolution and its
+`mypy-advisory` exit-code logic (proved by `test_ci_gate_is_reproducible.py`),
+`html_to_brief`'s runtime no-drop invariant, and `complexity_sensor`. Extra entries beyond what
+discovery finds are allowed for exactly this reason — discovery sets the **floor** on the
+register, not the ceiling.
+
+**Measured result: 20 registered — 19 proved, 0 unproved, 1 report-only.**
+
+### 2. Do hooks count separately from the scripts they invoke? — ANSWERED: yes
+
+Implemented. `.claude/settings.json` is parsed for `run_hook.sh <name>` and each resolved
+`scripts/hooks/<name>.py` is registered in its own right, as are the pre-commit `entry:` targets.
+The reasoning in the question holds and is why: a hook can be inert while its script is fine,
+which is what `validate_badges` was for months.
+
+### 3. B-042 has no home in this taxonomy — still open, deliberately
+
+A sensor with the wrong setpoint is neither inert nor inaccurate; it works, and the system is
+worse for it. Boeckeler's framework does not name it, and a proof of teeth cannot catch it —
+`missing_chart` **fires correctly**. Still worth an ADR on its own, separate from this spec.
+
+The register does not fix it, but it now has one concrete place where the gap is visible: the
+`publication_validator` entry carries a note saying that `missing_chart` fires correctly and is
+still a defect, so the next reader of the register meets the limit rather than inferring it.

--- a/scripts/check_sensor_proofs.py
+++ b/scripts/check_sensor_proofs.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""Gate: no sensor ships without a proof it can fail (B-043).
+
+`docs/specs/sensor-proof-of-teeth.md` is the spec. The short version: the
+2026-07-29 harness assessment graded this repo *guide-maximal, sensor-disconnected*,
+B-030…B-035 fixed the wiring, and then a single day (2026-08-01) produced four
+independent proofs that **nothing validates the sensors themselves** —
+
+* **B-039** — `(mypy || echo "advisory")` returned exit 0 against a stub `mypy`
+  exiting 127. A *fifth* inert sensor, found after B-031 fixed four by name.
+* **B-040** — a gate that has run once, by hand, with no ground truth.
+* **B-041** — a ledger that recorded only the runs where the hero succeeded.
+* **B-042** — a sensor whose setpoint manufactured the defect it prevents.
+
+B-031 fixed four named sensors; it did not fix the class. This is the standing
+check rather than another audit.
+
+**Why this is a sensor and not a line in a `SKILL.md`.** The strongest guide in
+this codebase — `CLAUDE.md` constraint #1, *"NO new API keys. Ever."* — had zero
+computational backing until B-030 gave it a `PreToolUse` deny. B-028 is the same
+story: the review stage existed as prose while `--mode` defaulted to `post`, and
+the default won. A rule nothing enforces gets skipped, so this ships in
+`make ci-local` — and, being a sensor, it carries its own proof of teeth in
+`tests/test_check_sensor_proofs.py::TestItsOwnProofOfTeeth`.
+
+## What it checks
+
+1. Every script a **gate site** invokes appears in `docs/sensors/register.yaml`.
+   Gate sites are read from the wiring, not guessed from filenames: the
+   `Makefile`, `.pre-commit-config.yaml`, `.claude/settings.json`, and the
+   publish entrypoints. A filename pattern would be gameable by renaming and
+   blind to anything wired in under another name.
+2. Every entry names a `proof` that exists, is a real test, and is neither
+   skipped nor xfail — or says `proof: none` and records a `reason`.
+3. Every entry carries `regulates` (what defect it catches) and, when proved,
+   `mutation` (what the proof breaks to make it fire).
+
+## What it deliberately cannot check
+
+**It verifies a proof exists and runs. It cannot verify the proof is genuine.**
+A test named `test_gutting_a_critical_file_is_caught` whose body is `assert True`
+passes this gate. Closing that hole means mutation-testing the mutation tests,
+which is where the value curve goes flat — so the limit is stated rather than
+papered over. Genuineness is a review-time concern, and the `mutation:` field
+exists so a reviewer can check the claim against the test in one glance without
+reading the whole file.
+
+Exit code 0 when the register is honest, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+#: The register, relative to the repo root, so fixture trees can be checked too.
+REGISTER_RELPATH = "docs/sensors/register.yaml"
+
+#: `proof:` value that declares an unproved sensor. Legitimate with a `reason:` —
+#: the spec ships the register green on a TRUE baseline rather than after a
+#: backfill sprint, and the count of these is the burndown (see ``--list``).
+UNPROVED = "none"
+
+#: `proof:` value for something a gate site wires in that cannot block anything —
+#: `session_context` injects the constraints at SessionStart and `post_edit_sensor`
+#: returns `additionalContext`; neither can deny a call or fail a gate. They are
+#: informants, not sensors, so there is no "can it fail?" to answer.
+#:
+#: This is a *declared* exemption and the checker cannot verify the claim, the same
+#: way it cannot verify a proof is genuine. It is visible in the register and in
+#: ``--list`` so a reviewer adjudicates it, which is the `docs/harness-overrides.md`
+#: convention. Marking a sensor that CAN block as `n/a` would defeat this gate — do
+#: not do it, and expect it to be challenged at review.
+NOT_A_SENSOR = "n/a"
+
+#: Both reason-carrying states, kept apart so the burndown counts only what is
+#: genuinely owed: `none` is a debt, `n/a` is not.
+_REASON_REQUIRED = (UNPROVED, NOT_A_SENSOR)
+
+#: Scripts that gate a publish. `deploy_to_blog` and `promote_review` refuse
+#: content themselves (`--mode` is required, B-028; the hero-prompt comment is
+#: rejected, BUG-065/ADR-0017) and they run `publication_validator` as the
+#: acceptance oracle. Their `from scripts.X import` edges are followed, so a new
+#: gate imported into the publish path is discovered without touching this list.
+PUBLISH_ENTRYPOINTS: tuple[str, ...] = (
+    "scripts/deploy_to_blog.py",
+    "scripts/promote_review.py",
+)
+
+#: An in-repo script path inside a gate-site config value.
+_SCRIPT_RE = re.compile(r"\b(scripts/(?:hooks/)?[a-z0-9_]+\.py)\b")
+
+#: `python -m scripts.foo` / `-m scripts.hooks.foo`.
+_MODULE_RE = re.compile(r"-m\s+(scripts(?:\.hooks)?\.[a-z0-9_]+)\b")
+
+#: `run_hook.sh <name>` in `.claude/settings.json` → `scripts/hooks/<name>.py`.
+_HOOK_RE = re.compile(r"run_hook\.sh[\\\"'\s]+([a-z0-9_]+)")
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One reason the register is not honest.
+
+    Attributes:
+        subject: The entry id, script path, or file the finding is about.
+        message: What is wrong, phrased so the fix is obvious.
+
+    """
+
+    subject: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.subject}: {self.message}"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Discovery — a script is a sensor when a gate site invokes it
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _uncommented_makefile(text: str) -> str:
+    """Drop comment lines from a Makefile.
+
+    The real Makefile discusses its sensors at length in comments — B-039's whole
+    reasoning lives there. Counting those would make the register a transcript of
+    the commentary rather than a list of what runs.
+    """
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _module_to_path(module: str) -> str:
+    """Turn ``scripts.hooks.foo`` into ``scripts/hooks/foo.py``."""
+    return module.replace(".", "/") + ".py"
+
+
+def _scripts_in(text: str) -> set[str]:
+    """Return every in-repo script path a blob of config text invokes."""
+    found = set(_SCRIPT_RE.findall(text))
+    found.update(_module_to_path(m) for m in _MODULE_RE.findall(text))
+    return found
+
+
+def _from_makefile(root: Path) -> set[str]:
+    path = root / "Makefile"
+    if not path.is_file():
+        return set()
+    return _scripts_in(_uncommented_makefile(path.read_text(encoding="utf-8")))
+
+
+def _from_pre_commit(root: Path) -> set[str]:
+    """Read hook `entry:` values, so a comment about a sensor is not a gate site."""
+    path = root / ".pre-commit-config.yaml"
+    if not path.is_file():
+        return set()
+    try:
+        config = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError:
+        return set()
+    if not isinstance(config, dict):
+        return set()
+
+    found: set[str] = set()
+    for repo in config.get("repos") or []:
+        if not isinstance(repo, dict):
+            continue
+        for hook in repo.get("hooks") or []:
+            if isinstance(hook, dict) and hook.get("entry"):
+                found |= _scripts_in(str(hook["entry"]))
+    return found
+
+
+def _from_harness_hooks(root: Path) -> set[str]:
+    """Read `.claude/settings.json`.
+
+    Answers the spec's open question 2 — yes, a hook is registered separately from
+    the script it invokes. A hook can be inert while its script is fine; that is
+    exactly how `validate_badges` was `|| true` for months.
+    """
+    path = root / ".claude" / "settings.json"
+    if not path.is_file():
+        return set()
+    try:
+        settings = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return set()
+
+    text = json.dumps(settings)
+    found = _scripts_in(text)
+    found.update(f"scripts/hooks/{name}.py" for name in _HOOK_RE.findall(text))
+    return found
+
+
+def _from_publish_path(root: Path) -> set[str]:
+    """Follow `from scripts.X import` out of the publish entrypoints."""
+    found: set[str] = set()
+    for relpath in PUBLISH_ENTRYPOINTS:
+        path = root / relpath
+        if not path.is_file():
+            continue
+        found.add(relpath)
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, SyntaxError, UnicodeDecodeError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.level == 0:
+                module = node.module or ""
+                if module.startswith("scripts.") and module.count(".") <= 2:
+                    found.add(_module_to_path(module))
+    return found
+
+
+def discover_gate_scripts(root: Path) -> dict[str, list[str]]:
+    """Return every in-repo script a gate site invokes, mapped to its gate sites.
+
+    Args:
+        root: Repo (or fixture tree) root.
+
+    Returns:
+        ``{"scripts/foo.py": ["Makefile", ".pre-commit-config.yaml"]}``. A gate
+        site file that does not exist contributes nothing and is not an error —
+        degrade, do not crash.
+
+    """
+    sources = {
+        "Makefile": _from_makefile,
+        ".pre-commit-config.yaml": _from_pre_commit,
+        ".claude/settings.json": _from_harness_hooks,
+        "publish path": _from_publish_path,
+    }
+
+    discovered: dict[str, list[str]] = {}
+    for site, reader in sources.items():
+        for script in sorted(reader(root)):
+            if not (root / script).is_file():
+                # A gate site naming a script that does not exist is its own
+                # defect, caught by TestHooksPointAtRealScripts (B-036). Not
+                # this gate's job, and registering a phantom helps nobody.
+                continue
+            discovered.setdefault(script, []).append(site)
+    return discovered
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Proof resolution
+# ═══════════════════════════════════════════════════════════════════════════
+
+_MUTING_MARKS = ("skip", "skipif", "xfail")
+
+
+def _muting_mark(node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) -> str:
+    """Return the name of a skip/xfail mark on a node, or "".
+
+    Skipping is how a proof rots quietly: it stays green in the suite and stops
+    running, so the sensor it covers silently loses its teeth.
+    """
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        parts: list[str] = []
+        while isinstance(target, ast.Attribute):
+            parts.append(target.attr)
+            target = target.value
+        if isinstance(target, ast.Name):
+            parts.append(target.id)
+        names = list(reversed(parts))
+        if "pytest" in names and "mark" in names:
+            for mark in _MUTING_MARKS:
+                if mark in names:
+                    return mark
+    return ""
+
+
+def _resolve_proof(root: Path, proof: str) -> Finding | None:
+    """Check that a ``path::[Class::]test`` reference names a test that will run.
+
+    Args:
+        root: Repo (or fixture tree) root.
+        proof: The register entry's ``proof`` value.
+
+    Returns:
+        A Finding when the proof cannot run, else None.
+
+    """
+    parts = proof.split("::")
+    if len(parts) < 2:
+        return Finding(proof, "proof must be 'path/to/test_x.py::test_name'")
+
+    relpath, *path_in_file = parts
+    path = root / relpath
+    if not path.is_file():
+        return Finding(proof, f"proof file {relpath} does not exist")
+
+    try:
+        tree: ast.AST = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (OSError, SyntaxError, UnicodeDecodeError) as exc:
+        return Finding(proof, f"proof file {relpath} could not be parsed: {exc}")
+
+    body: list[ast.stmt] = tree.body  # type: ignore[attr-defined]
+    for index, name in enumerate(path_in_file):
+        is_last = index == len(path_in_file) - 1
+        match = next(
+            (
+                node
+                for node in body
+                if isinstance(
+                    node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef
+                )
+                and node.name == name
+            ),
+            None,
+        )
+        if match is None:
+            return Finding(proof, f"{relpath} defines no {name}")
+        mark = _muting_mark(match)
+        if mark:
+            return Finding(
+                proof,
+                f"{name} is marked pytest.mark.{mark} — a proof that does not run "
+                "is not a proof",
+            )
+        if not is_last:
+            body = match.body
+    return None
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# The check
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def load_register(root: Path) -> tuple[list[dict[str, object]], list[Finding]]:
+    """Parse the register.
+
+    Args:
+        root: Repo (or fixture tree) root.
+
+    Returns:
+        ``(entries, findings)``. A register that cannot be read yields no entries
+        and a finding — "could not run" must never look like "clean", which is
+        B-039's complaint exactly.
+
+    """
+    path = root / REGISTER_RELPATH
+    if not path.is_file():
+        return [], [Finding(REGISTER_RELPATH, "register does not exist")]
+
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return [], [Finding(REGISTER_RELPATH, f"register is not valid YAML: {exc}")]
+
+    if not isinstance(data, dict) or "sensors" not in data:
+        return [], [
+            Finding(REGISTER_RELPATH, "register must be a mapping with 'sensors'")
+        ]
+
+    sensors = data.get("sensors") or []
+    if not isinstance(sensors, list):
+        return [], [Finding(REGISTER_RELPATH, "'sensors' must be a list")]
+
+    entries = [entry for entry in sensors if isinstance(entry, dict)]
+    findings = [
+        Finding(REGISTER_RELPATH, "every sensor entry must be a mapping")
+        for entry in sensors
+        if not isinstance(entry, dict)
+    ]
+    return entries, findings
+
+
+def _check_entry(root: Path, entry: dict[str, object]) -> list[Finding]:
+    """Validate one register entry."""
+    entry_id = str(entry.get("id") or "<entry with no id>")
+    findings: list[Finding] = []
+
+    if not entry.get("id"):
+        findings.append(Finding(entry_id, "entry needs an 'id'"))
+
+    script = str(entry.get("script") or "")
+    if not script:
+        findings.append(Finding(entry_id, "entry needs a 'script'"))
+    elif not (root / script).is_file():
+        findings.append(
+            Finding(
+                entry_id, f"{script} does not exist — the register outlived its sensor"
+            )
+        )
+
+    if not str(entry.get("regulates") or "").strip():
+        findings.append(
+            Finding(
+                entry_id,
+                "entry needs 'regulates' — a proof whose reasoning is not written "
+                "down cannot be re-adjudicated when the sensor changes",
+            )
+        )
+
+    proof = str(entry.get("proof") or "").strip()
+    if not proof:
+        findings.append(
+            Finding(
+                entry_id,
+                f"entry needs a 'proof' (or 'proof: {UNPROVED}' plus a 'reason')",
+            )
+        )
+    elif proof in _REASON_REQUIRED:
+        if not str(entry.get("reason") or "").strip():
+            findings.append(
+                Finding(
+                    entry_id,
+                    f"'proof: {proof}' needs a 'reason' — an unproved sensor that "
+                    "says so is a baseline; one that says nothing is a mute button",
+                )
+            )
+    else:
+        if not str(entry.get("mutation") or "").strip():
+            findings.append(
+                Finding(
+                    entry_id,
+                    "entry needs 'mutation' — what the proof breaks to make the "
+                    "sensor fire, so a reviewer can check the claim in one glance",
+                )
+            )
+        resolved = _resolve_proof(root, proof)
+        if resolved is not None:
+            findings.append(Finding(entry_id, resolved.message))
+
+    return findings
+
+
+def check_register(root: Path | None = None) -> list[Finding]:
+    """Check a tree's sensors against its register.
+
+    Args:
+        root: Repo (or fixture tree) root. Defaults to this repo.
+
+    Returns:
+        Every reason the register is not honest, in a stable order. Empty means
+        the gate passes.
+
+    """
+    root = root or REPO_ROOT
+    entries, findings = load_register(root)
+
+    seen: set[str] = set()
+    for entry in entries:
+        entry_id = str(entry.get("id") or "")
+        if entry_id and entry_id in seen:
+            findings.append(
+                Finding(entry_id, "duplicate id — one of these is never read")
+            )
+        seen.add(entry_id)
+        findings.extend(_check_entry(root, entry))
+
+    registered = {str(entry.get("script") or "") for entry in entries}
+    for script, sites in sorted(discover_gate_scripts(root).items()):
+        if script not in registered:
+            findings.append(
+                Finding(
+                    script,
+                    f"invoked by {', '.join(sites)} but absent from {REGISTER_RELPATH} "
+                    "— every sensor ships with a proof it can fail (B-043)",
+                )
+            )
+    return findings
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CLI
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _print_list(root: Path) -> None:
+    """Print what is registered and what is proved, unproved count last."""
+    entries, findings = load_register(root)
+    for finding in findings:
+        print(f"✗ {finding}", file=sys.stderr)
+
+    # Gate sites are COMPUTED, never read from the entry. A hand-written `gates:`
+    # field is a claim about the wiring that drifts the moment the wiring moves,
+    # which is the class of defect this whole gate exists to catch.
+    gate_sites = discover_gate_scripts(root)
+
+    unproved = informants = 0
+    for entry in sorted(entries, key=lambda e: str(e.get("id") or "")):
+        proof = str(entry.get("proof") or "").strip()
+        reason = str(entry.get("reason") or "").strip()
+        if proof == UNPROVED:
+            unproved += 1
+            mark, detail = "○", f"UNPROVED — {reason}"
+        elif proof == NOT_A_SENSOR:
+            informants += 1
+            mark, detail = "·", f"cannot block — {reason}"
+        else:
+            mark, detail = "●", proof
+        script = str(entry.get("script") or "")
+        where = ", ".join(
+            gate_sites.get(script, ["declared, not wired to a gate site"])
+        )
+        print(
+            f"{mark} {entry.get('id')}  ({script})\n    fires at: {where}\n    {detail}"
+        )
+
+    proved = len(entries) - unproved - informants
+    print(
+        f"\n{len(entries)} registered: {proved} proved, {unproved} unproved, "
+        f"{informants} cannot block."
+    )
+    if unproved:
+        print(
+            "The unproved count is the burndown — retire them one at a time (B-043 step 5)."
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the gate.
+
+    Returns:
+        0 when the register is honest, 1 otherwise.
+
+    """
+    parser = argparse.ArgumentParser(description="Check that every sensor has a proof.")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=REPO_ROOT,
+        help="repo root to check (default: this repo)",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="show what is registered and what is proved, then exit 0",
+    )
+    args = parser.parse_args(argv)
+
+    if args.list:
+        _print_list(args.root)
+        return 0
+
+    findings = check_register(args.root)
+    if not findings:
+        print("OK: every sensor a gate site invokes has a register entry and a proof.")
+        return 0
+
+    print(
+        f"::error::{len(findings)} sensor(s) without an honest register entry. "
+        "B-043: no sensor ships without a proof it can fail — see "
+        "docs/specs/sensor-proof-of-teeth.md.",
+        file=sys.stderr,
+    )
+    for finding in findings:
+        print(f"  {finding}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_agent_loader.py
+++ b/tests/test_agent_loader.py
@@ -228,7 +228,13 @@ def test_schema_validation_rejects_invalid(tmp_path: Path) -> None:
     p = tmp_path / "bad_metadata.yaml"
     p.write_text(yaml.dump(data))
 
-    with pytest.raises((ValueError, Exception)):
+    # B-043: this was `pytest.raises((ValueError, Exception))`, which passes on ANY
+    # error — an import failure or a typo in the fixture would have satisfied it just
+    # as well as the schema rejection it claims to prove. That is the same defect
+    # B-039 found in `(mypy || echo "advisory")`: a check that cannot tell "ran and
+    # found the problem" from "never ran". This is the registered proof of teeth for
+    # the agent-yaml sensor, so it names the exception it expects.
+    with pytest.raises(ValueError, match="failed schema validation"):
         load_agent(p)
 
 

--- a/tests/test_check_bare_name_imports.py
+++ b/tests/test_check_bare_name_imports.py
@@ -1,0 +1,121 @@
+"""Proof of teeth for the bare-name import guard (B-043).
+
+`scripts/check_bare_name_imports.py` runs in `make ci-local` and had **zero
+tests** until this file — one of the two largest gaps the B-043 baseline
+measured. It guards ADR-0010: a bare `from llm_client import call_llm` resolves
+through `sys.path`, so any module of that name anywhere on the path silently
+takes precedence. That is the CVE-377-adjacent module-spoofing class.
+
+The tests here are efficacy tests, not unit tests. Each one **plants the defect
+the guard exists to catch** in a throwaway tree and asserts the guard exits
+non-zero, then plants the correct form and asserts it exits zero. Both halves
+matter: a guard that always fails is as useless as one that never does.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import check_bare_name_imports as guard
+
+
+@pytest.fixture
+def tree(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A throwaway repo with one module in scripts/ and an empty src/.
+
+    The guard resolves everything from module-level constants, so pointing it at
+    a fixture tree means repointing those.
+    """
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "scripts" / "llm_client.py").write_text(
+        "def call_llm() -> None:\n    pass\n"
+    )
+    (tmp_path / "src").mkdir()
+
+    monkeypatch.setattr(guard, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(guard, "SCRIPTS_DIR", tmp_path / "scripts")
+    monkeypatch.setattr(guard, "SCAN_ROOTS", ["src", "scripts"])
+    return tmp_path
+
+
+class TestItFiresOnTheDefectItExistsFor:
+    """Plant a bare-name import; the guard must notice."""
+
+    def test_a_bare_from_import_is_caught(self, tree: Path) -> None:
+        (tree / "src" / "consumer.py").write_text("from llm_client import call_llm\n")
+
+        assert guard.main() == 1
+
+    def test_a_bare_plain_import_is_caught(self, tree: Path) -> None:
+        """`import llm_client` spoofs just as well as the `from` form."""
+        (tree / "src" / "consumer.py").write_text("import llm_client\n")
+
+        assert guard.main() == 1
+
+    def test_an_aliased_bare_import_is_caught(self, tree: Path) -> None:
+        (tree / "src" / "consumer.py").write_text("import llm_client as llm\n")
+
+        assert guard.main() == 1
+
+    def test_the_violation_is_reported_with_its_location(
+        self, tree: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A guard that fails without saying where costs more than it saves."""
+        (tree / "src" / "consumer.py").write_text(
+            "\n\nfrom llm_client import call_llm\n"
+        )
+
+        guard.main()
+
+        assert "consumer.py:3" in capsys.readouterr().err
+
+
+class TestItDoesNotFireOnCorrectCode:
+    """The other half of the mutation. Without these, every test above would
+    pass against a guard hardcoded to return 1."""
+
+    def test_the_fully_qualified_form_passes(self, tree: Path) -> None:
+        (tree / "src" / "consumer.py").write_text(
+            "from scripts.llm_client import call_llm\n"
+        )
+
+        assert guard.main() == 0
+
+    def test_a_relative_import_inside_scripts_passes(self, tree: Path) -> None:
+        """ADR-0010 forbids bare *absolute* imports; siblings may use `from .X`."""
+        (tree / "scripts" / "sibling.py").write_text(
+            "from .llm_client import call_llm\n"
+        )
+
+        assert guard.main() == 0
+
+    def test_an_unrelated_module_name_passes(self, tree: Path) -> None:
+        (tree / "src" / "consumer.py").write_text("import json\n")
+
+        assert guard.main() == 0
+
+    def test_a_docstring_example_is_not_a_violation(self, tree: Path) -> None:
+        """AST parsing is the reason this guard can be documented in its own
+        docstring without flagging itself."""
+        (tree / "src" / "consumer.py").write_text(
+            '"""Never write `import llm_client`; use scripts.llm_client."""\n'
+        )
+
+        assert guard.main() == 0
+
+
+class TestItDegradesHonestly:
+    """A guard that cannot run must say so rather than pass quietly — the
+    `(mypy || echo advisory)` failure mode B-039 found."""
+
+    def test_no_scripts_modules_is_an_error_not_a_pass(self, tree: Path) -> None:
+        (tree / "scripts" / "llm_client.py").unlink()
+
+        assert guard.main() == 1
+
+    def test_an_unparseable_file_does_not_crash_the_guard(self, tree: Path) -> None:
+        (tree / "src" / "broken.py").write_text("def (((\n")
+
+        assert guard.main() == 0

--- a/tests/test_check_sensor_proofs.py
+++ b/tests/test_check_sensor_proofs.py
@@ -1,0 +1,544 @@
+"""Tests for the sensor-proof checker (B-043).
+
+`docs/specs/sensor-proof-of-teeth.md` exists because 2026-08-01 produced four
+independent proofs that nothing in this repo validates the sensors themselves —
+B-039 found a *fifth* inert sensor after B-031 fixed four by name. B-031 fixed
+four named sensors; it did not fix the class.
+
+**The load-bearing test in this file is `TestItsOwnProofOfTeeth`.** It points the
+checker at a fixture tree containing a sensor wired into a gate but absent from
+the register, and asserts the checker fails. A checker that cannot fail is the
+exact joke this item exists to prevent, so that test is the item's own proof of
+teeth and every other test here is secondary to it.
+
+Everything runs against throwaway fixture trees rather than the real repo, except
+`TestTheRealRegister`, which asserts the shipped register is honest.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts.check_sensor_proofs import (
+    REGISTER_RELPATH,
+    check_register,
+    discover_gate_scripts,
+    main,
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Fixture-tree builders
+# ═══════════════════════════════════════════════════════════════════════════
+
+#: A Makefile whose gate step runs one in-repo sensor.
+MAKEFILE = textwrap.dedent(
+    """\
+    VENV_BIN := $(CURDIR)/.venv/bin
+    PY       := $(VENV_BIN)/python
+
+    ci-local:
+    \t@echo "── rogue guard ──" && $(PY) scripts/rogue_guard.py
+    """
+)
+
+#: A pre-commit config whose only local hook runs one in-repo sensor.
+PRECOMMIT = textwrap.dedent(
+    """\
+    repos:
+      - repo: local
+        hooks:
+          - id: rogue-guard
+            name: rogue guard
+            entry: .venv/bin/python scripts/rogue_guard.py
+            language: system
+    """
+)
+
+#: A harness settings file wiring one Stop hook.
+SETTINGS = textwrap.dedent(
+    """\
+    {
+      "hooks": {
+        "Stop": [
+          {
+            "matcher": "",
+            "hooks": [
+              {
+                "type": "command",
+                "command": "\\"${CLAUDE_PROJECT_DIR:-.}/scripts/hooks/run_hook.sh\\" rogue_hook"
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
+)
+
+PROVEN_ENTRY = textwrap.dedent(
+    """\
+    sensors:
+      - id: rogue_guard
+        script: scripts/rogue_guard.py
+        gates: ["make ci-local"]
+        regulates: >-
+          Something worth regulating, described well enough to re-adjudicate.
+        proof: tests/test_rogue_guard.py::test_it_fires_on_a_real_defect
+        mutation: >-
+          Break the thing, run the guard, assert non-zero.
+    """
+)
+
+PROOF_FILE = textwrap.dedent(
+    """\
+    def test_it_fires_on_a_real_defect() -> None:
+        assert True
+    """
+)
+
+
+def build_tree(
+    root: Path,
+    *,
+    register: str = "sensors: []\n",
+    gates: dict[str, str] | None = None,
+    proof: str | None = None,
+    scripts: tuple[str, ...] = ("scripts/rogue_guard.py",),
+) -> Path:
+    """Write a throwaway repo containing only what the checker reads.
+
+    Args:
+        root: Directory to build in.
+        register: Contents of ``docs/sensors/register.yaml``.
+        gates: Gate-site files as relpath → content. Defaults to a Makefile whose
+            ci-local recipe runs ``scripts/rogue_guard.py``; pass ``{}`` for none.
+        proof: Contents of ``tests/test_rogue_guard.py``, or None to omit it.
+        scripts: Sensor scripts to create, relative to the tree root.
+
+    Returns:
+        The tree root, for chaining.
+
+    """
+    (root / "docs" / "sensors").mkdir(parents=True, exist_ok=True)
+    (root / REGISTER_RELPATH).write_text(register)
+
+    files = dict(gates if gates is not None else {"Makefile": MAKEFILE})
+    if proof is not None:
+        files["tests/test_rogue_guard.py"] = proof
+    for relpath in scripts:
+        files[relpath] = "def main() -> int:\n    return 1\n"
+
+    for relpath, content in files.items():
+        target = root / relpath
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+
+    return root
+
+
+def failures(root: Path) -> list[str]:
+    """Return the checker's findings against a tree, as plain strings."""
+    return [str(finding) for finding in check_register(root)]
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# The load-bearing test — this checker's own proof that it can fail
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestItsOwnProofOfTeeth:
+    """B-043 ships a sensor, and a sensor that cannot fail is worse than none —
+    it is the `|| true` on `validate_badges` that swallowed both the stale-badge
+    failures it existed to catch *and* the proof it had no implementation.
+
+    These tests mutate a fixture tree (add a sensor, do not register it) and
+    assert the checker notices. Nothing else in this file substitutes for them.
+    """
+
+    def test_a_wired_sensor_absent_from_the_register_fails(
+        self, tmp_path: Path
+    ) -> None:
+        build_tree(tmp_path, register="sensors: []\n")
+
+        found = failures(tmp_path)
+
+        assert found, (
+            "a sensor wired into ci-local but unregistered must fail the check"
+        )
+        assert any("rogue_guard" in f for f in found)
+
+    def test_that_same_tree_passes_once_the_sensor_is_registered(
+        self, tmp_path: Path
+    ) -> None:
+        """The other half of the mutation: without this, the failure above could
+        be an unconditional failure rather than a detection."""
+        build_tree(tmp_path, register=PROVEN_ENTRY, proof=PROOF_FILE)
+
+        assert failures(tmp_path) == []
+
+    def test_it_exits_non_zero_at_the_command_line(self, tmp_path: Path) -> None:
+        """`make ci-local` reads the exit code, not the findings list."""
+        build_tree(tmp_path, register="sensors: []\n")
+
+        assert main(["--root", str(tmp_path)]) != 0
+
+    def test_it_exits_zero_when_the_register_is_honest(self, tmp_path: Path) -> None:
+        build_tree(tmp_path, register=PROVEN_ENTRY, proof=PROOF_FILE)
+
+        assert main(["--root", str(tmp_path)]) == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Discovery — what the register's boundary actually is
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestDiscoveryFindsSensorsAtTheirGateSite:
+    """A filename pattern (`*_guard.py`, `validate_*.py`) is gameable by renaming
+    and blind to a sensor wired in under any other name. Discovery reads the
+    wiring instead: a script is a sensor when a gate site invokes it.
+    """
+
+    def test_a_makefile_recipe_is_a_gate_site(self, tmp_path: Path) -> None:
+        build_tree(tmp_path)
+
+        assert "scripts/rogue_guard.py" in discover_gate_scripts(tmp_path)
+
+    def test_a_pre_commit_entry_is_a_gate_site(self, tmp_path: Path) -> None:
+        build_tree(tmp_path, gates={".pre-commit-config.yaml": PRECOMMIT})
+
+        assert "scripts/rogue_guard.py" in discover_gate_scripts(tmp_path)
+
+    def test_a_harness_hook_is_a_gate_site(self, tmp_path: Path) -> None:
+        """B-030's hooks block a tool call and a turn; open question 2 in the spec
+        answers yes — a hook is registered separately from what it invokes."""
+        build_tree(
+            tmp_path,
+            gates={".claude/settings.json": SETTINGS},
+            scripts=("scripts/hooks/rogue_hook.py",),
+        )
+
+        assert "scripts/hooks/rogue_hook.py" in discover_gate_scripts(tmp_path)
+
+    def test_a_makefile_comment_is_not_a_gate_site(self, tmp_path: Path) -> None:
+        """The real Makefile discusses scripts in its comments at length. Counting
+        those would make the register a transcript of the commentary."""
+        build_tree(
+            tmp_path,
+            gates={
+                "Makefile": "# see scripts/rogue_guard.py for the reasoning\nall:\n\t@true\n"
+            },
+        )
+
+        assert discover_gate_scripts(tmp_path) == {}
+
+    def test_the_gate_site_is_recorded_not_just_the_script(
+        self, tmp_path: Path
+    ) -> None:
+        """`--list` has to say where a sensor fires; "somewhere" is not auditable."""
+        build_tree(tmp_path)
+
+        assert discover_gate_scripts(tmp_path)["scripts/rogue_guard.py"] == ["Makefile"]
+
+    def test_a_missing_gate_site_file_is_not_an_error(self, tmp_path: Path) -> None:
+        """A tree with no pre-commit config discovers nothing from it and says
+        nothing about it — degrade, do not crash."""
+        build_tree(tmp_path, gates={})
+
+        assert discover_gate_scripts(tmp_path) == {}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Proof resolution — the three rules from the spec
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestAProofMustExistAndBeAbleToRun:
+    """Rule 2: an entry naming a proof that does not exist, is skipped, or is
+    xfail has a register entry and no proof. That is worse than `proof: none`,
+    which at least admits it."""
+
+    def test_a_proof_naming_a_missing_file_fails(self, tmp_path: Path) -> None:
+        build_tree(tmp_path, register=PROVEN_ENTRY, proof=None)
+
+        assert any("tests/test_rogue_guard.py" in f for f in failures(tmp_path))
+
+    def test_a_proof_naming_a_missing_test_fails(self, tmp_path: Path) -> None:
+        build_tree(
+            tmp_path,
+            register=PROVEN_ENTRY,
+            proof="def test_something_else() -> None:\n    assert True\n",
+        )
+
+        assert any("test_it_fires_on_a_real_defect" in f for f in failures(tmp_path))
+
+    def test_a_skipped_proof_fails(self, tmp_path: Path) -> None:
+        """Skipping is how a proof rots quietly: it stays green and stops running."""
+        build_tree(
+            tmp_path,
+            register=PROVEN_ENTRY,
+            proof=(
+                "import pytest\n\n\n"
+                '@pytest.mark.skip(reason="flaky")\n'
+                "def test_it_fires_on_a_real_defect() -> None:\n    assert True\n"
+            ),
+        )
+
+        assert any("skip" in f.lower() for f in failures(tmp_path))
+
+    def test_an_xfail_proof_fails(self, tmp_path: Path) -> None:
+        build_tree(
+            tmp_path,
+            register=PROVEN_ENTRY,
+            proof=(
+                "import pytest\n\n\n"
+                "@pytest.mark.xfail\n"
+                "def test_it_fires_on_a_real_defect() -> None:\n    assert True\n"
+            ),
+        )
+
+        assert any("xfail" in f.lower() for f in failures(tmp_path))
+
+    def test_a_proof_inside_a_class_resolves(self, tmp_path: Path) -> None:
+        """Most proofs in this repo live in a class; `file::Class::test` must work."""
+        build_tree(
+            tmp_path,
+            register=PROVEN_ENTRY.replace(
+                "tests/test_rogue_guard.py::test_it_fires_on_a_real_defect",
+                "tests/test_rogue_guard.py::TestTeeth::test_it_fires_on_a_real_defect",
+            ),
+            proof=(
+                "class TestTeeth:\n"
+                "    def test_it_fires_on_a_real_defect(self) -> None:\n"
+                "        assert True\n"
+            ),
+        )
+
+        assert failures(tmp_path) == []
+
+    def test_a_skipped_class_fails_its_proof(self, tmp_path: Path) -> None:
+        """A class-level skip mutes every proof inside it, silently."""
+        build_tree(
+            tmp_path,
+            register=PROVEN_ENTRY.replace(
+                "tests/test_rogue_guard.py::test_it_fires_on_a_real_defect",
+                "tests/test_rogue_guard.py::TestTeeth::test_it_fires_on_a_real_defect",
+            ),
+            proof=(
+                "import pytest\n\n\n"
+                '@pytest.mark.skip(reason="later")\n'
+                "class TestTeeth:\n"
+                "    def test_it_fires_on_a_real_defect(self) -> None:\n"
+                "        assert True\n"
+            ),
+        )
+
+        assert any("skip" in f.lower() for f in failures(tmp_path))
+
+
+class TestAnEntryMustCarryItsReasoning:
+    """Rule 3: `regulates` and `mutation` exist so a reviewer can check the claim
+    against the test in one glance. The checker cannot verify a proof is genuine
+    — that limit is deliberate — so the reviewer needs the reasoning written down."""
+
+    def test_a_missing_regulates_fails(self, tmp_path: Path) -> None:
+        register = "\n".join(
+            line
+            for line in PROVEN_ENTRY.splitlines()
+            if "regulates" not in line and "Something worth regulating" not in line
+        )
+        build_tree(tmp_path, register=register + "\n", proof=PROOF_FILE)
+
+        assert any("regulates" in f for f in failures(tmp_path))
+
+    def test_a_missing_mutation_fails(self, tmp_path: Path) -> None:
+        register = "\n".join(
+            line
+            for line in PROVEN_ENTRY.splitlines()
+            if "mutation" not in line and "Break the thing" not in line
+        )
+        build_tree(tmp_path, register=register + "\n", proof=PROOF_FILE)
+
+        assert any("mutation" in f for f in failures(tmp_path))
+
+    def test_an_entry_naming_a_script_that_does_not_exist_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """A register that outlives its sensor claims coverage it does not have."""
+        build_tree(tmp_path, register=PROVEN_ENTRY, proof=PROOF_FILE, scripts=())
+
+        assert any("scripts/rogue_guard.py" in f for f in failures(tmp_path))
+
+
+class TestProofNoneIsAnHonestBaseline:
+    """The spec ships the register green on a TRUE baseline rather than after a
+    backfill sprint, and the count of `proof: none` is the burndown. An unproved
+    sensor that says so is strictly better than one nobody has counted."""
+
+    NONE_ENTRY = textwrap.dedent(
+        """\
+        sensors:
+          - id: rogue_guard
+            script: scripts/rogue_guard.py
+            gates: ["make ci-local"]
+            regulates: >-
+              Something worth regulating.
+            proof: none
+            reason: >-
+              Backfilled 2026-08-01 as a measured baseline; proof scheduled.
+        """
+    )
+
+    def test_proof_none_with_a_reason_passes(self, tmp_path: Path) -> None:
+        build_tree(tmp_path, register=self.NONE_ENTRY)
+
+        assert failures(tmp_path) == []
+
+    def test_proof_none_without_a_reason_fails(self, tmp_path: Path) -> None:
+        """Otherwise `proof: none` is a mute button rather than a recorded override."""
+        register = "\n".join(
+            line
+            for line in self.NONE_ENTRY.splitlines()
+            if "reason" not in line and "Backfilled" not in line
+        )
+        build_tree(tmp_path, register=register + "\n")
+
+        assert any("reason" in f for f in failures(tmp_path))
+
+    def test_proof_none_does_not_need_a_mutation(self, tmp_path: Path) -> None:
+        """There is no mutation to describe when there is no proof."""
+        build_tree(tmp_path, register=self.NONE_ENTRY)
+
+        assert not any("mutation" in f for f in failures(tmp_path))
+
+
+class TestNotEverythingWiredIntoAGateIsASensor:
+    """`session_context` injects the constraints at SessionStart and
+    `post_edit_sensor` returns `additionalContext`. Both are wired into
+    `.claude/settings.json`, so discovery finds them; neither can deny a call or
+    fail a gate, so there is no "can it fail?" to answer. `proof: n/a` records
+    that, and keeps the `proof: none` burndown counting only what is owed.
+    """
+
+    NA_ENTRY = textwrap.dedent(
+        """\
+        sensors:
+          - id: rogue_guard
+            script: scripts/rogue_guard.py
+            gates: ["make ci-local"]
+            regulates: >-
+              Nothing — it only reports.
+            proof: n/a
+            reason: >-
+              Returns additionalContext; it cannot block a call or fail a gate.
+        """
+    )
+
+    def test_proof_na_with_a_reason_passes(self, tmp_path: Path) -> None:
+        build_tree(tmp_path, register=self.NA_ENTRY)
+
+        assert failures(tmp_path) == []
+
+    def test_proof_na_without_a_reason_fails(self, tmp_path: Path) -> None:
+        """Otherwise `n/a` is a way to exempt a real sensor in one word."""
+        register = "\n".join(
+            line
+            for line in self.NA_ENTRY.splitlines()
+            if "reason" not in line and "additionalContext" not in line
+        )
+        build_tree(tmp_path, register=register + "\n")
+
+        assert any("reason" in f for f in failures(tmp_path))
+
+    def test_it_does_not_count_towards_the_burndown(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """`n/a` is not a debt; counting it as one makes the burndown never reach
+        zero and so stop being read."""
+        build_tree(tmp_path, register=self.NA_ENTRY)
+
+        main(["--root", str(tmp_path), "--list"])
+
+        assert "0 unproved" in capsys.readouterr().out
+
+
+class TestTheRegisterFileItself:
+    """Malformed input must fail the gate rather than silently pass it — the
+    `(mypy || echo advisory)` failure mode, where 'never ran' looked like 'clean'."""
+
+    def test_a_missing_register_fails(self, tmp_path: Path) -> None:
+        (tmp_path / "Makefile").write_text(MAKEFILE)
+
+        assert failures(tmp_path)
+        assert main(["--root", str(tmp_path)]) != 0
+
+    def test_unparseable_yaml_fails(self, tmp_path: Path) -> None:
+        build_tree(tmp_path, register="sensors: [unclosed\n")
+
+        assert failures(tmp_path)
+
+    def test_a_register_that_is_not_a_mapping_fails(self, tmp_path: Path) -> None:
+        build_tree(tmp_path, register="- just\n- a\n- list\n")
+
+        assert failures(tmp_path)
+
+    def test_a_duplicate_id_fails(self, tmp_path: Path) -> None:
+        """Two entries with one id means one of them is never read."""
+        build_tree(
+            tmp_path,
+            register=PROVEN_ENTRY + PROVEN_ENTRY.split("\n", 1)[1],
+            proof=PROOF_FILE,
+        )
+
+        assert any("duplicate" in f.lower() for f in failures(tmp_path))
+
+
+class TestTheListView:
+    """`--list` is where the `proof: none` burndown lives, rather than in
+    someone's head."""
+
+    def test_list_reports_each_sensor_and_exits_zero(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        build_tree(tmp_path, register=PROVEN_ENTRY, proof=PROOF_FILE)
+
+        code = main(["--root", str(tmp_path), "--list"])
+
+        assert code == 0
+        assert "rogue_guard" in capsys.readouterr().out
+
+    def test_list_counts_the_unproved(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        build_tree(tmp_path, register=TestProofNoneIsAnHonestBaseline.NONE_ENTRY)
+
+        main(["--root", str(tmp_path), "--list"])
+
+        assert "1" in capsys.readouterr().out
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# The real repo
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTheRealRegister:
+    """The gate has to be green on `main` from the first commit, and the register
+    has to describe this repo rather than an aspiration."""
+
+    def test_the_shipped_register_passes_its_own_check(self) -> None:
+        found = failures(REPO_ROOT)
+
+        assert found == [], "\n".join(found)
+
+    def test_this_checker_is_in_its_own_register(self) -> None:
+        """A sensor exempting itself is the failure this item is named after."""
+        register = (REPO_ROOT / REGISTER_RELPATH).read_text()
+
+        assert "scripts/check_sensor_proofs.py" in register

--- a/tests/test_destructive_change_guard.py
+++ b/tests/test_destructive_change_guard.py
@@ -1,13 +1,41 @@
 #!/usr/bin/env python3
-"""Tests for destructive change guard."""
+"""Tests for destructive change guard.
 
+`TestItCatchesARealGutting` is this sensor's **proof of teeth** (B-043). Until it
+was written, every test in this file checked configuration (is this file on the
+critical list?) or the bypass path — nothing gutted a file and asserted the guard
+noticed. That is the difference the B-043 baseline measured across the repo:
+unit tests answer *does the code work*, efficacy tests answer *does it fire on a
+real defect*, and only the second kind would have caught the four inert sensors
+found on 2026-08-01.
+
+The proof runs against a real git repository in `tmp_path` rather than mocked
+diff stats, deliberately. B-039's third finding was a fix that looked right and
+did nothing — `export PATH :=` in the Makefile, confirmed by `make showpath`,
+still ran the ambient binary. Mocking `get_diff_stats` would test the arithmetic
+while assuming the git plumbing underneath it works, which is the same shape of
+assumption. This truncates a real file in a real repo and runs the real guard.
+"""
+
+import subprocess
+from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from scripts.destructive_change_guard import (
     CRITICAL_FILES,
     MAX_DELETION_PCT,
+    check_destructive_changes,
     get_intentional_rewrites,
+    main,
 )
+
+#: A file on CRITICAL_FILES, so the guard is supposed to protect it.
+PROTECTED = "scripts/publication_validator.py"
+
+#: One that is not, so it is the control.
+UNPROTECTED = "scripts/spend_report.py"
 
 
 class TestConfiguration:
@@ -98,3 +126,112 @@ class TestIntentionalRewriteBypass:
             mock_run.return_value.stdout = body
             allowlist = get_intentional_rewrites()
         assert "src/agent_sdk/stage4_runner.py" in allowlist
+
+
+def _git(repo: Path, *args: str) -> None:
+    """Run one git command in a fixture repo, raising on failure."""
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A git repo on `main` holding a 100-line copy of each candidate file.
+
+    The guard resolves everything through git in the process's working directory,
+    so the fixture chdirs rather than patching. It also clears the PR-context
+    environment: an allowlisted file is waved through, and a proof that passes
+    because the defect was allowlisted proves nothing.
+    """
+    for name in (PROTECTED, UNPROTECTED):
+        target = tmp_path / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("".join(f"line {n}\n" for n in range(100)))
+
+    _git(tmp_path, "init", "-b", "main")
+    _git(tmp_path, "config", "user.email", "test@example.com")
+    _git(tmp_path, "config", "user.name", "Test")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-m", "baseline")
+
+    for var in ("GITHUB_REF", "PR_NUMBER", "INTENTIONAL_REWRITE"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+class TestItCatchesARealGutting:
+    """The mutation the spec names: truncate a file listed as critical to a stub,
+    run the guard, assert it blocks."""
+
+    def test_gutting_a_critical_file_is_caught(self, repo: Path) -> None:
+        (repo / PROTECTED).write_text("# gutted\n")
+
+        violations = check_destructive_changes()
+
+        assert violations, "a critical file cut from 100 lines to 1 must be blocked"
+        assert PROTECTED in violations[0]
+
+    def test_the_violation_reports_the_scale_of_the_loss(self, repo: Path) -> None:
+        """A blocked commit has to say what tripped it or it just gets retried."""
+        (repo / PROTECTED).write_text("# gutted\n")
+
+        assert "99%" in check_destructive_changes()[0]
+
+    def test_it_exits_non_zero(self, repo: Path) -> None:
+        """`make ci-local` reads the exit code, not the return value."""
+        (repo / PROTECTED).write_text("# gutted\n")
+
+        with pytest.raises(SystemExit) as exit_info:
+            main()
+
+        assert exit_info.value.code == 1
+
+
+class TestItDoesNotFireOnOrdinaryWork:
+    """The other half of the mutation. A guard that blocks everything is
+    disabled within a day — the noise-overload failure mode that gets a sensor
+    reverted to `stages: [manual]`, which is exactly what B-031 found mypy on."""
+
+    def test_a_targeted_edit_passes(self, repo: Path) -> None:
+        lines = (repo / PROTECTED).read_text().splitlines(keepends=True)
+        (repo / PROTECTED).write_text("".join(lines[:90]))
+
+        assert check_destructive_changes() == []
+
+    def test_an_untouched_tree_passes(self, repo: Path) -> None:
+        assert check_destructive_changes() == []
+
+    def test_it_exits_zero_on_a_clean_tree(self, repo: Path) -> None:
+        with pytest.raises(SystemExit) as exit_info:
+            main()
+
+        assert exit_info.value.code == 0
+
+    def test_gutting_a_file_that_is_not_critical_passes(self, repo: Path) -> None:
+        """The list is the scope. Widening it silently would make the guard a
+        general "large diff" alarm, which is a different and much noisier tool."""
+        (repo / UNPROTECTED).write_text("# gutted\n")
+
+        assert check_destructive_changes() == []
+
+
+class TestTheBypassStillWorks:
+    """An intentional rewrite is allowed — but only when it is recorded, which is
+    the `docs/harness-overrides.md` convention in another form."""
+
+    def test_an_allowlisted_file_is_waved_through(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (repo / PROTECTED).write_text("# gutted\n")
+        monkeypatch.setenv("INTENTIONAL_REWRITE", PROTECTED)
+
+        assert check_destructive_changes() == []
+
+    def test_allowlisting_a_different_file_does_not_help(
+        self, repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A blanket bypass would be the `|| true` B-031 deleted."""
+        (repo / PROTECTED).write_text("# gutted\n")
+        monkeypatch.setenv("INTENTIONAL_REWRITE", UNPROTECTED)
+
+        assert check_destructive_changes()

--- a/tests/test_html_to_brief.py
+++ b/tests/test_html_to_brief.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 from bs4 import BeautifulSoup
 
+from scripts import html_to_brief
 from scripts.html_to_brief import (
     REFUTED_HEADING,
     BriefConversionError,
@@ -528,3 +529,72 @@ class TestHtmlToMarkdownDirectly:
         assert "Section" in body
         assert "Prose." in body
         assert REFUTED_HEADING not in body
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Proof of teeth for the no-drop invariant (B-043)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestTheNoDropInvariantHasTeeth:
+    """The third of the three mutations run by hand on 2026-08-01, recorded here
+    so it stops living in shell history (B-043).
+
+    `TestNothingSilentlyDropped` above is this converter's most important sensor:
+    it is the only thing standing between a research brief and silently losing a
+    paragraph on its way to the writer, and a lost paragraph is invisible
+    downstream — the article simply never mentions it.
+
+    A test that asserts an invariant holds says nothing about whether it would
+    *notice* the invariant breaking. So this class breaks it on purpose. Adding
+    `table` to `CHROME_TAGS` makes the converter discard tabular content, and the
+    invariant must report the loss; the hand-run version of this reported 48 lost
+    words.
+
+    This is why `content_words()` computes the expected set from `SPEC_CHROME_TAGS`
+    hardcoded in this file rather than importing `CHROME_TAGS` from the module. If
+    it imported it, the expectation would move with the mutation and the whole
+    check would pass while content vanished — a sensor calibrated against the thing
+    it is measuring.
+    """
+
+    def test_dropping_a_content_tag_is_reported(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        html = read_fixture("table_bearing")
+        monkeypatch.setattr(
+            html_to_brief, "CHROME_TAGS", (*SPEC_CHROME_TAGS, "table", "tbody", "tr")
+        )
+
+        out = words(build_brief(html, source_name="table_bearing.html"))
+
+        missing = content_words(html) - out
+        assert missing, (
+            "CHROME_TAGS now discards tables, so the invariant must report the "
+            "lost words — it did not, which means it could not have caught this"
+        )
+
+    def test_the_same_fixture_is_clean_unmutated(self) -> None:
+        """The control. Without it the assertion above would also pass against an
+        invariant that reports losses unconditionally."""
+        html = read_fixture("table_bearing")
+
+        out = words(build_brief(html, source_name="table_bearing.html"))
+
+        assert not content_words(html) - out
+
+    def test_the_runtime_check_reports_a_loss(self) -> None:
+        """`find_dropped_words` runs on every real conversion, not only in tests.
+        Feed it a markdown rendering with content removed and it must say so."""
+        html = read_fixture("headings_and_prose")
+        markdown = build_brief(html, source_name="headings_and_prose.html")
+
+        truncated = "\n".join(markdown.splitlines()[:3])
+
+        assert html_to_brief.find_dropped_words(html, truncated)
+
+    def test_the_runtime_check_is_silent_on_a_faithful_conversion(self) -> None:
+        html = read_fixture("headings_and_prose")
+        markdown = build_brief(html, source_name="headings_and_prose.html")
+
+        assert not html_to_brief.find_dropped_words(html, markdown)

--- a/tests/test_lint_adrs.py
+++ b/tests/test_lint_adrs.py
@@ -1,0 +1,195 @@
+"""Proof of teeth for the ADR governance lint (B-043).
+
+`scripts/lint_adrs.py` is the `adr-lint` pre-commit hook and had **zero tests**
+until this file — the other of the two largest gaps the B-043 baseline measured.
+It enforces `skills/adr-governance/SKILL.md`: one canonical location, one number
+per ADR, a status from a closed set, an mkdocs entry, and supersession links that
+point both ways.
+
+Every test here plants **one** governance defect in a throwaway ADR tree and
+asserts the lint reports it, with a clean tree as the control. A lint with seven
+rules and no proof that any of them fires is seven rules on paper.
+
+Two of these have bitten this repo for real: ADR-0018 was renumbered from 0016
+after `main` landed a different ADR-0016 while the draft sat on disk (a duplicate
+number), and `adr-lint` fails while an ADR is untracked because the hook
+framework stashes the `mkdocs.yml` nav line but not the file (the mkdocs rule).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from scripts.lint_adrs import lint, main
+
+ADR = textwrap.dedent(
+    """\
+    # ADR-0001: A Decision
+
+    **Status:** Accepted
+    **Date:** 2026-08-01
+
+    ## Context
+
+    Something needed deciding.
+    """
+)
+
+
+def write_adr(root: Path, name: str, body: str = ADR, *, in_nav: bool = True) -> Path:
+    """Add an ADR to a fixture tree, optionally wiring it into mkdocs.yml."""
+    path = root / "docs" / "adr" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    if in_nav:
+        nav = root / "mkdocs.yml"
+        nav.write_text(nav.read_text() + f"      - adr/{name}\n")
+    return path
+
+
+@pytest.fixture
+def tree(tmp_path: Path) -> Path:
+    """A minimal repo with one valid ADR — the control for every mutation."""
+    (tmp_path / "mkdocs.yml").write_text("nav:\n  - ADRs:\n")
+    write_adr(tmp_path, "0001-a-decision.md")
+    return tmp_path
+
+
+class TestTheCleanTreeIsClean:
+    """Without this, every failing assertion below could be an always-red lint."""
+
+    def test_a_valid_adr_tree_passes(self, tree: Path) -> None:
+        assert lint(tree) == []
+
+    def test_it_exits_zero(self, tree: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.argv", ["lint_adrs.py", "--repo-root", str(tree)])
+
+        assert main() == 0
+
+
+class TestItFiresOnEachGovernanceDefect:
+    """One mutation per rule. Each asserts the *specific* rule fired, not merely
+    that something did — a lint that reports the wrong reason sends the next
+    reader to the wrong place."""
+
+    def test_a_status_outside_the_allowed_set_is_caught(self, tree: Path) -> None:
+        write_adr(
+            tree,
+            "0002-approved.md",
+            ADR.replace("**Status:** Accepted", "**Status:** Approved"),
+        )
+
+        assert any("not in allowed set" in e for e in lint(tree))
+
+    def test_a_missing_status_header_is_caught(self, tree: Path) -> None:
+        write_adr(tree, "0002-no-status.md", "# ADR-0002: No Status\n\n## Context\n")
+
+        assert any("missing '**Status:**' header" in e for e in lint(tree))
+
+    def test_a_filename_off_the_pattern_is_caught(self, tree: Path) -> None:
+        write_adr(tree, "0002_snake_case.md")
+
+        assert any("does not match NNNN-kebab-case" in e for e in lint(tree))
+
+    def test_a_duplicate_number_is_caught(self, tree: Path) -> None:
+        """This one happened: ADR-0018 was renumbered from 0016 because `main`
+        landed a different 0016 while the draft sat uncommitted on disk."""
+        write_adr(tree, "0001-a-different-decision.md")
+
+        assert any("duplicate ADR number" in e for e in lint(tree))
+
+    def test_an_adr_missing_from_mkdocs_is_caught(self, tree: Path) -> None:
+        write_adr(tree, "0002-unlisted.md", in_nav=False)
+
+        assert any("not referenced in mkdocs.yml" in e for e in lint(tree))
+
+    def test_an_adr_outside_the_canonical_directory_is_caught(self, tree: Path) -> None:
+        (tree / "docs" / "ADR-0002-stray.md").write_text(ADR)
+
+        assert any("outside canonical location" in e for e in lint(tree))
+
+    def test_a_superseded_adr_with_no_link_is_caught(self, tree: Path) -> None:
+        write_adr(
+            tree,
+            "0002-superseded.md",
+            ADR.replace("**Status:** Accepted", "**Status:** Superseded"),
+        )
+
+        assert any("no 'Superseded by ADR-NNNN' link" in e for e in lint(tree))
+
+    def test_one_way_supersession_is_caught(self, tree: Path) -> None:
+        """A link that points one way is how an ADR tree starts lying about
+        which decision is current."""
+        write_adr(
+            tree,
+            "0002-the-superseder.md",
+            ADR.replace("**Date:**", "**Supersedes:** ADR-0001\n**Date:**"),
+        )
+
+        assert any("does not have 'Superseded by ADR-0002'" in e for e in lint(tree))
+
+    def test_a_dangling_supersession_target_is_caught(self, tree: Path) -> None:
+        write_adr(
+            tree,
+            "0002-points-at-nothing.md",
+            ADR.replace("**Date:**", "**Supersedes:** ADR-0099\n**Date:**"),
+        )
+
+        assert any("which does not exist" in e for e in lint(tree))
+
+    def test_a_bidirectional_pair_passes(self, tree: Path) -> None:
+        """The negative control for the two supersession tests above."""
+        (tree / "docs" / "adr" / "0001-a-decision.md").write_text(
+            ADR.replace(
+                "**Status:** Accepted",
+                "**Status:** Superseded\n**Superseded by** ADR-0002",
+            )
+        )
+        write_adr(
+            tree,
+            "0002-the-superseder.md",
+            ADR.replace("**Date:**", "**Supersedes:** ADR-0001\n**Date:**"),
+        )
+
+        assert lint(tree) == []
+
+
+class TestItCannotPassByFailingToRun:
+    """B-039's failure mode: a sensor that never ran reporting the same thing as
+    a sensor that ran and found nothing."""
+
+    def test_an_empty_adr_directory_is_an_error_not_a_pass(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "mkdocs.yml").write_text("nav:\n")
+        (tmp_path / "docs" / "adr").mkdir(parents=True)
+
+        assert any("no ADRs found" in e for e in lint(tmp_path))
+
+    def test_a_missing_mkdocs_is_an_error_not_a_pass(self, tmp_path: Path) -> None:
+        (tmp_path / "mkdocs.yml").write_text("nav:\n")
+        write_adr(tmp_path, "0001-a-decision.md")
+        (tmp_path / "mkdocs.yml").unlink()
+
+        assert any("not found" in e for e in lint(tmp_path))
+
+    def test_violations_exit_non_zero(
+        self, tree: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exit code is what the pre-commit hook reads."""
+        write_adr(tree, "0001-a-different-decision.md")
+        monkeypatch.setattr("sys.argv", ["lint_adrs.py", "--repo-root", str(tree)])
+
+        assert main() == 1
+
+
+class TestTheRealAdrTree:
+    """The repo's own ADRs must pass, or the hook is red on `main`."""
+
+    def test_this_repos_adrs_lint_clean(self) -> None:
+        errors = lint(Path(__file__).parent.parent)
+
+        assert errors == [], "\n".join(errors)


### PR DESCRIPTION
Implements **B-043**. Spec: `docs/specs/sensor-proof-of-teeth.md` (LGTM'd 2026-08-01).

B-031 fixed four sensors *by name* and left the class alone — which is why B-039 was still there
to find. This is the standing check rather than another audit.

## What ships

| | |
|---|---|
| `scripts/check_sensor_proofs.py` | the gate — a `make ci-local` step |
| `docs/sensors/register.yaml` | 20 entries: **19 proved, 0 unproved, 1 report-only** |
| `tests/test_check_sensor_proofs.py` | 33 tests, incl. the checker's own proof of teeth |

It fails when a script a gate site invokes has no register entry; when an entry names a proof
that does not exist, is `skip`, or is `xfail`; or when an entry omits the reasoning
(`regulates` / `mutation`) a reviewer needs to adjudicate the claim.

## The three decisions worth reviewing

**1. Discovery reads the wiring, not filenames.** The checker parses the `Makefile`,
`.pre-commit-config.yaml`, `.claude/settings.json` and the publish entrypoints. A
`scripts/*_guard.py` glob would have been gameable by renaming and blind to a sensor added under
any other name — the exact gap B-031 left open. **Consequence: add a sensor to any of those four
files and `make ci-local` goes red until you register it.** That is the feature.

**2. Verified in situ, not only against fixtures.** Adding a recipe invoking a new script to the
real `Makefile` made the real gate exit 1 naming it; reverting restored green. This is B-039's
third lesson applied to its own successor — `export PATH :=` looked right, `make showpath`
confirmed it, and only running a recipe against a stub binary showed it did nothing.

**3. The limit is stated rather than papered over.** The checker verifies a proof *exists and
runs*. It cannot verify a proof is *genuine* — `assert True` under an honest-sounding name
passes. Mutation-testing the mutation tests is where the value curve goes flat, so the
`mutation:` field exists instead, to make genuineness a one-glance review check. This is in the
script's own docstring, not only in the spec.

## Proofs written

`proof: none` was built as a legitimate recorded baseline and **turned out not to be needed** —
every discovered sensor got a real proof.

- **`tests/test_lint_adrs.py`** (16) and **`tests/test_check_bare_name_imports.py`** (10) — the
  two sensors with *zero* tests before this PR. Each test plants one defect and asserts the
  sensor fires, with a clean control.
- **`destructive_change_guard`** — its existing 12 tests checked configuration and the bypass
  path; nothing gutted a file. The new proof truncates a real file in a real git repo rather than
  mocking `get_diff_stats`, because mocking the plumbing assumes away exactly what B-039 found
  broken.
- **The third hand-run mutation from 2026-08-01 is now a test.** Two already survived in
  `test_ci_gate_is_reproducible.py`; nothing had mutated `CHROME_TAGS` to show the no-drop
  invariant would notice. Now `TestTheNoDropInvariantHasTeeth`.

**One inherited proof was quietly weak and got tightened.**
`test_schema_validation_rejects_invalid` asserted `pytest.raises((ValueError, Exception))`, which
passes on *any* error — a typo in the fixture would have satisfied it. That is B-039's defect in
miniature, inside a test. Tightened, since the register now claims it as a proof.

## Open question answered — what counts as a sensor

The proposal was right in substance and **wrong in one word**. It said *"anything whose non-zero
exit can block a commit, push, `ci-local`, or a publish"*. Measured, non-zero exit is the wrong
test: **every harness hook exits 0 by design**, so a broken hook cannot brick the session, and
they refuse via JSON instead.

| Wired into `.claude/settings.json` | How it refuses | Sensor? |
|---|---|---|
| `guard_constraints.py` | `permissionDecision: "deny"` | **yes** |
| `session_gate.py` | `decision: "block"` | **yes** |
| `post_edit_sensor.py` | `additionalContext` only | no — it reports |
| `session_context.py` | `additionalContext` only | no — it reports |

> **Adopted:** a sensor is anything a gate site invokes that can **refuse** — deny a tool call,
> block a turn, or exit non-zero.

Both named cases resolve as proposed, both **checked rather than assumed**:

- **`publication_validator` — in.** Imported by both publish entrypoints; its verdict stops a publish.
- **`article_evaluator` — out.** Zero gate-site references anywhere. It scored the fabricated
  article **76** while the validator passed it — precisely what "scores but does not gate" looks
  like. Note it *is* on `destructive_change_guard`'s `CRITICAL_FILES`: being protected from being
  gutted is not the same as being a sensor, and the two lists should not be conflated.

## Deliberately not built

- **The inferential runner** (B-040's arm). Sequencing unchanged — it waits on n≈5 real reviews
  per `docs/specs/review-gate-calibration.md`. The eight labelled cases already exist.
- **Anything toward verifying a proof is genuine.** See decision 3.
- **B-042.** `missing_chart` fires *correctly*; the defect is its setpoint, which a proof of teeth
  cannot catch. Its `publication_validator` register entry carries a note saying so, so the next
  reader of the register meets the limit rather than inferring it.

## Verification

`make ci-local`: **2,761 passed, 9 skipped** (2,689 on `main` — 72 new tests), coverage **83.82%**,
**93%** on the new module. No new dependency (PyYAML was already required), no key, no network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
