### PR TITLE
B-042 live acceptance: two defects the tests could not see

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -26,6 +26,33 @@ _(none)_
 
 ## Todo
 
+### B-044 · Finish the B-042 acceptance — the two steps only the owner can take
+
+**Opened 2026-08-02** from the first live run of the hand-off. Full record:
+`docs/reviews/b042-live-acceptance-2026-08-02.md`.
+
+The flow now works end to end in code — **BUG-070** and **BUG-071** were found live and are
+fixed, with regression tests. What remains is not code:
+
+1. **Draw the hero** at `output/posts/images/migration-deadline-testing-trap-hero.svg`. The
+   brief is in the review packet and the `.image_prompt.md` sidecar. Then `make art
+   SLUG=migration-deadline-testing-trap`, deploy `--mode review`, read the live page,
+   `make publish`. Steps 4 and 5 have **never run live** and will not until the hero exists.
+2. **Re-source the artifact**, if the B-038 HTML→brief path is to be accepted too. This run
+   used `claude_web` instead, because the Claude.ai conversation that produced
+   `sre-quality-governance-guide.html` could not be identified from `recents` — the artifact
+   dates to **Jul 21 13:04** and nothing in the list obviously matches it. Pasting into a
+   guessed thread was not worth the risk.
+
+**Read the article before publishing.** Three editorial items are flagged in the record — the
+contested IBM 60-to-1 ratio carrying an uncited "corroborated by every serious study"
+sentence, a reference list that is mostly secondary sources, and 8 quantified claims without
+inline attribution.
+
+**Two small, non-blocking improvements to the chart proposal**, both observed on the real
+packet: range endpoints are extracted as point values ("15–20%" proposes a row reading
+`20 %`), and the ±60-character context window cuts mid-word.
+
 > **Opened 2026-07-29 from the article-two run.** **B-025** was withdrawn the same
 > day (see below); **B-026** and **B-027** landed the same day (see Done). Ids are
 > never reused, so all three numbers stay spent. **B-028** and **B-029** are open,

--- a/data/skills_state/defect_tracker.json
+++ b/data/skills_state/defect_tracker.json
@@ -1184,10 +1184,27 @@
       "prevention_test_added": false,
       "introduced_in_commit": "95c838ce",
       "introduced_date": "2026-08-01"
+    },
+    {
+      "id": "BUG-071",
+      "severity": "critical",
+      "discovered_in": "acceptance",
+      "discovered_date": "2026-08-02T00:00:00",
+      "description": "`## References` rendered as literal text on generated articles. The stat audit collapses the blank line before it; kramdown will not start a block element on the line after a paragraph. The CRITICAL inline_heading_marker check could not see it, because the same edit leaves a trailing space and the check's regex allowed only one whitespace character.",
+      "component": "stage3_runner",
+      "status": "fixed",
+      "fixed_date": "2026-08-02T00:00:00",
+      "is_production_escape": false,
+      "root_cause": "validation_gap",
+      "root_cause_notes": "audit_article_stats splits on (?<=[.!?])\\s+ and rejoins with ' ', swallowing the newline before '## References'. This has happened on every article; Stage 4's unconditional chart embed sat in the gap and supplied the blank line by accident. B-042 deleted that embed, so the first chart-less article is the first one to break. Verified by running kramdown directly, and by the '. \\n![Chart]...\\n\\n## References' shape still on disk in both pre-B-042 articles.",
+      "prevention_test_added": true,
+      "prevention_test_file": "tests/test_normalize_paragraphs.py",
+      "introduced_in_commit": "95c838ce",
+      "introduced_date": "2026-08-01"
     }
   ],
   "summary": {
-    "total_bugs": 53,
+    "total_bugs": 54,
     "fixed_bugs": 7,
     "production_bugs": 6,
     "defect_escape_rate": 42.9,
@@ -1225,6 +1242,6 @@
     "avg_time_to_resolve_days": 2.0,
     "avg_critical_ttd_days": 3.7,
     "last_updated": "2026-08-02T00:00:00",
-    "total": 53
+    "total": 54
   }
 }

--- a/data/skills_state/defect_tracker.json
+++ b/data/skills_state/defect_tracker.json
@@ -436,7 +436,7 @@
         "Added LENGTH as first MANDATORY rule in writer prompt",
         "Documented gate vs target in prompt (gate=700, target=800-1000)"
       ],
-      "fix_notes": "Aligned word-count gates across codebase to 700 (matches publication_validator.py and skills/economist-writing/SKILL.md sweet-spot floor). Updated agent_reviewer.py, editorial_judge.py, skill_synthesizer.py from 800→700. Strengthened stage3_crew.py writer prompt with explicit LENGTH rule (700-1200 words, target 800-1000) in MANDATORY block."
+      "fix_notes": "Aligned word-count gates across codebase to 700 (matches publication_validator.py and skills/economist-writing/SKILL.md sweet-spot floor). Updated agent_reviewer.py, editorial_judge.py, skill_synthesizer.py from 800\u2192700. Strengthened stage3_crew.py writer prompt with explicit LENGTH rule (700-1200 words, target 800-1000) in MANDATORY block."
     },
     {
       "id": "BUG-030",
@@ -502,7 +502,7 @@
       "status": "fixed",
       "fixed_date": "2026-04-26T16:56:33.701701",
       "fix_commit": "2cf28a4",
-      "fix_notes": "Allow `_client` injection to bypass the availability guard — caller is supplying whatever interface chroma would provide.",
+      "fix_notes": "Allow `_client` injection to bypass the availability guard \u2014 caller is supplying whatever interface chroma would provide.",
       "root_cause": "code_logic",
       "root_cause_notes": "Availability guard checked before honouring injection.",
       "is_production_escape": false,
@@ -531,7 +531,7 @@
         "new_validation"
       ],
       "prevention_actions": [
-        "Add a regression test asserting the dashboard's sprint-trends section renders with non-empty content when sprint_history.json contains ≥2 sprints.",
+        "Add a regression test asserting the dashboard's sprint-trends section renders with non-empty content when sprint_history.json contains \u22652 sprints.",
         "Grep audit: any future state-file relocation must update all readers in one commit."
       ]
     },
@@ -540,20 +540,20 @@
       "severity": "high",
       "discovered_in": "test_failure",
       "discovered_date": "2026-04-26T16:56:33.701701",
-      "description": "scripts/defect_tracker.py reads from legacy `skills/defect_tracker.json` instead of `data/skills_state/defect_tracker.json` — same migration miss as BUG-034",
+      "description": "scripts/defect_tracker.py reads from legacy `skills/defect_tracker.json` instead of `data/skills_state/defect_tracker.json` \u2014 same migration miss as BUG-034",
       "component": "defect_tracker",
       "status": "fixed",
       "fixed_date": "2026-04-26T16:56:33.701701",
       "fix_commit": "2cf28a4",
       "fix_notes": "Path updated to data/skills_state/.",
       "root_cause": "integration_error",
