### PR TITLE
BUG-072: a real PNG hero crashed make art

### DIFF
--- a/data/skills_state/defect_tracker.json
+++ b/data/skills_state/defect_tracker.json
@@ -1201,10 +1201,27 @@
       "prevention_test_file": "tests/test_normalize_paragraphs.py",
       "introduced_in_commit": "95c838ce",
       "introduced_date": "2026-08-01"
+    },
+    {
+      "id": "BUG-072",
+      "severity": "high",
+      "discovered_in": "acceptance",
+      "discovered_date": "2026-08-02T00:00:00",
+      "description": "`make art` crashed with UnicodeDecodeError on a real PNG hero. _hero_description called path.read_text() on any hero to harvest an SVG <desc>; a PNG is binary. .png is a first-class hero format (_HERO_SUFFIXES lists it, deploy generates its .webp sibling), so this was a supported path that had never been exercised.",
+      "component": "pipeline",
+      "status": "fixed",
+      "fixed_date": "2026-08-02T00:00:00",
+      "is_production_escape": false,
+      "root_cause": "test_gap",
+      "root_cause_notes": "PNG heroes in test_frontmatter_blog_contract.py are created with (images / 'my-slug-hero.png').write_text('stub') \u2014 a text file wearing a .png name \u2014 so read_text() always succeeded. Same class as BUG-070: the fixture is not what reality produces. Found by putting a real Gemini PNG on disk and running make art.",
+      "prevention_test_added": true,
+      "prevention_test_file": "tests/test_hero_description.py",
+      "introduced_in_commit": "unknown",
+      "introduced_date": "2026-07-29"
     }
   ],
   "summary": {
-    "total_bugs": 54,
+    "total_bugs": 55,
     "fixed_bugs": 7,
     "production_bugs": 6,
     "defect_escape_rate": 42.9,
@@ -1242,6 +1259,6 @@
     "avg_time_to_resolve_days": 2.0,
     "avg_critical_ttd_days": 3.7,
     "last_updated": "2026-08-02T00:00:00",
-    "total": 54
+    "total": 55
   }
 }

--- a/src/agent_sdk/pipeline.py
+++ b/src/agent_sdk/pipeline.py
@@ -441,10 +441,24 @@ _IMAGE_ALT_LINE = re.compile(r"^image_alt:.*$\n?", re.MULTILINE)
 
 
 def _hero_description(path: Path) -> str:
-    """The hero's ``<desc>``, cleaned for use as YAML-safe alt text."""
+    """The hero's ``<desc>``, cleaned for use as YAML-safe alt text.
+
+    Only an SVG has one. BUG-072: this read *any* hero as text, so a real PNG —
+    a first-class hero format, listed in ``_HERO_SUFFIXES`` and given a ``.webp``
+    sibling at deploy — raised ``UnicodeDecodeError`` and took ``make art`` down
+    with it. The suite missed it because its PNG heroes are written with
+    ``write_text("stub")``, which is a text file wearing a ``.png`` name.
+
+    A PNG hero therefore has no alt text to harvest, and the caller leaves
+    ``image_alt`` for a human. That is correct rather than a gap: alt text
+    describes what was drawn, and nothing on disk can tell us that about a
+    raster.
+    """
+    if path.suffix.lower() != ".svg":
+        return ""
     try:
         match = _HERO_DESC.search(path.read_text())
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return ""
     if not match:
         return ""

--- a/tests/test_hero_description.py
+++ b/tests/test_hero_description.py
@@ -1,0 +1,56 @@
+"""BUG-072: a real PNG hero crashed `make art`.
+
+``_hero_description`` reads the hero to pull alt text out of an SVG ``<desc>``.
+It called ``path.read_text()`` unconditionally, so a genuine PNG — binary —
+raised ``UnicodeDecodeError`` and took the whole ``make art`` step down.
+
+``.png`` is a first-class hero format: ``_HERO_SUFFIXES`` lists it, and the
+deploy step generates the ``.webp`` sibling a PNG hero needs. So this was not
+an unsupported path, it was a supported one that had never been exercised.
+
+Why the suite missed it, again: the PNG heroes in
+``test_frontmatter_blog_contract.py`` are created with
+``(images / "my-slug-hero.png").write_text("stub")`` — a *text file with a .png
+name*. ``read_text()`` succeeds on those. Found on 2026-08-02 by putting a real
+Gemini PNG on disk and running ``make art``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.agent_sdk.pipeline import _hero_description, _link_hero_asset
+
+#: The first eight bytes of any PNG. Enough to make the file genuinely binary.
+_PNG_MAGIC = b"\x89PNG\r\n\x1a\n" + b"\x00\x01\x02\x03" * 16
+
+_ARTICLE = '---\nlayout: post\ntitle: "My Slug"\n---\n\nBody.\n'
+
+
+class TestABinaryHeroDoesNotCrash:
+    def test_a_real_png_yields_no_description(self, tmp_path: Path) -> None:
+        hero = tmp_path / "my-slug-hero.png"
+        hero.write_bytes(_PNG_MAGIC)
+
+        assert _hero_description(hero) == ""
+
+    def test_linking_a_real_png_hero_succeeds(self, tmp_path: Path) -> None:
+        """The end-to-end property: `make art` must survive a PNG hero."""
+        (tmp_path / "my-slug-hero.png").write_bytes(_PNG_MAGIC)
+
+        out = _link_hero_asset(_ARTICLE, "my-slug", images_dir=tmp_path)
+
+        assert "image: /assets/images/my-slug-hero.png" in out
+
+    def test_an_svg_desc_is_still_read(self, tmp_path: Path) -> None:
+        """Scope guard: the SVG path is the reason this function exists."""
+        hero = tmp_path / "my-slug-hero.svg"
+        hero.write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg"><desc>Scissors cutting a '
+            "ribbon</desc></svg>"
+        )
+
+        assert _hero_description(hero) == "Scissors cutting a ribbon"
+
+    def test_a_missing_hero_yields_no_description(self, tmp_path: Path) -> None:
+        assert _hero_description(tmp_path / "absent-hero.svg") == ""


### PR DESCRIPTION
Third defect found live in the B-042 hand-off, and the third with the same root cause: the fixture is not what reality produces.

`_hero_description` read *any* hero as text to harvest an SVG `<desc>`, so a genuine PNG raised `UnicodeDecodeError` and took the whole `make art` step down. `.png` is a first-class hero format — `_HERO_SUFFIXES` lists it and `_copy_hero_asset` generates its `.webp` sibling — so this was a supported path that had never been run.

The suite missed it because its PNG heroes are created with `(images / 'my-slug-hero.png').write_text('stub')` — a text file wearing a `.png` name, on which `read_text()` succeeds. Found by putting a real PNG on disk and running `make art`.

A PNG hero now yields no alt text and the caller leaves `image_alt` for a human. That is correct rather than a gap: alt text describes what was drawn, and nothing on disk can tell us that about a raster.

`make ci-local` green. Full suite **2768 passed, 9 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)