### PR TITLE
feat(B-040): the calibration set reaches 23 cases and 52% negatives

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -715,7 +715,9 @@ instruction points at a target that actually works from nothing.
 
 ### B-040 · Calibrate the editorial review gate so it can be promoted
 
-**Opened 2026-08-01.** Spec: `docs/specs/review-gate-calibration.md` — **awaiting LGTM.**
+**Opened 2026-08-01.** Spec: `docs/specs/review-gate-calibration.md` — **LGTM'd 2026-08-05**,
+with both open questions answered in the affirmative (agent drafts negatives + owner
+spot-checks a sample; `unverified` is a third outcome with its own `n`). Task breakdown below.
 
 ADR-0018 Decision 3 keeps `blog-post-review` advisory and says "promote to blocking once a
 false-positive rate is known." **Nothing has ever produced that number.** The gate has run
@@ -746,6 +748,47 @@ above 85 would mean the rubric is broken rather than the pipeline"). Different t
 
 **Scope:** M. **Files:** `scripts/calibrate_review_gate.py`, `docs/evals/review-gate/`,
 `tests/test_calibrate_review_gate.py`.
+
+#### Plan — 2026-08-05, post-LGTM
+
+**Phase 1 · the case set — unblocked now.** The set is 8 cases, **2 negatives (25%)**, against
+a criterion of ≥20 cases and ≥40% negatives. All 8 carry
+`source: testing-shortcuts-migration-deadline`; the README claims two sources but
+`review-queue-throughput-tax` has contributed **zero**.
+
+- [ ] **Task 1 — convert the ADR-0018 findings into cases (S).** The 10 labelled fidelity
+      defects plus the **near-false-positive** (the summarised Graphite fetch that would have
+      reported a false G2 failure on Graphite's own published figure). The spec calls that one
+      case worth more than all ten positives, because false positives are what block
+      promotion — and it is the case the set does not have. Correct the README's provenance
+      claim in the same change. **Files:** `docs/evals/review-gate/cases/*.yaml`, README.
+- [ ] **Task 2 — mine ~15 negatives from the 26 published articles (M).** Source of truth is
+      the `oviney/blog` clone at `/Users/ouray.viney/code/economist-blog-v5/_posts` (26 posts,
+      current to 2026-08-02). Every case carries `source:` provenance. **Owner spot-checks a
+      sample** — per the answered open question, this is the control on the agent drafting
+      cases for a judge of its own model family, so it is not optional.
+
+**Checkpoint (owner):** ≥20 cases, ≥40% negatives, spot-check passed. Phase 2 opens here.
+
+**Phase 2 · the runner — TDD, judge stubbed in tests, no model calls in the suite.**
+
+- [ ] **Task 3 — case loader + schema validation + balance report (S).** A file missing
+      `expected` or `why` is rejected loudly, never skipped. Balance reported every run.
+- [ ] **Task 4 — agreement arithmetic (S).** False-positive, false-negative and `unverified`
+      as **three separate counts with three denominators**; `n` beside every rate; a rate from
+      <20 cases labelled provisional in the output itself. Degenerate cases (all-pass,
+      all-fail, empty) covered.
+- [ ] **Task 5 — keyless judge via the Agent SDK + `--gate` / `--report` (M).** Runs the gate
+      **as accepted 2026-07-31** — v1 does not touch `rubric.md` or `REVIEW_PROMPT.md`.
+- [ ] **Task 6 — report to `logs/review_gate_calibration.json`, append-only (S).** Decide
+      *against* wiring into `make ci-local`: the runner makes model calls, and `ci-local` must
+      stay keyless and offline.
+
+**Sequencing note, flagged rather than acted on.** The spec gates the build on "n≈5 real
+reviews"; the repo has 2. That gate is worth re-examining at the Phase 2 checkpoint, because
+the runner grades **cases**, not review runs — the 5 reviews inform how to *interpret* the
+result (threshold tuning vs anchor revision), not the harness design. Owner's call at the
+checkpoint; Phase 1 does not depend on it either way.
 
 **Shipped 2026-08-01 alongside the spec, because waiting corrupts the baseline:**
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -735,7 +735,10 @@ monitoring, not an eval set. The guide's instruction — *"20-50 simple tasks dr
 failures"* — is satisfiable today at **finding** granularity: ADR-0018 enumerates 10 labelled
 fidelity defects plus the 1 labelled near-false-positive.
 
-- [ ] ~25 cases, ≥40% negatives, each traceable to a real article or a real finding
+- [x] ~25 cases, ≥40% negatives, each traceable to a real article or a real finding
+      *(23 cases at 52% negatives, 2026-08-05 — pending the owner spot-check. Known gap:
+      **G3 has no positive case** and one must not be invented, so G3's false-negative rate
+      is unmeasurable in v1.)*
 - [ ] Report false-positive and false-negative rates **separately, with `n`** — never averaged
 - [ ] Keyless judge via the Agent SDK; case selection and arithmetic deterministic
 - [ ] Sufficient for the owner to answer ADR-0018 Decision 3
@@ -756,13 +759,18 @@ a criterion of ≥20 cases and ≥40% negatives. All 8 carry
 `source: testing-shortcuts-migration-deadline`; the README claims two sources but
 `review-queue-throughput-tax` has contributed **zero**.
 
-- [ ] **Task 1 — convert the ADR-0018 findings into cases (S).** The 10 labelled fidelity
+**Phase 1 DONE 2026-08-05 — PR #473, open, gated on the owner spot-check.** The set is
+**23 cases / 12 negatives (52%) / 4 source articles**; `make ci-local` green at 2,768 passed,
+9 skipped. Resume instructions and the four cases to spot-check are in `docs/HANDOFF.md`.
+
+- [x] **Task 1 — convert the ADR-0018 findings into cases (S).** The 10 labelled fidelity
       defects plus the **near-false-positive** (the summarised Graphite fetch that would have
       reported a false G2 failure on Graphite's own published figure). The spec calls that one
       case worth more than all ten positives, because false positives are what block
       promotion — and it is the case the set does not have. Correct the README's provenance
       claim in the same change. **Files:** `docs/evals/review-gate/cases/*.yaml`, README.
-- [ ] **Task 2 — mine ~15 negatives from the 26 published articles (M).** Source of truth is
+- [x] **Task 2 — mine ~15 negatives from the 26 published articles (M).** *(12 mined, from 3
+      articles; the criterion was the 40% ratio, which 12 clears at 52%.)* Source of truth is
       the `oviney/blog` clone at `/Users/ouray.viney/code/economist-blog-v5/_posts` (26 posts,
       current to 2026-08-02). Every case carries `source:` provenance. **Owner spot-checks a
       sample** — per the answered open question, this is the control on the agent drafting

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,4 +1,67 @@
-# Hand-off — 2026-08-02
+# Hand-off — 2026-08-09
+
+## Resume here: B-040 Phase 1 is done and waiting on one owner action
+
+**Machine change.** Work stopped on this laptop mid-item, deliberately, with everything
+pushed. Nothing is in progress locally; there is no uncommitted work to recover.
+
+**State.** `docs/specs/review-gate-calibration.md` was **LGTM'd 2026-08-05** with both open
+questions answered in the affirmative (the agent drafts negative cases with provenance and
+the owner spot-checks a sample; `unverified` is a third outcome with its own `n`, never
+folded into either error rate). The plan is in `BACKLOG.md` under B-040 — two phases, and
+Phase 1 is complete.
+
+**Open PR: [#473](https://github.com/oviney/economist-agents/pull/473)** — the calibration
+set goes from 8 cases / 25% negatives to **23 cases / 52% negatives across 4 source
+articles**, clearing the spec's ≥20 and ≥40% criteria. `make ci-local` green at 2,768 passed,
+9 skipped. Not merged, because it is gated on the action below.
+
+**The one thing needed to resume: the owner spot-check.** This is the control the answered
+open question 1 requires — the agent drafted the negatives and is the same model family as
+the judge under test, so the cases need an independent read. Four, highest-risk first:
+
+| Case | Why it is the risky one |
+|---|---|
+| `g2-publishers-own-headline-figure` | The labelled near-false-positive. If this verdict is wrong, the number ADR-0018 Decision 3 blocks on is wrong. |
+| `g2-baseline-measures-something-else` | Its paired opposite, from the same sentence. The pair tests whether the gate can split a sentence rather than condemn it. |
+| `g2-claim-scoped-to-the-studys-scope` | "Correct" here is a judgement call, not checkable arithmetic. |
+| `g2-second-hand-attribution-is-declared` | Same — it turns on whether declaring a second-hand source is a virtue or a defect. |
+
+**Then Phase 2** (the runner, TDD, judge stubbed, no model calls in the suite) — Tasks 3–6
+in `BACKLOG.md`. One question is queued for that checkpoint and is the owner's to settle:
+the spec gates the build on n≈5 real reviews and the repo has 2, but the runner grades
+**cases**, not review runs. The 5 reviews inform how to interpret the result (threshold
+tuning vs anchor revision), not the harness design.
+
+### Three things recorded in PR #473 rather than fixed, because fixing them meant inventing
+
+1. **Only 6 of ADR-0018's 10 findings were reconstructible. The review report was never
+   persisted** — only `docs/reviews/review-queue-throughput-tax-42d2fbb4.html` (the rendered
+   draft page, not the verdict) and the ADR's prose survive. A mislabelled ground-truth case
+   is worse than a missing one. **Operating consequence: every future review run must append
+   its verdict block**, per ADR-0018 Decision 4's observability row. This is the second time
+   an unread-or-unwritten instrument has cost this repo real work (see B-041's cost ledger).
+2. **G3 has no positive case and one must not be invented.** No arithmetic defect has ever
+   been recorded here — ADR-0018 found G3 clean, and B-042's fabricated chart figures were a
+   G4 fabrication, not a computation that failed to reproduce. So **G3's false-negative rate
+   is unmeasurable in v1**: the set can show G3 does not over-fire, not that it fires at all.
+   Same class as B-031 and B-043 — a sensor with no proof it can fail.
+3. **6 of the 12 negatives come from one article**, so the register is narrower than 52%
+   suggests. An argument for the set growing as reviews accrue, not for treating it as done.
+
+### Also open, and not mine to decide
+
+**[PR #474](https://github.com/oviney/economist-agents/pull/474) — Mermaid VS Code extension
+artifacts.** A `.github/instructions/mermaid.instructions.md` file and a 7-line block appended
+to `.github/copilot-instructions.md` appeared in the working tree during the 2026-08-09
+session. **Neither was authored by the agent or requested by the owner** — they are written by
+the Mermaid VS Code extension. They are committed on their own branch rather than merged or
+deleted, so the machine change loses nothing, and kept out of #473 so a tooling artifact does
+not ride into a calibration PR. `.github/copilot-instructions.md` is one of the six documents
+B-028 Task 2 corrected, so a tool appending to it unprompted is worth an owner decision:
+keep, or close the PR and gitignore the path.
+
+## Hand-off — 2026-08-02
 
 ## The hand-off ran end to end and the article is published
 

--- a/docs/evals/review-gate/README.md
+++ b/docs/evals/review-gate/README.md
@@ -29,11 +29,56 @@ reported a false G2 failure on a figure that is correct and is Graphite's own pu
 number. That case is worth more than any of the true positives, because false positives are
 what block promotion to blocking.
 
+> **Six of the ten are here, not ten — and the reason is worth recording.** Until 2026-08-05
+> this section described cases that did not exist: every file on disk carried
+> `source: testing-shortcuts-migration-deadline`, and this article had contributed **none**.
+> The six added on 2026-08-05 were reconstructed from ADR-0018's prose, which describes five
+> findings verbatim plus the G5 supersession. **The review report itself was never persisted.**
+> Only `docs/reviews/review-queue-throughput-tax-42d2fbb4.html` — the rendered draft page, not
+> the verdict — and the ADR's summary survive. The remaining findings (among them an
+> organisation-level conclusion imported into a paper reporting no organisation-level outcome)
+> cannot be turned into cases without guessing which passage each refers to, and a
+> mislabelled ground-truth case is worse than a missing one (rule 3 below).
+>
+> **The operating consequence:** a review whose verdict block is not saved is a review whose
+> findings are only as durable as whatever prose someone wrote about it afterwards. Every
+> future run should append its verdict block to `logs/`, per ADR-0018 Decision 4's
+> observability row.
+
 **`testing-shortcuts-migration-deadline`** — generated 2026-08-01 from an owner artifact that
 contained **zero citations**. The writer sourced the piece itself and fabricated freely; the
 deterministic evaluator scored it **76** and the publication validator **passed** it. It
 reproduced ADR-0018's chart finding exactly, one day after the ADR was accepted. Unplanned,
 and better material than anything designed on purpose.
+
+## Set status — 2026-08-05
+
+**23 cases · 12 negatives (52%) · 4 source articles.** Both spec criteria met: ≥20 cases,
+≥40% negatives.
+
+| Gate | fail | pass |
+|---|---|---|
+| G1 Source resolvability | 1 | 1 |
+| G2 Citation fidelity | 7 | 5 |
+| G3 Arithmetic integrity | **0** | 2 |
+| G4 No fabrication | 2 | 2 |
+| G5 Evidence currency | 1 | 2 |
+
+**G3 has no positive case, and one must not be invented to fill the row.** No arithmetic
+defect has ever been recorded in this repo — ADR-0018 found G3 clean on the one real review,
+and B-042's fabricated chart figures were a G4 fabrication, not a computation that failed to
+reproduce. The consequence must be stated in the report rather than hidden: **G3's
+false-negative rate is unmeasurable in v1.** The set can show G3 does not over-fire; it cannot
+show G3 fires at all. That is the same defect class as B-031 and B-043 — a sensor with no
+proof it can fail — and the honest fix is a real G3 failure when one occurs, not a
+manufactured one now.
+
+Two adjacent notes on what these numbers do and do not support. **`n=23` does not carry a
+confidence interval**, and the runner is required to label rates from fewer than 20 cases
+provisional; 23 clears that bar only just. And **6 of the 12 negatives come from a single
+article**, so a judge that happens to suit one author's register will look better calibrated
+than it is. Both are arguments for the set continuing to grow as reviews accrue, not for
+treating this snapshot as finished.
 
 ## Format
 

--- a/docs/evals/review-gate/cases/g1-references-carry-full-locators.yaml
+++ b/docs/evals/review-gate/cases/g1-references-carry-full-locators.yaml
@@ -1,0 +1,17 @@
+id: g1-references-carry-full-locators
+gate: G1
+expected: pass
+source: green-light-red-ledger-flaky-tests-invisible-tax
+passage: >-
+  1. Parry, J. et al. "Cost of Flaky Tests in CI: An Industrial Case Study." *ICST 2024
+  Industry Track*, April 2024.
+  https://conf.researchr.org/details/icst-2024/icst-2024-industry/1/Cost-of-Flaky-Tests-in-CI-An-Industrial-Case-Study
+  3. Micco, J. "Flaky Tests at Google and How We Mitigate Them." *Google Testing Blog*, May
+  2016. https://testing.googleblog.com/2016/05/flaky-tests-at-google-and-how-we.html
+why: >-
+  A NEGATIVE case, and the deliberate mirror of g1-references-carry-no-locators. Each entry
+  resolves to one specific document: named author, exact title, venue, date, and a direct URL
+  to the item rather than to a publisher's landing page. This is what G1 satisfaction looks
+  like, and the set needs it — a gate evaluated only on missing locators learns to fire on
+  reference lists generally. Scoped to G1 only: whether a 2016 source remains current is a G5
+  question and this case does not adjudicate it.

--- a/docs/evals/review-gate/cases/g2-baseline-measures-something-else.yaml
+++ b/docs/evals/review-gate/cases/g2-baseline-measures-something-else.yaml
@@ -1,0 +1,16 @@
+id: g2-baseline-measures-something-else
+gate: G2
+expected: fail
+source: review-queue-throughput-tax
+passage: >-
+  A median pull request requiring a review takes 14 hours to merge, according to Graphite
+  Research, against nine hours for one merged without review: a 55 per cent penalty for the
+  privilege of a second opinion.
+why: >-
+  The nine-hour baseline is described as measuring something the source does not measure, so
+  the 55 per cent "penalty" is a comparison between two different quantities. Note the
+  pairing with g2-publishers-own-headline-figure: the 14-hour figure in this same sentence is
+  correct and is the publisher's own headline number. A well-calibrated gate must fail the
+  baseline clause while passing the median clause. A gate that fails the whole sentence is
+  right for the wrong reason, and one that passes the whole sentence misses a real defect —
+  which is why both halves are in the set as separate cases.

--- a/docs/evals/review-gate/cases/g2-chart-referenced-shows-neither-figure.yaml
+++ b/docs/evals/review-gate/cases/g2-chart-referenced-shows-neither-figure.yaml
@@ -1,0 +1,17 @@
+id: g2-chart-referenced-shows-neither-figure
+gate: G2
+expected: fail
+source: review-queue-throughput-tax
+passage: >-
+  The chart below makes clear, however, that those same squads absorbed a 91 per cent
+  increase in PR review time and a 154 per cent surge in average PR size, with no measurable
+  improvement in the DORA metrics of deployment frequency, lead time, or change failure rate
+  at the organisational level.
+why: >-
+  The chart contains neither of the two figures the prose says it shows, and it sits three
+  sections below this reference — the reader reaches it after two intervening headings, by
+  which point "below" no longer identifies anything. The defect required a rendered page to
+  see, which is why the B-013 live review stage caught it and markdown review would not have.
+  Worth keeping for a second reason: the deterministic evaluator awarded this article 10/10
+  on visual_engagement for "image: yes, chart embedded: yes". A counting check cannot
+  distinguish a chart that supports the prose from one that does not.

--- a/docs/evals/review-gate/cases/g2-claim-scoped-to-the-studys-scope.yaml
+++ b/docs/evals/review-gate/cases/g2-claim-scoped-to-the-studys-scope.yaml
@@ -1,0 +1,17 @@
+id: g2-claim-scoped-to-the-studys-scope
+gate: G2
+expected: pass
+source: the-ai-testing-paradox
+passage: >-
+  GitHub reported that developers in a controlled experiment completed a JavaScript task
+  faster with Copilot, and large survey cohorts said the tool helped them stay in flow and
+  reduce repetitive effort. Those gains are real. They also describe only one slice of the
+  software lifecycle.
+why: >-
+  A NEGATIVE case, and the deliberate inverse of the review-queue defect where a study's
+  finding was inflated into an organisation-level conclusion it never reported. Here the scope
+  is preserved at every step: a controlled experiment, one language, one task, with the
+  self-reported survey cohort named separately from the experiment rather than merged into a
+  single claim — and the inference is then explicitly bounded. This is the strongest form of
+  G2 compliance, because the article had an obvious rhetorical incentive to overstate and did
+  not. If the gate cannot pass this, it cannot pass careful writing at all.

--- a/docs/evals/review-gate/cases/g2-offsetting-clause-deleted.yaml
+++ b/docs/evals/review-gate/cases/g2-offsetting-clause-deleted.yaml
@@ -1,0 +1,14 @@
+id: g2-offsetting-clause-deleted
+gate: G2
+expected: fail
+source: review-queue-throughput-tax
+passage: >-
+  According to LinearB's 2026 Software Engineering Benchmarks Report, which analysed 8.1
+  million pull requests across more than 4,800 organisations, AI-assisted PRs wait 4.6 times
+  longer for a reviewer to pick them up than manually written code.
+why: >-
+  The source's finding is "AI PRs wait 4.6x longer before review, but are reviewed 2x faster
+  once picked up." The offsetting second clause is deleted, so the quantity survives intact
+  while the source's net position is inverted. This is the hardest sub-class of G2 to catch,
+  because every number in the sentence is correct and recomputes — G3 is clean. Fidelity here
+  is about what was omitted, not what was stated.

--- a/docs/evals/review-gate/cases/g2-predictor-not-in-the-cited-ranking.yaml
+++ b/docs/evals/review-gate/cases/g2-predictor-not-in-the-cited-ranking.yaml
@@ -1,0 +1,13 @@
+id: g2-predictor-not-in-the-cited-ranking
+gate: G2
+expected: fail
+source: review-queue-throughput-tax
+passage: >-
+  PR size, author seniority, and lines changed all trail behind review presence as predictors
+  of cycle time.
+why: >-
+  "Author seniority" is attributed to a ranking of predictors that does not contain it. The
+  cited source ranks the other factors; this one was added to the list. The claim is
+  plausible, unquantified, and reads as a summary of the source rather than an addition to
+  it, which is what makes it a G2 rather than a G4 — nothing here is invented wholesale, it
+  is a real ranking with an extra member inserted.

--- a/docs/evals/review-gate/cases/g2-projection-reported-as-a-projection.yaml
+++ b/docs/evals/review-gate/cases/g2-projection-reported-as-a-projection.yaml
@@ -1,0 +1,17 @@
+id: g2-projection-reported-as-a-projection
+gate: G2
+expected: pass
+source: the-ai-testing-paradox
+passage: >-
+  The best public warning sign so far comes from GitClear's analysis of roughly 153 million
+  changed lines of code. Its 2024 report argues that code churn is on pace to double relative
+  to a 2021 pre-AI baseline, while copy-pasted additions rise and refactoring activity
+  weakens.
+why: >-
+  A NEGATIVE case. A projection is reported as a projection — "argues", "on pace to double",
+  against a named baseline year — rather than as a measured doubling, which is the single
+  most common way a forecast becomes a fabricated statistic. The sample is given with an
+  honest approximation ("roughly 153 million"), the publisher is named, and the direction of
+  the other two findings is stated without inventing magnitudes for them. A gate that flags
+  this is flagging correct epistemic hedging, and the article that would satisfy it instead
+  would be the one that dropped the hedge.

--- a/docs/evals/review-gate/cases/g2-publishers-own-headline-figure.yaml
+++ b/docs/evals/review-gate/cases/g2-publishers-own-headline-figure.yaml
@@ -1,0 +1,17 @@
+id: g2-publishers-own-headline-figure
+gate: G2
+expected: pass
+source: review-queue-throughput-tax
+passage: >-
+  A median pull request requiring a review takes 14 hours to merge, according to Graphite
+  Research.
+why: >-
+  A NEGATIVE case, and the highest-value one in the set — this is the labelled
+  near-false-positive from the 2026-07-29 review that produced ADR-0018. During that review a
+  summarised fetch of the Graphite page returned an incomplete answer, and had it been
+  trusted the gate would have reported a G2 failure here. Only re-reading the raw page text
+  corrected it. The figure is correct and is Graphite's own published number: the cited
+  document is titled "The Median Developer's PRs Take 14 Hours to Merge". A gate that fails
+  this case is failing an article on its source's own headline finding, which is precisely
+  the false positive that would train the owner to override the gate and so destroy it.
+  ADR-0018 Decision 3 is blocked on the rate this case measures.

--- a/docs/evals/review-gate/cases/g2-second-hand-attribution-is-declared.yaml
+++ b/docs/evals/review-gate/cases/g2-second-hand-attribution-is-declared.yaml
@@ -1,0 +1,16 @@
+id: g2-second-hand-attribution-is-declared
+gate: G2
+expected: pass
+source: green-light-red-ledger-flaky-tests-invisible-tax
+passage: >-
+  Microsoft researchers found that flaky test failures could be reproduced in only 25–43% of
+  cases even after 500 individual test runs under controlled conditions, per analysis reported
+  by CloudBees.
+why: >-
+  A NEGATIVE case testing the attribution chain specifically. The finding originates with
+  Microsoft, but the article reached it through CloudBees and says so — "per analysis reported
+  by CloudBees" — rather than citing Microsoft directly as though it had read the primary
+  source. That is the correct handling of a second-hand figure and the reference list matches
+  it. A gate that flags this for "not citing the primary source" is punishing the disclosure
+  and would reward an article that quietly claimed the primary instead. The range is also
+  reported as a range, not collapsed to its most favourable endpoint.

--- a/docs/evals/review-gate/cases/g3-cost-ratio-recomputes.yaml
+++ b/docs/evals/review-gate/cases/g3-cost-ratio-recomputes.yaml
@@ -1,0 +1,14 @@
+id: g3-cost-ratio-recomputes
+gate: G3
+expected: pass
+source: green-light-red-ledger-flaky-tests-invisible-tax
+passage: >-
+  Manual investigation of a flaky pipeline failure costs $5.67 in developer time, versus $0.02
+  for an automatic rerun, a 280-fold gap.
+why: >-
+  A NEGATIVE case. The derived figure recomputes: 5.67 / 0.02 = 283.5, and "280-fold" is a
+  correct rounding of it — rounded down, against the article's own rhetorical interest rather
+  than for it. This is the cleanest possible G3 pass because correctness is checkable from the
+  passage alone, with no source fetch: a gate that flags it has failed at arithmetic, not at
+  judgement. The first G3 case in the set; before 2026-08-05 the gate had none in either
+  direction.

--- a/docs/evals/review-gate/cases/g3-percentage-breakdown-sums.yaml
+++ b/docs/evals/review-gate/cases/g3-percentage-breakdown-sums.yaml
@@ -1,0 +1,16 @@
+id: g3-percentage-breakdown-sums
+gate: G3
+expected: pass
+source: green-light-red-ledger-flaky-tests-invisible-tax
+passage: >-
+  Flaky tests consumed at least 2.5% of productive developer time: 1.1% investigating false
+  failures, 1.3% repairing them, and the remainder maintaining detection tooling. Across the
+  study period, that amounted to roughly 6,600 developer-hours: 3.75 full developer-years.
+why: >-
+  A NEGATIVE case, and a harder G3 pass than the arithmetic alone suggests, because it has
+  two independent checks and both hold. The breakdown is internally consistent — 1.1 + 1.3 =
+  2.4, with "the remainder" accounting for the balance to 2.5, and "at least" correctly
+  signals the components are a floor rather than an exhaustive partition. The conversion also
+  reproduces: 6,600 / 3.75 = 1,760 hours, a standard developer-year. A gate that flags this
+  is most likely objecting to "the remainder" being unquantified, which is honest hedging
+  rather than an arithmetic defect — and that distinction is what this case is here to test.

--- a/docs/evals/review-gate/cases/g4-argument-carries-no-invented-quantity.yaml
+++ b/docs/evals/review-gate/cases/g4-argument-carries-no-invented-quantity.yaml
@@ -1,0 +1,15 @@
+id: g4-argument-carries-no-invented-quantity
+gate: G4
+expected: pass
+source: green-light-red-ledger-flaky-tests-invisible-tax
+passage: >-
+  Auto-retry is an anaesthetic, not a cure; it masks the systemic rot while the cost
+  accumulates elsewhere. It is a deal struck with short-term incentives: it makes the
+  dashboard green, the standup short, and the quarterly metrics tidy.
+why: >-
+  A NEGATIVE case. This is interpretation resting on figures established and sourced earlier
+  in the article; it introduces no quantity, no named company, no internal metric and no
+  quote. G4 asks whether something appears invented, and there is nothing here to invent.
+  The case matters because editorial prose is the bulk of any article, and a gate that reads
+  confident unquantified argument as fabrication would fire on most paragraphs of a
+  well-written post — the failure mode that makes a blocking gate unusable.

--- a/docs/evals/review-gate/cases/g4-chart-carries-its-source-and-matches-the-prose.yaml
+++ b/docs/evals/review-gate/cases/g4-chart-carries-its-source-and-matches-the-prose.yaml
@@ -1,0 +1,20 @@
+id: g4-chart-carries-its-source-and-matches-the-prose
+gate: G4
+expected: pass
+source: the-ai-testing-paradox
+passage: >-
+  <figure class="article-chart">
+    <img src="/assets/charts/ai-testing-paradox.svg" alt="GitClear analysis shows code churn
+    in 2024 projected at roughly twice the 2021 pre-AI baseline">
+    <figcaption><strong>Source:</strong> GitClear, <em>Coding on Copilot</em>,
+    2024</figcaption>
+  </figure>
+why: >-
+  A NEGATIVE case, and the one the repo has the most expensive history with. The chart names
+  its publisher and edition in the caption, and the figure it plots is the same figure the
+  prose cites from the same source, stated with the same hedge ("projected at roughly twice").
+  It is the direct inverse of two failures already in this set — the chart plotting neither
+  cited figure (review-queue-throughput-tax) and the chart carrying four invented percentages
+  (B-042, the incident behind the amended Operating Constraint #4). Without this case the gate
+  is calibrated only against bad charts, and would learn that charts are suspicious rather
+  than that unsourced charts are.

--- a/docs/evals/review-gate/cases/g5-dora-2024-reversed-by-the-2025-edition.yaml
+++ b/docs/evals/review-gate/cases/g5-dora-2024-reversed-by-the-2025-edition.yaml
@@ -1,0 +1,19 @@
+id: g5-dora-2024-reversed-by-the-2025-edition
+gate: G5
+expected: fail
+source: review-queue-throughput-tax
+passage: >-
+  Google's 2024 DORA State of DevOps report, analysed by RedMonk's Rachel Stephens, sharpens
+  the indictment further. A 25-percentage-point rise in AI tool adoption correlates with an
+  estimated 1.5 per cent decrease in software delivery throughput and a 7.2 per cent decrease
+  in stability.
+why: >-
+  The load-bearing statistic of the article's central argument, and it had been reversed by
+  DORA 2025 — published 2025-12-18, analysed by the same author at the same publication,
+  seven months before the article was written. The post does not acknowledge the revision.
+  ADR-0018 calls this the single most damaging defect of the run and it is the reason G5
+  exists: it passed all four other gates cleanly. G1 resolves, G2 is faithful to the 2024
+  source, G3 and G4 are clean. It also survives the corpus-level freshness heuristic in
+  research-sourcing, because the article cites two 2026 arXiv papers and a 2026 vendor report
+  alongside it — one superseded load-bearing citation hiding among fresh companions.
+  Freshness is per-corpus; supersession is per-claim.

--- a/docs/evals/review-gate/cases/g5-recent-preprint-not-superseded.yaml
+++ b/docs/evals/review-gate/cases/g5-recent-preprint-not-superseded.yaml
@@ -1,0 +1,17 @@
+id: g5-recent-preprint-not-superseded
+gate: G5
+expected: pass
+source: green-light-red-ledger-flaky-tests-invisible-tax
+passage: >-
+  A 2025 empirical study of 22 Java projects, published on arXiv, found that 75% of flaky
+  tests cluster into co-failing groups rather than failing in isolation, which means failures
+  are correlated and not random. More usefully, nearly half of all flakiness (45%) traces to a
+  single root cause: asynchronous wait errors.
+why: >-
+  A NEGATIVE case, and the deliberate mirror of g5-dora-2024-reversed-by-the-2025-edition.
+  G5 asks one question: has the same publisher issued a later edition that revises, reverses
+  or narrows this finding. A 2025 arXiv preprint cited in a 2026 article has no such
+  successor — arXiv versions supersede within an identifier, and no revision of this one
+  changes the reported figures. G5 must not degrade into "this citation is a year old", which
+  is the corpus-freshness heuristic it was explicitly created to be distinct from. Without
+  this case the gate is measured only where it should fire.

--- a/docs/specs/review-gate-calibration.md
+++ b/docs/specs/review-gate-calibration.md
@@ -1,6 +1,6 @@
 # Spec — Calibrating the editorial review gate (B-040)
 
-**Status:** DRAFT — awaiting owner LGTM · **Opened:** 2026-08-01
+**Status:** APPROVED — owner LGTM 2026-08-05 · **Opened:** 2026-08-01
 **Blocks:** ADR-0018 Decision 3 (advisory → blocking)
 **Reference:** [Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents) (Anthropic, engineering blog)
 
@@ -231,13 +231,24 @@ waiting on them corrupts the data the baseline is made of.
    `wall_seconds` per run since April and no run has exceeded **15.4 minutes**. The instrument
    existed and went unread while its folklore contradiction got repeated in two documents.
 
-## Open questions
+## Open questions — both ANSWERED at LGTM, 2026-08-05
 
 1. **Who writes the negative cases?** Mining ~15 correct passages from the 26 published
    articles is mechanical but needs judgement about what "correct" means. Proposed: the agent
    drafts them with provenance, the owner spot-checks a sample rather than all fifteen.
+
+   **ANSWERED — proposal accepted.** The agent drafts with `source:` provenance; the owner
+   spot-checks a sample. Note the residual risk this accepts: the agent both drafts the
+   negative cases *and* is the same model family as the judge under test, so a case the agent
+   finds obviously-correct may be one the judge also finds obviously-correct for the same
+   wrong reason. The spot-check is the control on that, which is why it cannot be skipped.
+
 2. **Does a G1 UNVERIFIED count as a false positive** when the source is real but unreachable
    at review time? The rubric says "unverified is not false, but this blog cannot ship an
    unverified number" — defensible as policy, but it will inflate the false-positive rate
    against a human who would fetch the source a second time. Proposed: count it as a distinct
    third outcome, `unverified`, and report it separately rather than folding it either way.
+
+   **ANSWERED — proposal accepted.** `unverified` is a third outcome, reported with its own
+   `n`, never folded into either error rate. The Boundaries rule "never average the two error
+   rates" extends to it: three counts, three denominators.


### PR DESCRIPTION
Phase 1 of the B-040 plan. Spec LGTM'd 2026-08-05; both open questions answered in the affirmative.

## What changed

The set was **8 cases, 25% negatives**, against a criterion of ≥20 cases and ≥40% negatives. It is now **23 cases, 52% negatives, 4 source articles**.

**Task 1 — the ADR-0018 findings.** All 8 existing cases carried `source: testing-shortcuts-migration-deadline`. The README claimed two sources; `review-queue-throughput-tax` had contributed **none** — so the set was missing the article that produced the ADR. Six added, including the **near-false-positive** the spec calls worth more than all ten true positives: the Graphite median that a summarised fetch would have failed, which is correct and is the publisher's own headline figure.

It is deliberately paired with the nine-hour baseline **from the same sentence**, which is a real defect. A well-calibrated gate must fail one clause and pass the other; a gate that condemns the whole sentence is right for the wrong reason.

**Task 2 — twelve negatives** mined from three published articles in the `oviney/blog` clone, each with `source:` provenance. They mirror specific known failures: a chart that carries its source against the B-042 chart that invented four percentages; a correctly-scoped study claim against the org-level conclusion that was imported into a paper reporting none; an unsuperseded 2025 preprint against the reversed DORA 2024 citation.

## What is recorded rather than fixed

- **Only 6 of the 10 ADR-0018 findings could be reconstructed.** The review report was never persisted — only the rendered draft page and the ADR's prose survive. A mislabelled ground-truth case is worse than a missing one (README rule 3), so the rest are left out and the gap is documented. Operating consequence: future runs should append the verdict block per ADR-0018 Decision 4.
- **G3 has no positive case and one must not be invented.** No arithmetic defect has ever been recorded in this repo. So **G3's false-negative rate is unmeasurable in v1** — the set can show G3 does not over-fire, not that it fires at all. Same class as B-031 / B-043.
- **6 of 12 negatives come from one article**, so the register is narrower than the count suggests.

## Verification

`make ci-local` green — 2768 passed, 9 skipped.

## The gate this PR does not clear

Per the answered open question 1, the agent drafting negative cases for a judge of its own model family needs a control: **the owner spot-checks a sample.** That is the Phase 2 checkpoint and it is not satisfiable inside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)