-      "root_cause_notes": "Same migration as BUG-034 — three readers missed when state files moved.",
+      "root_cause_notes": "Same migration as BUG-034 \u2014 three readers missed when state files moved.",
       "is_production_escape": true,
       "prevention_strategy": [
         "new_validation"
       ],
       "prevention_actions": [
-        "See BUG-034 — same prevention applies."
+        "See BUG-034 \u2014 same prevention applies."
       ]
     },
     {
@@ -561,20 +561,20 @@
       "severity": "high",
       "discovered_in": "test_failure",
       "discovered_date": "2026-04-26T16:56:33.701701",
-      "description": "scripts/agent_metrics.py reads from legacy `skills/agent_metrics.json` instead of `data/skills_state/agent_metrics.json` — same migration miss as BUG-034/035",
+      "description": "scripts/agent_metrics.py reads from legacy `skills/agent_metrics.json` instead of `data/skills_state/agent_metrics.json` \u2014 same migration miss as BUG-034/035",
       "component": "agent_metrics",
       "status": "fixed",
       "fixed_date": "2026-04-26T16:56:33.701701",
       "fix_commit": "2cf28a4",
       "fix_notes": "Path updated to data/skills_state/.",
       "root_cause": "integration_error",
-      "root_cause_notes": "Same migration as BUG-034 — three readers missed when state files moved.",
+      "root_cause_notes": "Same migration as BUG-034 \u2014 three readers missed when state files moved.",
       "is_production_escape": true,
       "prevention_strategy": [
         "new_validation"
       ],
       "prevention_actions": [
-        "See BUG-034 — same prevention applies."
+        "See BUG-034 \u2014 same prevention applies."
       ]
     },
     {
@@ -608,16 +608,16 @@
           "patch_frontmatter_extensible": "_patch_frontmatter (flow.py ~line 413) uses regex string injection. Straightforward to extend. Existing tests in TestPatchFrontmatter (test_flow_agent_sdk.py lines 339-357) cover the pattern.",
           "anthropic_mock_pattern": "conftest.py has mock_anthropic_client fixture (lines 26-38). Claude vision calls use the same query() async generator path. Mockable via patch of src.agent_sdk.stage3_runner.query.",
           "gaps_identified": [
-            "_FakePipelineResult (test_flow_agent_sdk.py lines 28-45) has no image_alt or image_caption fields — must be extended.",
+            "_FakePipelineResult (test_flow_agent_sdk.py lines 28-45) has no image_alt or image_caption fields \u2014 must be extended.",
             "No test currently validates stage3 output through publication_validator image metadata CRITICAL gates end-to-end."
           ],
           "critical_blocker": "Writer prompt (stage3_runner.py lines 253-256) MUST be updated first to require both fields. Vision refinement and frontmatter injection have nothing to refine until the writer emits these fields.",
           "recommended_test_plan": {
-            "test_writer_emits_fields": "tests/test_flow_agent_sdk.py — new TestWriterFrontmatter class",
-            "test_vision_refinement": "tests/test_flow_agent_sdk.py — new TestVisionRefinement class, patch query()",
-            "test_integration": "tests/test_flow_agent_sdk.py — extend TestQualityGate: mock pipeline → validator passes image gates",
-            "test_patch_frontmatter": "tests/test_flow_agent_sdk.py — extend TestPatchFrontmatter",
-            "sequence": "TDD: RED (write failing tests) → update prompt → GREEN → add vision step → REFACTOR"
+            "test_writer_emits_fields": "tests/test_flow_agent_sdk.py \u2014 new TestWriterFrontmatter class",
+            "test_vision_refinement": "tests/test_flow_agent_sdk.py \u2014 new TestVisionRefinement class, patch query()",
+            "test_integration": "tests/test_flow_agent_sdk.py \u2014 extend TestQualityGate: mock pipeline \u2192 validator passes image gates",
+            "test_patch_frontmatter": "tests/test_flow_agent_sdk.py \u2014 extend TestPatchFrontmatter",
+            "sequence": "TDD: RED (write failing tests) \u2192 update prompt \u2192 GREEN \u2192 add vision step \u2192 REFACTOR"
           }
         }
       },
@@ -799,7 +799,7 @@
       "github_issue": null,
       "is_production_escape": false,
       "root_cause": "code_logic",
-      "root_cause_notes": "DIAGNOSED (generous --writer-budget 3.00 run): DUAL cause. (1) Under-budget — the run completed at $0.5907 total, but the defaults (run_pipeline writer 0.30 / CLI 0.60) are exhausted once the writer retries. (2) The writer emits conversational preamble on some attempts (e.g. 'The search tool is wired to arXiv... I'll write the article grounded in...'), failing the well-formed check (starts_with_dash=False) and forcing a retry that burns budget. Fix: port the closed PR #441 _extract_article preamble/fence recovery into the stage3 retry loop so preamble attempts recover in-place instead of retrying, AND raise the default writer budget for margin. NOTE: a generous-budget run DID produce a publish-valid article (publication_validator PASSED) — keyless generation works.",
+      "root_cause_notes": "DIAGNOSED (generous --writer-budget 3.00 run): DUAL cause. (1) Under-budget \u2014 the run completed at $0.5907 total, but the defaults (run_pipeline writer 0.30 / CLI 0.60) are exhausted once the writer retries. (2) The writer emits conversational preamble on some attempts (e.g. 'The search tool is wired to arXiv... I'll write the article grounded in...'), failing the well-formed check (starts_with_dash=False) and forcing a retry that burns budget. Fix: port the closed PR #441 _extract_article preamble/fence recovery into the stage3 retry loop so preamble attempts recover in-place instead of retrying, AND raise the default writer budget for margin. NOTE: a generous-budget run DID produce a publish-valid article (publication_validator PASSED) \u2014 keyless generation works.",
       "discovered_by": "B-009 T1 fail-fast keyless run",
       "prevention_test_added": true,
       "fixed_date": "2026-07-22T00:00:00",
@@ -844,13 +844,13 @@
       "severity": "high",
       "discovered_in": "development",
       "discovered_date": "2026-07-22T00:00:00",
-      "description": "Keyless deterministic research is unreliable and aborts the whole pipeline. The two free providers (arXiv, Semantic Scholar) rate-limit/err heavily (HTTP 429/503); when BOTH fail on a topic, deterministic research returns zero sources and the empty-research guard (#438) aborts the run (exit 2, 'Pipeline aborted: research failed', provider_failed={'arxiv':True,'semantic_scholar':True}). Observed live: a default-budget keyless run aborted before the writer. This is the primary blocker to reliable keyless article production — bigger than the writer bugs. Likely mitigation: default the keyless path to research_mode='claude_web' (ADR-0013, Claude's own WebSearch on the subscription — not the rate-limited academic APIs), which is exactly why claude_web was introduced.",
+      "description": "Keyless deterministic research is unreliable and aborts the whole pipeline. The two free providers (arXiv, Semantic Scholar) rate-limit/err heavily (HTTP 429/503); when BOTH fail on a topic, deterministic research returns zero sources and the empty-research guard (#438) aborts the run (exit 2, 'Pipeline aborted: research failed', provider_failed={'arxiv':True,'semantic_scholar':True}). Observed live: a default-budget keyless run aborted before the writer. This is the primary blocker to reliable keyless article production \u2014 bigger than the writer bugs. Likely mitigation: default the keyless path to research_mode='claude_web' (ADR-0013, Claude's own WebSearch on the subscription \u2014 not the rate-limited academic APIs), which is exactly why claude_web was introduced.",
       "component": "agent_sdk.pipeline research (deterministic) / empty-research guard",
       "status": "fixed",
       "github_issue": null,
       "is_production_escape": false,
       "root_cause": "integration_error",
-      "root_cause_notes": "Keyless research depends on free rate-limited APIs with an abort-on-empty guard. Decide the reliable keyless research mode (claude_web vs hardened deterministic) — affects B-010's canonical-command choice and the live-run acceptance gate.",
+      "root_cause_notes": "Keyless research depends on free rate-limited APIs with an abort-on-empty guard. Decide the reliable keyless research mode (claude_web vs hardened deterministic) \u2014 affects B-010's canonical-command choice and the live-run acceptance gate.",
       "discovered_by": "B-010 T1 validation run",
       "prevention_test_added": false,
       "fixed_date": "2026-07-22T00:00:00",
@@ -861,13 +861,13 @@
       "severity": "medium",
       "discovered_in": "production",
       "discovered_date": "2026-07-24T00:00:00",
-      "description": "B-013 review drafts rendered BARE on the live blog — no <head>, no theme, no noindex meta — defeating both the 'review the post in the real theme' goal and the noindex acceptance criterion. Caught by the live leak test after merging oviney/blog PR #1157 (the other 6/7 checks passed: draft absent from homepage/blog/feed.xml/sitemap.xml/search + robots.txt disallows /review/).",
+      "description": "B-013 review drafts rendered BARE on the live blog \u2014 no <head>, no theme, no noindex meta \u2014 defeating both the 'review the post in the real theme' goal and the noindex acceptance criterion. Caught by the live leak test after merging oviney/blog PR #1157 (the other 6/7 checks passed: draft absent from homepage/blog/feed.xml/sitemap.xml/search + robots.txt disallows /review/).",
       "component": "oviney/blog _layouts/review.html (B-013 blog-side)",
       "status": "resolved",
       "github_issue": "oviney/blog#1159",
       "is_production_escape": true,
       "root_cause": "integration_error",
