### PR TITLE
Add Trustabl Agent Scanner to CI

### DIFF
--- a/.github/workflows/trustabl.yml
+++ b/.github/workflows/trustabl.yml
@@ -1,0 +1,17 @@
+name: Trustabl
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write
+  pull-requests: write
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: trustabl/trustabl-action@v0


### PR DESCRIPTION
We came across your repo and we like how you've designed a pipeline of specialized AI agents to generate Economist-style articles with verifiable sources. We scanned the repo, and noticed agent runtime reliability findings that might be worth reviewing.

1. [HIGH] Session permission mode bypasses approvals
   What it means: A ClaudeAgentOptions(. 

2. [HIGH] Path parameter used in I/O without validation
   File: mcp_servers/blog_deployer_server.py
   What it means: The tool accepts a path-like parameter and passes it to file or directory operations without resolving or sandboxing the path. 

Recommendations are based on our understanding of agent runtime reliability, some findings may be intentional. Please let us know if this was intentional or if our findings are helpful so we can improve the accuracy of the scanner.

Best,
Trustabl.ai
Open-source AI agent reliability scanner (runs locally, GitHub Action)