### PR TITLE
chore: ignore scripts/logs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ output/
 # Runtime telemetry / eval logs (appended-to by tests + pipeline)
 logs/article_evals.json
 logs/agent_sdk_costs.jsonl
+scripts/logs/
 
 # Secrets
 .env


### PR DESCRIPTION
## What & why

Runtime logs written under `scripts/logs/` were showing up as untracked noise in `git status`. This adds a single ignore line alongside the existing `logs/` telemetry ignores.

One line, no behaviour change.

## Related

No backlog item — housekeeping picked up while syncing the local checkout to `main`.

## How to test

1. `git status --short` is clean with files present under `scripts/logs/`.
2. `git check-ignore -v scripts/logs/anything.log` resolves to the new `.gitignore` rule.

## Checklist

- [x] Followed the agent-skills lifecycle (spec → plan → build → test → review → ship as applicable) — trivial one-line change, lifecycle exempt
- [x] Tests pass (`pytest`) and cover the change — pre-push hook ran the full suite: 2749 passed, 10 skipped
- [x] `ruff check` / `ruff format --check` clean — skipped by pre-commit, no Python files touched
- [x] Docs/ADRs updated if behaviour or architecture changed — n/a
- [x] Self-review completed; no unrelated changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)