-      "root_cause_notes": "review.html extended `layout: single`, assuming the remote minimal-mistakes theme. This blog has remote_theme COMMENTED OUT and uses local layouts (default/page/post) — there is no `single` layout, so the parent layout silently did not apply and the draft rendered as bare markdown-to-HTML. Real posts use `layout: post` -> `default.html`, whose <head> emits the page.noindex robots meta. Assumption about the target repo's theme was not verified before shipping.",
+      "root_cause_notes": "review.html extended `layout: single`, assuming the remote minimal-mistakes theme. This blog has remote_theme COMMENTED OUT and uses local layouts (default/page/post) \u2014 there is no `single` layout, so the parent layout silently did not apply and the draft rendered as bare markdown-to-HTML. Real posts use `layout: post` -> `default.html`, whose <head> emits the page.noindex robots meta. Assumption about the target repo's theme was not verified before shipping.",
       "discovered_by": "leak-test (deploy_review --mode review + read-only feed/sitemap/homepage/noindex checks)",
       "prevention_test_added": "Acceptance leak-test checklist in docs/specs/B-013-blog-side.md is the regression gate; run it on any change to the review collection/layout before calling B-013 done.",
       "fixed_date": "2026-07-24T00:00:00",
@@ -905,7 +905,7 @@
       "github_issue": "",
       "is_production_escape": false,
       "root_cause": "requirements_gap",
-      "root_cause_notes": "CONSTRAINT CONFLICT — must be resolved by the owner before any fix. CLAUDE.md constraint #4 (NON-NEGOTIABLE) currently forbids pipeline hero-image generation of ANY kind — not DALL-E/Gemini (needs a keyed service, violates constraint #1), and explicitly 'not procedural/PIL image generation either'; the hero is human-supplied from a prompt. So this request REVERSES documented policy. Feasible keyless interpretations to consider: (i) charts — already allowed & keyless (code-drawn), extend coverage to multiple figures per post; (ii) hero as a CODE/SVG-drawn editorial illustration authored by Claude (keyless, but currently banned by #4's 'no procedural' clause); (iii) true raster AI hero art — needs an image model = a keyed/paid service = blocked by constraints #1/#2 unless the owner adds one. NEXT STEP: owner decides whether to amend constraint #4 and which interpretation is in scope, then spec it (spec-driven-development).",
+      "root_cause_notes": "CONSTRAINT CONFLICT \u2014 must be resolved by the owner before any fix. CLAUDE.md constraint #4 (NON-NEGOTIABLE) currently forbids pipeline hero-image generation of ANY kind \u2014 not DALL-E/Gemini (needs a keyed service, violates constraint #1), and explicitly 'not procedural/PIL image generation either'; the hero is human-supplied from a prompt. So this request REVERSES documented policy. Feasible keyless interpretations to consider: (i) charts \u2014 already allowed & keyless (code-drawn), extend coverage to multiple figures per post; (ii) hero as a CODE/SVG-drawn editorial illustration authored by Claude (keyless, but currently banned by #4's 'no procedural' clause); (iii) true raster AI hero art \u2014 needs an image model = a keyed/paid service = blocked by constraints #1/#2 unless the owner adds one. NEXT STEP: owner decides whether to amend constraint #4 and which interpretation is in scope, then spec it (spec-driven-development).",
       "discovered_by": "owner report",
       "prevention_test_added": "",
       "fixed_date": "",
@@ -918,17 +918,17 @@
       "severity": "high",
       "discovered_in": "production",
       "discovered_date": "2026-07-24T00:00:00",
-      "description": "OWNER-REPORTED (prose). The generated flaky-tests article ('Green Light, Red Ledger…') reads like AI slop despite passing the deterministic economist-writing gates. It CLEARS the mechanical checks (named companies: Atlassian/Google/Microsoft/CloudBees; <=4 headings; colon-twist title; data-dense; no lists) yet still exhibits AI tells the current Stage-4 banned-phrase list does not catch.",
+      "description": "OWNER-REPORTED (prose). The generated flaky-tests article ('Green Light, Red Ledger\u2026') reads like AI slop despite passing the deterministic economist-writing gates. It CLEARS the mechanical checks (named companies: Atlassian/Google/Microsoft/CloudBees; <=4 headings; colon-twist title; data-dense; no lists) yet still exhibits AI tells the current Stage-4 banned-phrase list does not catch.",
       "component": "src/agent_sdk._shared (Stage 4 polish / banned-phrase list) + skills/economist-writing enforcement",
       "status": "resolved",
       "github_issue": "",
       "is_production_escape": true,
       "root_cause": "validation_gap",
-      "root_cause_notes": "Concrete AI-slop tells found on review against skills/economist-writing (none are in the current deterministic banlist): (1) EM-DASH rhythm — em-dashes used as the default connective, often 1-2 per paragraph. (2) META-COMMENTARY on its own argument: 'The argument here is blunter than most engineering post-mortems allow'; 'The numbers, once examined, make this case almost without assistance'; 'The most interesting question is not whether flaky tests are expensive… it is why'. (3) 'NOT X BUT Y' antithesis scaffold repeated ~6x: 'not cutting corners—she is making a…decision', 'not a nuisance …but a quantifiable payroll cost', 'not defective code but tests', 'not merely expensive but epistemically impossible'. (4) UNFALSIFIABLE SUPERLATIVES / overreach: 'No other category of engineering waste operates so openly and at such scale with so little executive scrutiny.' (5) PURPLE / MIXED-METAPHOR pile-up: dripping tap -> flooding basement -> 'the plumber charges considerably more than the pipe was worth'; 'offloaded from the pipeline to the engineer's nervous system'; 'the engineer is hunting a ghost'; 'auto-retry is an anaesthetic, not a cure'. (6) FAUX-SPECIFIC cuteness: 'a test decided to behave differently on a Tuesday'. These pass because Stage 4 only strips a fixed hedging/closing set; the rhythmic + rhetorical AI tells are unlisted.",
+      "root_cause_notes": "Concrete AI-slop tells found on review against skills/economist-writing (none are in the current deterministic banlist): (1) EM-DASH rhythm \u2014 em-dashes used as the default connective, often 1-2 per paragraph. (2) META-COMMENTARY on its own argument: 'The argument here is blunter than most engineering post-mortems allow'; 'The numbers, once examined, make this case almost without assistance'; 'The most interesting question is not whether flaky tests are expensive\u2026 it is why'. (3) 'NOT X BUT Y' antithesis scaffold repeated ~6x: 'not cutting corners\u2014she is making a\u2026decision', 'not a nuisance \u2026but a quantifiable payroll cost', 'not defective code but tests', 'not merely expensive but epistemically impossible'. (4) UNFALSIFIABLE SUPERLATIVES / overreach: 'No other category of engineering waste operates so openly and at such scale with so little executive scrutiny.' (5) PURPLE / MIXED-METAPHOR pile-up: dripping tap -> flooding basement -> 'the plumber charges considerably more than the pipe was worth'; 'offloaded from the pipeline to the engineer's nervous system'; 'the engineer is hunting a ghost'; 'auto-retry is an anaesthetic, not a cure'. (6) FAUX-SPECIFIC cuteness: 'a test decided to behave differently on a Tuesday'. These pass because Stage 4 only strips a fixed hedging/closing set; the rhythmic + rhetorical AI tells are unlisted.",
       "discovered_by": "owner report + economist-writing skill review",
       "prevention_test_added": "",
       "fixed_date": "",
