### PR TITLE
B-044: a range endpoint is not a measurement

### DIFF
--- a/src/agent_sdk/_shared.py
+++ b/src/agent_sdk/_shared.py
@@ -117,6 +117,39 @@ def _extract_stats(text: str) -> list[str]:
     return stats
 
 
+#: A figure that is the upper end of a range, matched against the text *before*
+#: it: "15–20%", "30-40%", "60 to 100 times". B-044, observed on the first real
+#: packet — the brief said "earmark 15–20% of IT budgets" and the proposal
+#: offered a row reading ``20 %``. The value is in the brief, so this was never
+#: fabrication; but a chart built from that row states a range endpoint as a
+#: measurement, which is the thing a reader cannot tell from real data.
+#:
+#: Only the upper end needs excluding: the lower end carries no unit of its own,
+#: so ``_STAT_PATTERN`` never matched it in the first place.
+_RANGE_UPPER_BOUND = re.compile(r"\d\s*(?:[-–—]|to)\s*$")
+
+#: How much of the brief to quote either side of a figure as provenance.
+_CONTEXT_CHARS = 60
+
+
+def _quote_context(brief: str, start: int, end: int) -> str:
+    """Quote the brief around a figure, without cutting words in half.
+
+    B-044: the first real packet opened a row with
+    ``'cts: Skipping Rigour Guarantees Overruns - Three-…'``. The figure and its
+    unit were right; only the provenance was hard to read — which matters,
+    because reading it is the owner's only check on the number.
+    """
+    left = max(0, start - _CONTEXT_CHARS)
+    right = min(len(brief), end + _CONTEXT_CHARS)
+    quoted = brief[left:right]
+    if left > 0 and not brief[left - 1].isspace():
+        quoted = re.sub(r"^\S*\s*", "", quoted)
+    if right < len(brief) and not brief[right].isspace():
+        quoted = re.sub(r"\s*\S*$", "", quoted)
+    return re.sub(r"\s+", " ", quoted.strip())
+
+
 def propose_chart_spec(research_brief: str) -> dict[str, Any] | None:
     """Propose chart rows by *extracting* figures from the brief. No LLM.
 
@@ -154,6 +187,8 @@ def propose_chart_spec(research_brief: str) -> dict[str, Any] | None:
     seen: set[tuple[float, str]] = set()
 
     for match in _STAT_PATTERN.finditer(research_brief):
+        if _RANGE_UPPER_BOUND.search(research_brief[: match.start()]):
+            continue
         value = float(match.group(1))
         unit = match.group(2).strip()
         key = (value, unit.lower())
@@ -161,9 +196,7 @@ def propose_chart_spec(research_brief: str) -> dict[str, Any] | None:
             continue
         seen.add(key)
 
-        start = max(0, match.start() - 60)
-        end = min(len(research_brief), match.end() + 60)
-        context = re.sub(r"\s+", " ", research_brief[start:end].strip())
+        context = _quote_context(research_brief, match.start(), match.end())
         rows.append(
             {
                 "metric": "",

--- a/src/agent_sdk/review_packet.py
+++ b/src/agent_sdk/review_packet.py
@@ -123,7 +123,9 @@ def _format_chart(result: _PacketSource) -> str:
             "(`%`, `per cent`, `billion`, `million`, `thousand`, `trillion`, "
             "`fold`, `times`, `x`). Bare counts and years are deliberately not "
             'proposed, so a figure written as "1,200 engineers" would not '
-            "appear above — if you know of one, it is yours to add.",
+            "appear above — if you know of one, it is yours to add. Neither is "
+            'either end of a range: "15–20%" is not a measurement, and a row '
+            "reading `20 %` would read as one.",
         ]
         return "\n".join(lines)
 
@@ -141,6 +143,10 @@ def _format_chart(result: _PacketSource) -> str:
         "data. Delete the rows you do not want: these are candidates, not a "
         "chart. One axis, one measure — the renderer rejects a spec whose values "
         "span too many orders of magnitude (B-014).",
+        "",
+        "Two kinds of figure are deliberately left out, so you know to add them "
+        'yourself if you want them: bare counts and years ("1,200 engineers"), '
+        'and either end of a range ("15–20%" is not a measurement).',
         "",
         "| value | unit | found in the brief as |",
         "|---|---|---|",

--- a/tests/test_propose_chart_spec.py
+++ b/tests/test_propose_chart_spec.py
@@ -112,6 +112,76 @@ class TestFramingIsLeftToTheOwner:
         assert len(keys) == len(set(keys))
 
 
+_BRIEF_WITH_RANGES = """
+## Research brief — ranges
+
+Oliver Wyman recommends earmarking 15-20% of IT budgets for debt reduction;
+organisations that defer until crisis spend 30–40% on emergency programmes.
+A defect costs 60 to 100 times more to fix once it reaches production.
+Separately, a clean point measurement: 54% of migrations ran behind schedule.
+"""
+
+
+class TestARangeEndpointIsNotAMeasurement:
+    """B-044, observed on the first real packet (2026-08-02).
+
+    The brief said "earmark 15–20% of IT budgets" and "spending 30–40%"; the
+    proposal offered rows reading ``20 %`` and ``40 %``. The value does appear
+    in the brief, so this was never fabrication — but a chart built from those
+    rows would state a range endpoint as a measurement, which is the same thing
+    the reader cannot distinguish from real data.
+
+    So a range bound is **not proposed at all**, in the same spirit as bare
+    counts and years: the proposal deliberately under-offers, and the packet
+    says what it left out so the owner can add it back knowingly.
+    """
+
+    def test_neither_end_of_a_hyphen_range_is_proposed(self) -> None:
+        spec = propose_chart_spec(_BRIEF_WITH_RANGES)
+        assert spec is not None
+        values = {row["value"] for row in spec["data"]}
+        assert 20 not in values, "proposed the upper bound of 15-20%"
+        assert 15 not in values
+
+    def test_neither_end_of_an_en_dash_range_is_proposed(self) -> None:
+        spec = propose_chart_spec(_BRIEF_WITH_RANGES)
+        assert spec is not None
+        values = {row["value"] for row in spec["data"]}
+        assert 40 not in values, "proposed the upper bound of 30–40%"
+        assert 30 not in values
+
+    def test_a_written_out_range_is_not_proposed(self) -> None:
+        """ "60 to 100 times" is a range in prose, not two measurements."""
+        spec = propose_chart_spec(_BRIEF_WITH_RANGES)
+        assert spec is not None
+        assert 100 not in {row["value"] for row in spec["data"]}
+
+    def test_a_genuine_point_measurement_survives(self) -> None:
+        """Scope guard: the exclusion must not swallow real figures."""
+        spec = propose_chart_spec(_BRIEF_WITH_RANGES)
+        assert spec is not None
+        assert 54 in {row["value"] for row in spec["data"]}
+
+
+class TestProvenanceIsReadable:
+    """B-044: the context window cut mid-word on the real packet.
+
+    The first row read ``'cts: Skipping Rigour Guarantees Overruns - Three-…'``.
+    The figure and its unit were right; the provenance was just hard to read,
+    which matters because reading it is the owner's only check on the number.
+    """
+
+    def test_context_does_not_begin_mid_word(self) -> None:
+        brief = (
+            "Overruns and rework dominate the failure modes reported across "
+            "the surveyed programmes, of which 75% exceeded budget."
+        )
+        spec = propose_chart_spec(brief)
+        assert spec is not None
+        context = spec["data"][0]["source"].removeprefix("brief: ").strip("'")
+        assert brief.startswith(context) or f" {context}" in f" {brief}"
+
+
 class TestTheProposalIsNotSilentlyRenderable:
     """The renderer must reject a proposal until the owner has framed it.
 


