### PR TITLE
chore: Mermaid VS Code extension artifacts (owner decision, do not auto-merge)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -834,3 +834,10 @@ See [SCRUM_MASTER_PROTOCOL.md](../docs/SCRUM_MASTER_PROTOCOL.md) for complete wo
 - [JEKYLL_EXPERTISE.md](../docs/JEKYLL_EXPERTISE.md): Jekyll integration patterns
 - [SKILLS_LEARNING.md](../docs/SKILLS_LEARNING.md): Skills manager documentation
 - [CHANGELOG.md](../docs/CHANGELOG.md): Version history and migration notes
+
+<!-- mermaid-ai-skills:start -->
+## Mermaid Diagrams
+
+When the user asks to create, edit, or visualize a diagram, follow the
+instructions in `.github/instructions/mermaid.instructions.md`.
+<!-- mermaid-ai-skills:end -->

--- a/.github/instructions/mermaid.instructions.md
+++ b/.github/instructions/mermaid.instructions.md
@@ -1,0 +1,85 @@
+---
+applyTo: "**"
+---
+# Mermaid AI Skills
+
+When the user asks to create, edit, or visualize any diagram, use the Mermaid
+VS Code extension tools and commands described below.
+
+## Workflow
+
+1. Determine the diagram type and generate Mermaid syntax.
+2. Write the diagram to a `.mmd` file in the project.
+3. Validate syntax: correct first-line keyword, arrow types, balanced brackets.
+4. Preview via the Mermaid extension — open the `.mmd` file (auto-preview) or run
+   **MermaidChart: Preview Diagram** (`mermaidChart.preview`).
+
+## LM Tools — call these for every diagram interaction
+
+- `mermaid-diagram-validator` — validate Mermaid syntax before presenting any diagram
+- `mermaid-diagram-preview` — render a live preview inside VS Code after generating
+- `get-syntax-docs-mermaid` — fetch correct syntax docs for any diagram type
+
+## VS Code Commands
+
+Invoke via Command Palette or the VS Code command API (GitHub Copilot in VS Code only).
+Do not invent command IDs. Prefer writing/editing `.mmd` files when a command is not needed.
+
+### Diagram editing & preview
+- **Preview** (`mermaidChart.preview`) — preview the active Mermaid editor (`.mmd` / `.mermaid` must be open).
+- **Create Diagram** (`mermaidChart.createMermaidFile`) — creates a demo flowchart and opens preview side by side.
+- **Repair Diagram** (`mermaidChart.repairDiagram`) — Mermaid AI repair for the active diagram; uses Mermaid AI credits — tell the user before running.
+- **Improve Diagram** (`mermaidChart.improveDiagram`) — uses Copilot / LM API; suggests layout + styling variants for the active diagram.
+
+### Generate diagrams (GitHub Copilot required)
+- **Generate Diagram from Code** (`mermaidChart.generateDiagramFromCode`)
+- **Generate Cloud Diagram** (`mermaidChart.generateCloudDiagram`)
+- **Generate ER Diagram** (`mermaidChart.generateERDiagram`)
+- **Generate Docker Diagram** (`mermaidChart.generateDockerDiagram`)
+- **Open AI Chat** (`mermaidChart.openCopilotChat`)
+
+### Mermaid Chart cloud
+- **Login** (`mermaidChart.login`) / **Logout** (`mermaidChart.logout`)
+- **Connect Diagram** (`mermaidChart.connectDiagramToMermaidChart`) — link a local diagram to Mermaid Chart.
+- **Sync Diagram** (`mermaidChart.syncDiagramWithMermaid`) — only for diagrams already connected (frontmatter has `id:`). Example:
+  ```yaml
+  ---
+  id: cbd9e9ba-a2cb-47c5-a98e-8c28a753428d
+  ---
+  ```
+
+### Review Mermaid Sync
+For diagrams updated by the Mermaid Chart GitHub Sync app (or pre-commit regenerate):
+- **Review Mermaid Sync** (`mermaidChart.reviewAppCommits`) — start / open the review flow.
+- **Regenerate with Mermaid AI** (`mermaidChart.regenerateDiagramWithMermaidAI`) — regenerate from source references.
+Do not manually rewrite diagrams managed by this workflow. Accept/reject/diff UI actions stay in the extension UI.
+
+### Install / update this pack
+- **MermaidChart: Install AI Skills…** (`mermaidChart.installAiSkills`)
+
+## @mermaid-chart slash commands
+
+| Command | Purpose |
+|---|---|
+| `/generate_diagram_from_code` | General diagram from any source file |
+| `/generate_execution_sequence` | Sequence diagram from code flow |
+| `/generate_er_diagram` | ER diagram from schema / models |
+| `/generate_cloud_architecture_diagram` | Cloud / CI-CD architecture |
+| `/generate_docker_diagram` | Architecture from Dockerfiles |
+| `/generate_c4_topdown_architecture` | C4 top-down architecture |
+| `/analyze_code_ownership` | Code ownership diagram |
+| `/generate_dependency_diagram` | Dependency / security visualisation |
+
+## Rules
+
+1. Always call `mermaid-diagram-validator` before showing any diagram.
+2. Always call `mermaid-diagram-preview` after generating a diagram.
+3. Use `get-syntax-docs-mermaid` before generating an unfamiliar diagram type.
+4. Prefer `@mermaid-chart` slash commands for complex generation.
+5. Write diagrams to `.mmd` files; never return unvalidated Mermaid syntax.
+6. Warn the user before Repair (Mermaid AI credits).
+7. Cooperate with the Sync workflow — do not manually regenerate managed diagrams.
+
+## Docs
+
+More commands and features: https://marketplace.visualstudio.com/items?itemName=MermaidChart.vscode-mermaid-chart


### PR DESCRIPTION
**Not my work and not requested.** Both files were written into the working tree by the Mermaid VS Code extension during the 2026-08-09 session:

- `.github/instructions/mermaid.instructions.md` — new, 85 lines
- `.github/copilot-instructions.md` — a 7-line block the extension appended between its own `<!-- mermaid-ai-skills:start/end -->` markers

## Why this is a PR rather than a deletion or a merge

A machine change was imminent and uncommitted files do not survive one, so deleting them silently would have destroyed something the owner had not seen. Keeping them out of #473 matters too — a tooling artifact should not ride into a calibration PR where it gets reviewed as though it were part of B-040.

## Why it needs your decision

`.github/copilot-instructions.md` is one of the six documents **B-028 Task 2** corrected after the unreviewed-publish RCA. A tool appending to a governed instruction file unprompted is worth a deliberate answer:

- **Keep** — merge as-is if the Mermaid tooling is wanted.
- **Reject** — close this PR, revert the appended block, and gitignore `.github/instructions/` so the extension stops re-adding it.

I have no basis to choose; nothing in the repo asked for Mermaid tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)