-      "fix_notes": "Candidate fixes (spec first): extend the deterministic banlist / add heuristics for em-dash density, 'not X but Y' frequency, meta-commentary stems ('the argument here', 'the numbers…make this case'), and superlative overreach; and/or add an economist-writing Stage-4 judge pass that flags these. Add regression fixtures built from the tells above.",
+      "fix_notes": "Candidate fixes (spec first): extend the deterministic banlist / add heuristics for em-dash density, 'not X but Y' frequency, meta-commentary stems ('the argument here', 'the numbers\u2026make this case'), and superlative overreach; and/or add an economist-writing Stage-4 judge pass that flags these. Add regression fixtures built from the tells above.",
       "resolution": "B-017: four flag-only detectors (em_dash_density, antithesis_scaffold, meta_commentary, unfalsifiable_superlative) added to publication_validator.py; HIGH/MEDIUM never CRITICAL. Verified on the real article. Metaphor tell (#5) is semantic - parked, not faked. Spec: docs/specs/B-017-ai-slop-enforcement.md",
       "resolved_date": "2026-07-24"
     },
@@ -979,7 +979,7 @@
       "title": "Six tests in test_economist_agent.py made live arXiv/citation HTTP calls; the merge gate's runtime was set by a third party's rate limiter",
       "description": "TestRunResearchAgent and TestIntegration patched agents.research_agent.call_llm but not the TWO other network paths inside ResearchAgent.research: _gather_arxiv_research (live arXiv HTTP) and scripts.citation_verifier.verify_citations (fetches every citation URL).",
       "evidence": "pytest --durations on the file: 34 passed in 624.53s (10m24s), with six tests accounting for 620s (127.75/127.24/122.40/97.14/96.21/50.21). Log shows 'arXiv transient error (HTTP 429 ...); retry 2/3 after 1.5s'. Reproduced on a clean tree via git stash, so it predates B-019.",
-      "root_cause": "Incomplete mocking at the wrong boundary. The tests were written against the LLM seam; the arXiv provider and citation verifier are reached deeper inside ResearchAgent.research and were never stubbed. Because the production code catches network errors and retries with backoff, the tests still PASSED — the defect was invisible except as duration, which is why it survived so long.",
+      "root_cause": "Incomplete mocking at the wrong boundary. The tests were written against the LLM seam; the arXiv provider and citation verifier are reached deeper inside ResearchAgent.research and were never stubbed. Because the production code catches network errors and retries with backoff, the tests still PASSED \u2014 the defect was invisible except as duration, which is why it survived so long.",
       "impact": "Severity raised MEDIUM -> HIGH on measurement. Cost is not a fixed ~2 min as first assessed: arXiv rate-limits under repeated runs, so the gate got slower the more it was used and was unbounded. make ci-local is the only merge gate (ADR-0015); it also failed offline and depended on arXiv availability.",
       "proposed_fix": "Patch ResearchAgent._gather_arxiv_research in the TestRunResearchAgent fixture to return an empty insights dict. Add a suite-wide guard test that fails if any test opens a socket.",
       "resolved_date": "2026-07-26",
@@ -1014,7 +1014,7 @@
       "evidence": "Noted while building B-016b; image_gate is still imported by pipeline for the --resume handshake path.",
       "root_cause": "Left behind by the DALL-E retirement (ADR-0014 / B-009). The handshake path that uses it predates SVG heroes.",
       "impact": "Misleading rather than broken: a reader of the code may believe hero images are gated on PNG dimensions. Also constrains the --resume handshake to PNG drops.",
-      "proposed_fix": "Decide the fate of the --resume image handshake now that Stage 3 draws the hero. If the handshake stays, teach it check_hero_svg for .svg drops; if it goes, delete image_gate.py with it. Spec-worthy, not a patch — it is on a user-facing path.",
+      "proposed_fix": "Decide the fate of the --resume image handshake now that Stage 3 draws the hero. If the handshake stays, teach it check_hero_svg for .svg drops; if it goes, delete image_gate.py with it. Spec-worthy, not a patch \u2014 it is on a user-facing path.",
       "fixed_date": "2026-07-28T00:00:00",
       "resolved_date": "2026-07-28",
       "prevention_test_added": "tests/test_single_pipeline_path.py",
@@ -1030,7 +1030,7 @@
       "description": "The writer budget is consumed ACROSS retry attempts, not per attempt: each attempt is given the remaining balance. One Sonnet writer attempt costs ~$0.42, so a first attempt that produces malformed output (a normal, handled condition with _WRITER_MAX_ATTEMPTS=3) leaves too little for the second, which then aborts the whole pipeline with BudgetExceededError.",
       "evidence": "B-020 acceptance run, 2026-07-27, default budgets: 'Writer attempt 1/3 produced malformed output (starts_with_dash=True, body_empty=True); retrying' then 'BudgetExceededError: cap=$0.3352, cost_at_abort=$0.4216'. $0.3352 is $0.60 minus the ~$0.26 the malformed attempt already spent. Pipeline exited 1 after ~14 min with no article.",
       "root_cause": "The default was never validated against a real retry. Its own help text claims it is 'sized for Sonnet with retries + tool turns', but at ~$0.42 per attempt three attempts need ~$1.26 and even two need ~$0.85.",
-      "impact": "The DEFAULT invocation fails whenever the writer's first attempt is malformed — which happened on the very first real end-to-end run. Wastes ~14 minutes and the cost of the attempts, and produces no article. The retry mechanism that exists to add resilience instead guarantees failure.",
+      "impact": "The DEFAULT invocation fails whenever the writer's first attempt is malformed \u2014 which happened on the very first real end-to-end run. Wastes ~14 minutes and the cost of the attempts, and produces no article. The retry mechanism that exists to add resilience instead guarantees failure.",
       "proposed_fix": "Raise the default to ~$1.60 (3 attempts x $0.42 plus headroom) and correct the help text with the measured per-attempt cost. Consider giving each attempt its own cap rather than sharing one balance, so a wasted attempt cannot starve the retry it exists to enable. Verify by running with the default and forcing a retry.",
       "workaround": "Pass --writer-budget 1.60 explicitly.",
       "fixed_date": "2026-07-28T00:00:00",
@@ -1049,8 +1049,8 @@
       "description": "hero_author holds its OWN reference to _collect_text. The ~10 test files that patch stage3_runner._collect_text therefore did not cover the hero step, which called the real Agent SDK during the test suite.",
       "evidence": "output/posts/test.image_prompt.md and output/posts/images/test-hero.svg appeared in the repo during a gate run, containing REAL generated content built from a test fixture's frontmatter ('Subject: alt', 'Editorial framing: cap'). Decisive measurement: the gate timed out at 900s (EXIT=124) before the guard and ran in 119.05s with 2371 passed after it.",
       "root_cause": "Introduced by me in B-016b. The BUG-058 socket guard cannot see these calls: claude_agent_sdk.query spawns a subprocess CLI, so no in-process socket opens.",