### PR DESCRIPTION
Both chart-proposal items from B-044, found on the first real packet.

## A range endpoint is not a measurement

The brief said "earmark 15–20% of IT budgets" and "spending 30–40%". The proposal offered rows reading `20 %` and `40 %`.

The value does appear in the brief, so this was never fabrication — but a chart built from those rows would state a range endpoint as a measurement, which is exactly the thing a reader cannot distinguish from real data. That is B-042's complaint arriving through a different door.

Range bounds are now not proposed at all, in the same spirit as bare counts and years: the proposal deliberately under-offers. The packet says what it left out in **both** branches, so nothing is dropped silently.

Only the upper end needed excluding — the lower end carries no unit of its own, so `_STAT_PATTERN` never matched it. A scope-guard test asserts a genuine point measurement in the same paragraph still survives.

## Provenance was cut mid-word

The first packet opened a row with `'cts: Skipping Rigour Guarantees Overruns - Three-…'`. The figure and unit were right; only the evidence was hard to read — and reading it is the owner's only check on the number. The ±60-character window now snaps to word boundaries.

## Applied to the live spec

`output/charts/migration-deadline-testing-trap.spec.json` went 19 rows → 17. The two dropped are exactly the `20 %` and `40 %` rows above.

## Verification

`make ci-local` green. Full suite **2764 passed, 9 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