-      "impact": "Every make ci-local made live subscription calls (~$0.45 and ~450s each) and wrote generated artefacts into output/. The gate became unusable — it timed out — which would have pushed people to skip it, the exact failure that let BUG-055..057 reach main.",
-      "resolution": "netguard.install_model_guard patches stage3_runner.query — the single chokepoint every model call funnels through — as an autouse fixture with the @pytest.mark.allow_network opt-out. Tests that legitimately exercise _collect_text internals patch it themselves and their patch wins. Regression: 3 tests in test_no_network_guard.py, one specifically covering the separate-reference trap. Zero existing tests broke, confirming none were relying on the real SDK."
+      "impact": "Every make ci-local made live subscription calls (~$0.45 and ~450s each) and wrote generated artefacts into output/. The gate became unusable \u2014 it timed out \u2014 which would have pushed people to skip it, the exact failure that let BUG-055..057 reach main.",
+      "resolution": "netguard.install_model_guard patches stage3_runner.query \u2014 the single chokepoint every model call funnels through \u2014 as an autouse fixture with the @pytest.mark.allow_network opt-out. Tests that legitimately exercise _collect_text internals patch it themselves and their patch wins. Regression: 3 tests in test_no_network_guard.py, one specifically covering the separate-reference trap. Zero existing tests broke, confirming none were relying on the real SDK."
     },
     {
       "id": "BUG-063",
@@ -1064,14 +1064,14 @@
       "impact": "Wastes the entire writer stage (~$0.85 and several minutes) on a graphics failure that a retry would likely absorb. Blocks B-020 acceptance.",
       "proposed_fix": "Give the graphics call the same bounded retry the writer has, feeding the ChartRenderError message back so the agent can correct the spec. Reuse the writer's attempt-loop shape rather than inventing a second one.",
       "resolved_date": "2026-07-27",
-      "resolution": "_graphics_with_retry in stage3_runner gives the graphics agent 3 bounded attempts, feeding ChartRenderError's own message back so it knows what to correct. Chart failures stay fatal, but 'fatal' now means 'no valid spec in 3 tries' rather than 'the first try was malformed'. Made async deliberately — a sync helper called from the async run_stage3 would have repeated the asyncio.run-inside-a-loop bug fixed the same day. Regression: tests/test_graphics_retry.py (3 tests). One existing test (test_run_stage3_fails_when_chart_render_fails) supplied only two mock replies so the retry hit StopIteration; its fixture was fixed, not its assertion."
+      "resolution": "_graphics_with_retry in stage3_runner gives the graphics agent 3 bounded attempts, feeding ChartRenderError's own message back so it knows what to correct. Chart failures stay fatal, but 'fatal' now means 'no valid spec in 3 tries' rather than 'the first try was malformed'. Made async deliberately \u2014 a sync helper called from the async run_stage3 would have repeated the asyncio.run-inside-a-loop bug fixed the same day. Regression: tests/test_graphics_retry.py (3 tests). One existing test (test_run_stage3_fails_when_chart_render_fails) supplied only two mock replies so the retry hit StopIteration; its fixture was fixed, not its assertion."
     },
     {
       "id": "BUG-064",
       "severity": "MEDIUM",
       "status": "resolved",
       "discovered_date": "2026-07-28T00:00:00",
-      "description": "_graphics_with_retry passes the FULL graphics_budget_usd to every attempt rather than the remaining balance, so _GRAPHICS_MAX_ATTEMPTS=3 can spend up to 3x the cap the operator set. The writer loop decrements correctly (see BUG-061); graphics is the mirror-image inconsistency. Not a run-aborter — it silently overspends instead of under-funding. Measured graphics cost has already reached $0.41 against a $0.40 cap on one B-020 run (logs/agent_sdk_costs.jsonl 2026-07-28T01:22).",
+      "description": "_graphics_with_retry passes the FULL graphics_budget_usd to every attempt rather than the remaining balance, so _GRAPHICS_MAX_ATTEMPTS=3 can spend up to 3x the cap the operator set. The writer loop decrements correctly (see BUG-061); graphics is the mirror-image inconsistency. Not a run-aborter \u2014 it silently overspends instead of under-funding. Measured graphics cost has already reached $0.41 against a $0.40 cap on one B-020 run (logs/agent_sdk_costs.jsonl 2026-07-28T01:22).",
       "component": "src/agent_sdk/stage3_runner.py::_graphics_with_retry",
       "github_issue": "",
       "is_production_escape": false,
@@ -1098,7 +1098,7 @@
       "discovered_by": "manual review of the live post while regenerating the B-017 slop list",
       "prevention_test_added": "tests/test_deploy_rejects_hero_prompt_comment.py",
       "fixed_date": "2026-07-28T00:00:00",
-      "fix_notes": "Gated at the DEPLOY boundary, not in publication_validator: the comment is injected after run_stage4 by design, so the validator cannot see it, and it is legitimate in the local artifact — only illegitimate on the blog. _reject_unrendered_hero_prompt guards BOTH deploy() and deploy_review() (a review deploy is a live URL too) and fires before any clone/push, so a rejected article costs nothing. Rejects rather than strips: stripping would hide that no hero was drawn. Removed from the live post in oviney/blog#1168.",
+      "fix_notes": "Gated at the DEPLOY boundary, not in publication_validator: the comment is injected after run_stage4 by design, so the validator cannot see it, and it is legitimate in the local artifact \u2014 only illegitimate on the blog. _reject_unrendered_hero_prompt guards BOTH deploy() and deploy_review() (a review deploy is a live URL too) and fires before any clone/push, so a rejected article costs nothing. Rejects rather than strips: stripping would hide that no hero was drawn. Removed from the live post in oviney/blog#1168.",
       "resolved_date": "2026-07-28",
       "verification": "4 regression tests + make ci-local green (2026-07-28)"
     },
@@ -1169,10 +1169,25 @@
       "fix_notes": "Extracted _dated_post_name(source_name, deploy_date): strip any existing YYYY-MM-DD- prefix, then always prefix the deploy date. Handles both shapes so the date cannot go missing again. WHY NO GATE CAUGHT IT, which is the more useful finding: scripts/validate-posts.sh globs _posts/*.md itself rather than asking Jekyll, so it validates an undated file happily; and acceptance_blog_frontmatter.sh stages its OWN copy as _posts/2026-01-01-<slug>.md - a different filename from the one the deploy path produces. The oracle passed on a name that would never exist. An oracle that renames its input is not testing the deploy path.",
       "resolved_date": "2026-07-29",
       "verification": "RED->GREEN on tests/test_deploy_post_filename.py (3 tests); dry-run now targets _posts/2026-07-29-review-queue-throughput-tax.md"
+    },
+    {
+      "id": "BUG-070",
+      "severity": "high",
+      "discovered_in": "acceptance",
+      "discovered_date": "2026-08-02T00:00:00",
+      "description": "`make art` sets `image:` but never removes the `<!-- HERO IMAGE` prompt comment, so the documented B-042 sequence (draw hero -> make art -> deploy --mode review) is refused by _reject_unrendered_hero_prompt. The happy path cannot complete without an undocumented manual edit.",
+      "component": "finalise_art",
+      "status": "open",
+      "is_production_escape": false,
+      "root_cause": "validation_gap",
+      "root_cause_notes": "scripts/finalise_art.py calls pipeline._link_hero_asset, which edits only the frontmatter (image:, image_alt:). The body comment injected by pipeline._inject_hero_prompt_comment is left in place. Two gates written in different items (BUG-065's comment refusal, B-042's art hand-off) were never run against each other end to end; every unit test covers one or the other. Reproduced live 2026-08-02 with four deploy probes.",
+      "prevention_test_added": false,
+      "introduced_in_commit": "95c838ce",
+      "introduced_date": "2026-08-01"
     }
   ],
   "summary": {
-    "total_bugs": 14,
+    "total_bugs": 53,
     "fixed_bugs": 7,
     "production_bugs": 6,
     "defect_escape_rate": 42.9,
@@ -1209,7 +1224,7 @@
     "avg_time_to_detect_days": 4.1,
     "avg_time_to_resolve_days": 2.0,
     "avg_critical_ttd_days": 3.7,
-    "last_updated": "2026-07-24T00:00:00",
-    "total": 21
+    "last_updated": "2026-08-02T00:00:00",
+    "total": 53
   }
 }

--- a/docs/reviews/b042-live-acceptance-2026-08-02.md
+++ b/docs/reviews/b042-live-acceptance-2026-08-02.md
@@ -1,0 +1,146 @@
+# B-042 hand-off — first live acceptance, 2026-08-02
+
+The flow had 2,747 passing tests and had never run. This is what happened when it did.
+
+**Two defects, both invisible to the suite, both in the hand-off itself.** Neither is a
+tuning question; both are gates that could not do their job on real input.
+
+## What was verified, and how
+
+### The art gate refuses. Confirmed, not assumed.
+
+Run against the real article with a deliberately invalid token, so a gate failure would
+have failed closed at git auth rather than published something.
+
+| Probe | Article state | Outcome |
+|---|---|---|
+| 1 | as generated — hero comment present | exit 1, `_reject_unrendered_hero_prompt` |
+| 2 | comment stripped, no `image:` | exit 1, `_require_hero` — "no `image:` in its frontmatter" |
+| 3 | `image:` set, file absent | exit 1, `_require_hero` — "would push a broken `<img>`" |
+| 4 | the exact state `make art` leaves | exit 1 — **and it should not have been** |
+
+No clone occurred in any probe (`temp_blog_repo` on disk is from 2026-08-01 17:44, untouched).
+The gates sit at `deploy_review` lines 621/623, ahead of the owner/repo/token checks, so the
+refusal is not confounded by a missing credential.
+
+**One ordering note.** `main()` requires `--blog-owner`, `--blog-repo` and a token *before*
+`deploy_review` is called, so reaching the art gate from the CLI needs full arguments even
+though the gate itself never touches them.
+
+### BUG-070 — `make art` produces an article deploy refuses
+
+`finalise_art` delegates to `pipeline._link_hero_asset`, which edits **only the frontmatter**.
+The `<!-- HERO IMAGE` comment stays in the body, so the documented sequence — draw hero,
+`make art`, `deploy --mode review` — cannot complete. The refusal message tells the owner to
+"replace the whole comment with the image reference", which is the job `make art` was
+supposed to have done.
+
+**Why 12 passing tests missed it:** every fixture in `test_finalise_art.py` used an article
+with no comment in it — input the pipeline never produces. Two gates written in separate
+items (BUG-065's comment refusal, B-042's hand-off) had never been run against each other.
+The regression test now imports the real gate rather than asserting on a substring.
+
+### BUG-071 — `## References` did not render as a heading
+
+The blog renders with **kramdown**, which unlike CommonMark will not start a block element on
+the line after a paragraph. Verified by running kramdown directly:
+
+```
+input:   "para text.\n## References\n\n1. A\n"
+output:  <p>para text.
+         ## References</p>
+```
+
+**The stat audit manufactures this, and always has.** `audit_article_stats` splits on
+`(?<=[.!?])\s+` — swallowing the newline before `## References` — and rejoins with a single
+space. Stage 4's unconditional chart embed used to sit in that gap and supply the blank line
+by accident. B-042 deleted that embed, so **the first article generated without a chart is
+the first one where the heading breaks.** Both pre-B-042 articles still carry the
+`. \n![Chart]…\n\n## References` shape on disk.
+
+**And the CRITICAL check written for exactly this could not see it.** `inline_heading_marker`
+used `[^\s]\s##\s`, which allows *one* whitespace character between the sentence and the
+marker. The same edit that broke the heading left a trailing space, making the separator two
+characters:
+
+| input | caught |
+|---|---|
+| `deadline.\n## References` | yes |
+| `deadline. \n## References` | **no** |
+| `deadline. ## References` | yes |
+
+One space silenced a CRITICAL gate. Fixed at both layers — the normaliser so the pipeline
+stops emitting it, the check made line-based so it cannot be defeated by whitespace.
+
+## The run
+
+`--research-mode claude_web`, same topic string as the 2026-08-01 run so the ledger rows stay
+comparable. Slug **changed**: `migration-deadline-testing-trap`, not
+`testing-shortcuts-migration-deadline`. The slug derives from the writer's title.
+
+| | 2026-08-01 (`--brief`) | 2026-08-02 (`claude_web`) |
+|---|---|---|
+| wall | 31.8 min | see `logs/agent_sdk_costs.jsonl` |
+| cost | $1.01 | $0.8597 |
+| references | 3, **no URLs** | 6, **all with URLs** |
+| chart | 4 invented percentages | none generated; 19 figures *proposed* from the brief |
+
+## Judging the packet as the owner
+
+**Section 3 (chart) — works as designed.** 19 candidate figures, every one traceable to brief
+text quoted alongside it, source URLs visible inside several of the context strings. `title`
+empty, every `metric` empty, so an untouched proposal will not render. This is the opposite
+of the fabricated chart.
+
+Two usability notes, neither a blocker:
+
+1. **Range endpoints are extracted as point values.** The brief says "earmark 15–20% of IT
+   budgets" and "spending 30–40%"; the proposal offers rows reading `20 %` and `40 %`. The
+   value does appear in the brief, so this is not fabrication — but a chart built from those
+   rows would state a range endpoint as a measurement. The quoted context shows the range, so
+   a careful reader catches it.
+2. **Context strings are cut mid-word** (`'cts: Skipping Rigour Guarantees…'`) because the
+   window is a fixed ±60 characters. Snapping to word boundaries would read better.
+
+**Section 2 (hero brief) — usable.** Concrete subject, editorial framing, palette, aspect
+ratio, and constraints. Nothing missing.
+
+**Section 1 (verdict) — the one part that misled.** It reported `Publication validator:
+PASSED`. With BUG-071 fixed, the same article is **REJECTED — 1 CRITICAL**. The packet was
+truthfully reporting what the validator said; the validator was wrong.
+
+## Still the owner's, and why
+
+1. **Re-sourcing the artifact via Claude.ai.** Not done. `claude.ai/recents` shows only
+   *"SRE Quality Governance Guide file location"* (Aug 1), a conversation *about* the file.
+   The artifact is `SRE_Quality_Governance_Guide (2).html`, downloaded **Jul 21 13:04**, and
+   nothing in the list obviously produced it. Pasting a long prompt into a guessed thread was
+   not a gamble worth taking, so research was re-sourced the other sanctioned way —
+   `claude_web`. **The B-038 HTML→brief path is therefore still unexercised on a re-sourced
+   artifact.**
+2. **The hero.** Constraint #4 as amended: the owner draws it. `make art` and the deploy are
+   blocked behind it, so steps 4 and 5 have not run live.
+
+**`BLOG_REPO_TOKEN` is not the blocker it first appeared to be.** `.env` carries no blog
+entries, but `gh` is authenticated as `oviney` with `repo` scope and ADMIN on `oviney/blog`,
+so `--token $(gh auth token)` supplies what the deploy needs.
+
+## Read the article before publishing it
+
+The prose passes and the citations resolve, but three things want an editor's eye:
+
+1. **The IBM Systems Sciences Institute 60-to-1 ratio is load-bearing and contested.** It
+   carries the section title and the subtitle. The sentence "Those numbers were challenged
+   when first published; they have since been corroborated by every serious study that
+   followed" has **no citation** and is a strong claim. That figure is widely criticised as
+   untraceable to a primary source.
+2. **Most references are secondary.** "Via ContextQA", "Via Rockstar Developer University",
+   "Curiosity Software … citing McKinsey" — the sourcing prompt asks for primary sources, and
+   these are write-ups about them.
+3. **The validator still reports 8 quantified claims without inline attribution**, and an
+   em-dash density of 1.45/paragraph. Both HIGH, both advisory.
+
+## What did not need doing
+
+`_check_placeholders` still cannot catch the hero comment, and still should not — the deploy
+gate owns that, and a second pattern there would be dead code.

--- a/scripts/finalise_art.py
+++ b/scripts/finalise_art.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 
@@ -42,6 +43,15 @@ CHARTS_DIR = Path("output/charts")
 #: still empty would produce a chart with no title and unlabelled bars, which is
 #: worse than no chart — so the renderer's own validation is allowed to refuse,
 #: and this message explains why rather than surfacing a bare stack trace.
+#: The reviewer comment ``pipeline._inject_hero_prompt_comment`` writes. Its own
+#: text says "replace this whole comment with it", and until BUG-070 nothing
+#: did — so ``make art`` set ``image:`` and the deploy gate refused the result,
+#: making the documented sequence impossible to complete.
+#:
+#: Non-greedy to the first ``-->`` is safe: the injector neutralises any ``-->``
+#: inside the prompt precisely so it cannot terminate the comment early.
+_HERO_PROMPT_BLOCK = re.compile(r"<!-- HERO IMAGE.*?-->\n*", re.DOTALL)
+
 _UNFRAMED_HINT = (
     "The chart spec still has the placeholders the proposal left for you: a "
     "`title`, and a `metric` label on every row you keep. Fill those in (and "
@@ -100,6 +110,10 @@ def finalise(slug: str) -> int:
         )
     else:
         print(f"  Hero: linked {HERO_IMAGES_DIR}/{slug}-hero.*")
+        # Only once the hero is actually linked. Stripping the brief while no
+        # hero exists would delete the instructions and leave the article
+        # looking finished, when the honest outcome is deploy's refusal.
+        article = _HERO_PROMPT_BLOCK.sub("", article)
 
     article_path.write_text(article)
     print(f"\nUpdated {article_path}")

--- a/scripts/publication_validator.py
+++ b/scripts/publication_validator.py
@@ -927,20 +927,54 @@ class PublicationValidator:
             return None
         return Path("output/posts/images") / Path(image).name
 
+    @staticmethod
+    def _heading_lacks_blank_line_before(body: str) -> bool:
+        """Return whether any heading sits directly below a non-blank line.
+
+        BUG-071. The blog renders with kramdown, which — unlike CommonMark —
+        will not start a block element on the line after a paragraph. So a
+        heading with no blank line above it renders as literal ``## References``
+        text inside the paragraph. Verified by running kramdown, not inferred.
+
+        This is line-based on purpose. The regex below it allows exactly one
+        whitespace character between the sentence and the marker, so the real
+        article — which ended ``deadline. `` with a trailing space — slipped
+        past a CRITICAL gate written for precisely this defect.
+
+        Fenced code blocks are skipped: ``# a comment`` in a shell example is
+        not a heading, and a false alarm on the packet's own commands would
+        train the reader to ignore the check.
+        """
+        in_fence = False
+        previous = ""
+        for line in body.split("\n"):
+            if line.lstrip().startswith(("```", "~~~")):
+                in_fence = not in_fence
+            elif not in_fence and re.match(r"#{1,6}\s", line) and previous.strip():
+                return True
+            previous = line
+        return False
+
     def _check_heading_structure(self, content: str) -> None:
-        """Reject inline markdown headings embedded inside paragraphs."""
+        """Reject markdown headings kramdown will not render as headings."""
         body = (
             content.split("---", 2)[2]
             if content.startswith("---") and len(content.split("---", 2)) >= 3
             else content
         )
-        if re.search(r"[^\s]\s##\s", body):
+        if re.search(r"[^\s]\s##\s", body) or self._heading_lacks_blank_line_before(
+            body
+        ):
             self.issues.append(
                 {
                     "check": "inline_heading_marker",
                     "severity": "CRITICAL",
-                    "message": "Heading markers are embedded inside paragraph text",
-                    "details": "Malformed markdown like '... sentence. ## Heading' must not publish",
+                    "message": "A heading will not render as a heading",
+                    "details": (
+                        "kramdown needs a blank line above a heading. Both "
+                        "'... sentence. ## Heading' and a heading on the line "
+                        "directly below a paragraph render as literal text"
+                    ),
                     "fix": "Move each markdown heading to its own line with surrounding paragraph breaks",
                 },
             )

--- a/src/agent_sdk/stage3_runner.py
+++ b/src/agent_sdk/stage3_runner.py
@@ -379,6 +379,19 @@ def _slug_for_chart(article: str, topic: str) -> str:
 
 _INLINE_HEADING_PATTERN = re.compile(r"[ \t]+(##+ +[A-Z][^\n]*)")
 _HEADING_LINE_PATTERN = re.compile(r"(?<!\n\n)(^|\n)(##+ +[^\n]+)\n(?!\n)")
+#: BUG-071. A heading already on its own line, but with a paragraph directly
+#: above it. kramdown will not start a block element on the line after a
+#: paragraph, so it renders as literal ``## References`` text.
+#:
+#: The stat audit manufactures this on every article — it splits on
+#: ``(?<=[.!?])\s+``, swallowing the newline before ``## References``, and
+#: rejoins with a space. Stage 4's unconditional chart embed used to sit in
+#: that gap and supply the blank line by accident; B-042 deleted it, so the
+#: first chart-less article is the first one where the heading breaks.
+#:
+#: ``[ \t]*`` before the newline matters: the audit leaves a trailing space, and
+#: that one character is also what blinded ``inline_heading_marker`` to it.
+_HEADING_NEEDS_BLANK_BEFORE = re.compile(r"(?<=\S)[ \t]*\n(#{1,6} +[^\n]+)")
 _DUPLICATE_FRONTMATTER_PATTERN = re.compile(r"\n---\nlayout:.*", re.DOTALL)
 
 
@@ -389,8 +402,13 @@ def _normalize_paragraphs(text: str) -> str:
     on the same line (``"...the easy part. ## The Perception Gap"``).
     Lift any inline heading onto its own line, then ensure every heading
     has a blank line before and after it.
+
+    The "before" half is BUG-071: a heading can also arrive already on its own
+    line with a paragraph directly above it, which kramdown renders as literal
+    text. See ``_HEADING_NEEDS_BLANK_BEFORE``.
     """
     text = _INLINE_HEADING_PATTERN.sub(r"\n\n\1", text)
+    text = _HEADING_NEEDS_BLANK_BEFORE.sub(r"\n\n\1", text)
     text = _HEADING_LINE_PATTERN.sub(r"\1\2\n\n", text)
     return text
 

--- a/tests/test_finalise_art.py
+++ b/tests/test_finalise_art.py
@@ -14,10 +14,22 @@ from pathlib import Path
 
 import pytest
 
+from scripts.deploy_to_blog import _reject_unrendered_hero_prompt, _require_hero
 from scripts.finalise_art import finalise
 
 _ARTICLE = (
     '---\nlayout: post\ntitle: "My Slug"\n---\n\n'
+    "Body paragraph one.\n\n## References\n\n1. A\n"
+)
+
+#: What the pipeline actually writes. Every other fixture in this file omits the
+#: reviewer comment, which is how BUG-070 stayed invisible: the suite tested
+#: ``finalise`` against an article the pipeline never produces.
+_ARTICLE_WITH_HERO_PROMPT = (
+    '---\nlayout: post\ntitle: "My Slug"\n---\n\n'
+    "<!-- HERO IMAGE — generate an image from the prompt below, then replace "
+    "this whole comment with it (see output/posts/<slug>.image_prompt.md):\n\n"
+    "Subject: an editorial illustration of something.\n-->\n\n"
     "Body paragraph one.\n\n## References\n\n1. A\n"
 )
 
@@ -124,6 +136,55 @@ class TestTheHeroIsLinked:
         article = (workspace / "output" / "posts" / "my-slug.md").read_text()
         assert "image:" not in article
         assert "deploy will refuse" in capsys.readouterr().err
+
+
+class TestTheHandOffSurvivesTheDeployGate:
+    """BUG-070. The two art gates were never run against each other.
+
+    ``_reject_unrendered_hero_prompt`` (BUG-065) refuses an article still
+    carrying the reviewer comment; ``make art`` (B-042) is what is supposed to
+    replace it. Every test above uses an article with **no** comment in it, so
+    the whole suite passed while the documented sequence — draw hero, ``make
+    art``, ``deploy --mode review`` — could not complete. Reproduced live on
+    2026-08-02, the first real run of the hand-off.
+    """
+
+    def test_finalise_removes_the_reviewer_comment(self, workspace: Path) -> None:
+        article_path = workspace / "output" / "posts" / "my-slug.md"
+        article_path.write_text(_ARTICLE_WITH_HERO_PROMPT)
+        _write_hero(workspace)
+
+        assert finalise("my-slug") == 0
+
+        article = article_path.read_text()
+        assert "<!-- HERO IMAGE" not in article, "the deploy gate will refuse this"
+        assert "image: /assets/images/my-slug-hero.svg" in article
+
+    def test_the_deploy_gate_accepts_what_finalise_produces(
+        self, workspace: Path
+    ) -> None:
+        """The end-to-end property, asserted against the real gate.
+
+        Importing the gate here is the point: a test that only checked for the
+        absence of a substring could drift from what deploy actually refuses.
+        """
+        article_path = workspace / "output" / "posts" / "my-slug.md"
+        article_path.write_text(_ARTICLE_WITH_HERO_PROMPT)
+        _write_hero(workspace)
+        finalise("my-slug")
+
+        _reject_unrendered_hero_prompt(article_path)
+        _require_hero(article_path)
+
+    def test_an_article_without_the_comment_is_unchanged_by_the_removal(
+        self, workspace: Path
+    ) -> None:
+        """Scope guard: the stripper must not touch anything else."""
+        _write_hero(workspace)
+        assert finalise("my-slug") == 0
+        article = (workspace / "output" / "posts" / "my-slug.md").read_text()
+        assert "Body paragraph one." in article
+        assert "## References" in article
 
 
 def test_a_missing_article_is_an_error(workspace: Path) -> None:

--- a/tests/test_normalize_paragraphs.py
+++ b/tests/test_normalize_paragraphs.py
@@ -1,0 +1,51 @@
+"""BUG-071: a heading needs a blank line above it, or kramdown eats it.
+
+The blog renders with kramdown, which will not start a block element on the
+line directly after a paragraph. ``...deadline.\\n## References`` therefore
+renders as the literal text ``## References`` inside the paragraph — verified
+by running kramdown itself on 2026-08-02, not inferred from the spec.
+
+The damage is manufactured by the stat audit, and it is manufactured on every
+article: ``audit_article_stats`` splits on ``(?<=[.!?])\\s+``, which swallows
+the newline before ``## References``, and rejoins with a single space. What
+changed is that B-042 deleted Stage 4's unconditional chart embed — the
+``![Chart](…)`` line had been sitting in the gap and supplying the blank line
+by accident. Both articles generated before B-042 show the same
+``. \\n![Chart]…\\n\\n## References`` shape on disk. The first article
+generated without a chart is the first one where the heading actually breaks.
+
+``_normalize_paragraphs`` already lifted *inline* headings onto their own line.
+It did not put a blank line above a heading that was already on one.
+"""
+
+from __future__ import annotations
+
+from src.agent_sdk.stage3_runner import _normalize_paragraphs
+
+
+class TestAHeadingAlwaysGetsABlankLineAboveIt:
+    def test_the_measured_case_a_stat_audited_references_heading(self) -> None:
+        """Exactly what the stat audit emits: trailing space, single newline."""
+        audited = "The next transformation will also have a fixed deadline. \n## References\n\n1. A\n"
+
+        result = _normalize_paragraphs(audited)
+
+        assert "deadline.\n\n## References" in result
+
+    def test_a_heading_on_its_own_line_after_a_paragraph(self) -> None:
+        result = _normalize_paragraphs("Paragraph text.\n## The Next Section\n\nMore.")
+        assert "text.\n\n## The Next Section" in result
+
+    def test_an_inline_heading_is_still_lifted(self) -> None:
+        """The behaviour that already worked must keep working."""
+        result = _normalize_paragraphs("...the easy part. ## The Perception Gap\n\nX.")
+        assert "part.\n\n## The Perception Gap" in result
+
+    def test_a_correctly_spaced_heading_is_left_alone(self) -> None:
+        already_fine = "Paragraph text.\n\n## A Heading\n\nMore text.\n"
+        assert _normalize_paragraphs(already_fine) == already_fine
+
+    def test_the_first_line_of_the_body_may_be_a_heading(self) -> None:
+        """No paragraph above it means nothing to separate it from."""
+        result = _normalize_paragraphs("## Opening Heading\n\nBody text.\n")
+        assert result.startswith("## Opening Heading")

--- a/tests/test_publication_validator.py
+++ b/tests/test_publication_validator.py
@@ -379,6 +379,52 @@ class TestPublicationValidatorBlogContract:
         assert len(heading_issues) == 1
 
 
+class TestAHeadingNeedsABlankLineBeforeIt:
+    """BUG-071. The blog renders with kramdown, which is stricter than CommonMark.
+
+    kramdown will not start a block element on the line after a paragraph, so
+    ``...deadline.\\n## References`` renders as the literal text
+    ``## References`` inside the paragraph — verified by running kramdown
+    itself on 2026-08-02, not inferred.
+
+    ``inline_heading_marker`` was written for exactly this and missed the real
+    article, because its regex ``[^\\s]\\s##\\s`` allows a *single* whitespace
+    character between the sentence and the marker. The generated article ended
+    ``deadline. `` with a trailing space, so the separator was two characters
+    and a CRITICAL gate went quiet.
+    """
+
+    def test_a_trailing_space_does_not_hide_the_defect(self) -> None:
+        """The measured case: one space is all it took to silence the gate."""
+        validator = PublicationValidator(expected_date="2026-04-03")
+        article = _make_article(body=f"{VALID_BODY} \n## References")
+        is_valid, issues = validator.validate(article)
+        assert not is_valid
+        assert [i for i in issues if i["check"] == "inline_heading_marker"]
+
+    def test_a_heading_directly_after_a_paragraph_is_rejected(self) -> None:
+        validator = PublicationValidator(expected_date="2026-04-03")
+        article = _make_article(body=f"{VALID_BODY}\n## References")
+        is_valid, issues = validator.validate(article)
+        assert not is_valid
+        assert [i for i in issues if i["check"] == "inline_heading_marker"]
+
+    def test_a_properly_separated_heading_is_accepted(self) -> None:
+        """Scope guard: the normal shape must stay clean."""
+        validator = PublicationValidator(expected_date="2026-04-03")
+        article = _make_article(body=f"{VALID_BODY}\n\n## References\n\n1. A")
+        _, issues = validator.validate(article)
+        assert not [i for i in issues if i["check"] == "inline_heading_marker"]
+
+    def test_a_hash_inside_a_fenced_code_block_is_not_a_heading(self) -> None:
+        """A shell comment is not markdown. Flagging it would be a false alarm."""
+        validator = PublicationValidator(expected_date="2026-04-03")
+        body = f"{VALID_BODY}\n\n```bash\nmake art SLUG=x\n# a comment\n```"
+        article = _make_article(body=body)
+        _, issues = validator.validate(article)
+        assert not [i for i in issues if i["check"] == "inline_heading_marker"]
+
+
 class TestChartIsNotTheValidatorsDecision:
     """B-042: the validator no longer rules on whether an article needs a chart.
 


### PR DESCRIPTION
First live acceptance of the B-042 hand-off. Two defects found that 2,747 passing tests could not see, both fixed with regression tests, plus the record.

Full write-up: `docs/reviews/b042-live-acceptance-2026-08-02.md`.

## The art gate refuses — verified, not assumed

Four probes against the real article with a deliberately invalid token, so a gate failure would have failed closed at git auth rather than published. All exit 1, none cloned.

| Probe | Article state | Outcome |
|---|---|---|
| 1 | as generated | refused — `_reject_unrendered_hero_prompt` |
| 2 | no `image:` | refused — `_require_hero` |
| 3 | `image:` set, file absent | refused — `_require_hero` |
| 4 | **the state `make art` leaves** | refused — **and should not have been** |

## BUG-070 — `make art` produces an article deploy refuses

`finalise_art` delegates to `_link_hero_asset`, which edits only the frontmatter, so the `<!-- HERO IMAGE` comment survives. The documented sequence cannot complete. Every fixture in `test_finalise_art.py` used an article with no comment in it — input the pipeline never produces.

## BUG-071 — `## References` did not render as a heading

kramdown will not start a block element on the line after a paragraph. Verified by running kramdown, not inferred.

The stat audit manufactures this on every article: it splits on `(?<=[.!?])\s+`, swallowing the newline, and rejoins with a space. Stage 4's unconditional chart embed had been sitting in the gap supplying the blank line by accident — B-042 deleted it, so the first chart-less article is the first to break. Both pre-B-042 articles still carry the `. \n![Chart]…\n\n## References` shape on disk.

The CRITICAL check written for exactly this could not see it: `[^\s]\s##\s` allows one whitespace character, and the same edit left a trailing space.

| input | caught |
|---|---|
| `deadline.\n## References` | yes |
| `deadline. \n## References` | **no** |

Fixed at both layers — the normaliser so the pipeline stops emitting it, the check made line-based so whitespace cannot defeat it.

## Not done, and why

- **The hero is the owner's** (constraint #4). Steps 4 and 5 have not run live.
- **The Claude.ai re-sourcing was not attempted.** The producing conversation could not be identified from `recents`; research was re-sourced via `claude_web` instead. The B-038 HTML→brief path remains unexercised on a re-sourced artifact.

Both carried in **B-044**, along with three editorial flags on the article itself.

## Verification

`make ci-local` green. Full suite **2759 passed, 9 skipped**. Sensor proofs OK, bandit clean, destructive-change guard clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
