### PR TITLE
fix(B-045): deploy_article must not publish files outside output/

### DIFF
--- a/mcp_servers/blog_deployer_server.py
+++ b/mcp_servers/blog_deployer_server.py
@@ -85,6 +85,58 @@ def list_deployable_articles(output_dir: str = "output") -> list[str]:
     return [str(a) for a in articles]
 
 
+_OUTPUT_ROOT_ENV = "BLOG_DEPLOY_OUTPUT_ROOT"
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _deployable_root() -> Path:
+    """The only directory `deploy_article` may read an article from.
+
+    Deliberately **not** a tool argument. `article_path` is chosen by an agent,
+    and an agent that can widen its own sandbox does not have one.
+
+    Returns:
+        Absolute, symlink-resolved path to the deployable root.
+
+    """
+    override = os.environ.get(_OUTPUT_ROOT_ENV)
+    root = Path(override) if override else _REPO_ROOT / "output"
+    return root.resolve()
+
+
+def _resolve_article_path(article_path: str) -> tuple[Path | None, str | None]:
+    """Resolve an agent-supplied article path, refusing anything outside `output/`.
+
+    `deploy_article` copies the named file into a **public** blog PR using
+    `GITHUB_TOKEN`, so an unconstrained path is an exfiltration route: text
+    injected into fetched research could name any readable file. `resolve()`
+    collapses `..` and follows symlinks before the check, so neither traversal
+    nor a symlink planted inside `output/` escapes.
+
+    Args:
+        article_path: Caller-supplied path to the article markdown file.
+
+    Returns:
+        `(resolved_path, None)` when the path is inside the deployable root and
+        exists, otherwise `(None, error_message)`. The sandbox check runs first
+        so an out-of-root path cannot be used to probe which files exist.
+
+    """
+    root = _deployable_root()
+    try:
+        candidate = Path(article_path).resolve()
+    except OSError as exc:  # pragma: no cover - platform-dependent
+        return None, f"Article path could not be resolved: {exc}"
+
+    if not candidate.is_relative_to(root):
+        return None, (
+            f"Article path is outside the deployable root {root}: {article_path}"
+        )
+    if not candidate.exists():
+        return None, f"Article not found: {article_path}"
+    return candidate, None
+
+
 @mcp.tool()
 def deploy_article(
     article_path: str,
@@ -113,11 +165,11 @@ def deploy_article(
             "article": None,
         }
 
-    article = Path(article_path)
-    if not article.exists():
+    article, path_error = _resolve_article_path(article_path)
+    if article is None:
         return {
             "success": False,
-            "error": f"Article not found: {article_path}",
+            "error": path_error,
             "pr_url": None,
             "article": None,
         }

--- a/tests/test_mcp_servers/test_blog_deployer_server.py
+++ b/tests/test_mcp_servers/test_blog_deployer_server.py
@@ -16,6 +16,16 @@ def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _sandbox_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point B-045's deployable root at the test's own `output/` directory.
+
+    The root is deliberately *not* a tool argument — an agent must not be able to
+    widen its own sandbox — so tests move it via the environment instead.
+    """
+    monkeypatch.setenv("BLOG_DEPLOY_OUTPUT_ROOT", str(tmp_path / "output"))
+
+
 @pytest.fixture
 def sample_article(tmp_path: Path) -> Path:
     """Create a sample article for deployment tests."""
@@ -137,11 +147,18 @@ class TestDeployArticle:
         assert result["success"] is False
         assert "GITHUB_TOKEN" in result["error"]
 
-    def test_article_not_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_article_not_found(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         from mcp_servers.blog_deployer_server import deploy_article
 
         monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
-        result = deploy_article("/nonexistent/article.md", "oviney/blog")
+        # Inside the deployable root (B-045) but absent, so this still exercises
+        # the missing-file branch rather than the sandbox refusal.
+        missing = tmp_path / "output" / "article.md"
+        result = deploy_article(str(missing), "oviney/blog")
         assert result["success"] is False
         assert "not found" in result["error"].lower()
 
@@ -260,6 +277,90 @@ class TestDeployArticle:
 
         assert result["success"] is True
         assert any(call.args[0] == chart for call in mock_copy.call_args_list)
+
+
+class TestDeployArticlePathSandbox:
+    """B-045: `article_path` is agent-supplied, so it must not escape `output/`.
+
+    `deploy_article` copies the named file into a **public** blog PR using
+    `GITHUB_TOKEN`. An agent steered by injected text in fetched research could
+    otherwise name any readable file and have it published.
+    """
+
+    @patch("mcp_servers.blog_deployer_server._run_command")
+    def test_rejects_article_outside_the_output_root(
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from mcp_servers.blog_deployer_server import deploy_article
+
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        secret = tmp_path / "secrets.md"
+        secret.write_text("ANTHROPIC_API_KEY=sk-should-never-be-published\n")
+
+        result = deploy_article(str(secret), "oviney/blog")
+
+        assert result["success"] is False
+        assert "outside" in result["error"].lower()
+        # The refusal must happen before anything clones or pushes.
+        mock_run.assert_not_called()
+
+    @patch("mcp_servers.blog_deployer_server._run_command")
+    def test_rejects_traversal_out_of_the_output_root(
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from mcp_servers.blog_deployer_server import deploy_article
+
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        secret = tmp_path / "secrets.md"
+        secret.write_text("token\n")
+        traversal = tmp_path / "output" / ".." / "secrets.md"
+
+        result = deploy_article(str(traversal), "oviney/blog")
+
+        assert result["success"] is False
+        assert "outside" in result["error"].lower()
+        mock_run.assert_not_called()
+
+    @patch("mcp_servers.blog_deployer_server._run_command")
+    def test_rejects_symlink_pointing_out_of_the_output_root(
+        self,
+        mock_run: MagicMock,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from mcp_servers.blog_deployer_server import deploy_article
+
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        secret = tmp_path / "secrets.md"
+        secret.write_text("token\n")
+        link = tmp_path / "output" / "innocent.md"
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(secret)
+
+        result = deploy_article(str(link), "oviney/blog")
+
+        assert result["success"] is False
+        assert "outside" in result["error"].lower()
+        mock_run.assert_not_called()
+
+    def test_accepts_an_article_inside_the_output_root(
+        self,
+        sample_article: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The guard must not reject the legitimate path (no false positive)."""
+        from mcp_servers.blog_deployer_server import _resolve_article_path
+
+        resolved, error = _resolve_article_path(str(sample_article))
+
+        assert error is None
+        assert resolved == sample_article.resolve()
 
 
 class TestMcpServerRegistration:


### PR DESCRIPTION
## What & why

`deploy_article` (`mcp_servers/blog_deployer_server.py`) took an agent-supplied `article_path`, wrapped it in `Path()` and checked only `.exists()`. Nothing constrained it to `output/`.

That matters here specifically: the function copies the named file into a **public** blog PR using `GITHUB_TOKEN`, and this pipeline ingests untrusted web research and owner HTML artifacts. Text injected into fetched research could steer an agent into naming any readable file. OWASP **LLM01** (prompt injection) → **LLM06** (excessive agency); the `security-and-hardening` rule is "never pass model output straight into a file path".

**This is not theoretical.** The symlink reproduction test failed with `assert True is False` before the fix — a symlink planted inside `output/` pointing at a file outside it deployed successfully.

## Provenance

Found by triaging PR #475 (Trustabl scanner outreach). That PR reported two findings; **I am recommending #475 itself be closed** — its payload is a GitHub Actions workflow, which reverses B-011 and adds an unsolicited third-party action. This is the finding worth keeping.

Its **other** finding — "session permission mode bypasses approvals" — is a **false positive**, measured not assumed: all five `permission_mode="bypassPermissions"` sites pair it with an explicit allowlist (`[]` in `research/_llm.py` and `llm_client.py`, `["Read"]` in `_shared.py`, `["WebSearch","WebFetch"]` in `claude_web.py`, caller-supplied-defaulting-to-`[]` in `stage3_runner.py`), all with `mcp_servers={}`. Bypassing approval for an empty tool set grants nothing.

## The fix

`_resolve_article_path` resolves first (collapsing `..`, following symlinks), then refuses anything not under the deployable root.

- **Sandbox check precedes the existence check**, so an out-of-root path can't probe which files exist.
- **The root is not a tool argument.** An agent that can widen its own sandbox does not have one. It comes from `BLOG_DEPLOY_OUTPUT_ROOT`, defaulting to the repo's `output/`; tests move it via the environment.

## Tests (Prove-It pattern — all 3 refusal tests failed first)

| Test | Guards |
|---|---|
| `test_rejects_article_outside_the_output_root` | plain out-of-root path |
| `test_rejects_traversal_out_of_the_output_root` | `output/../secrets.md` |
| `test_rejects_symlink_pointing_out_of_the_output_root` | symlink planted inside `output/` |
| `test_accepts_an_article_inside_the_output_root` | no false positive on the legitimate path |

Each refusal test also asserts `_run_command` was never called — the refusal must land before anything clones or pushes.

`test_article_not_found` now uses a missing path *inside* the root, so it still exercises the missing-file branch rather than the new refusal.

## Complexity note

`deploy_article` was **already** at 13/13/61 against the sensor's 10/12/50 thresholds before this change. Folding the existence check into the resolver keeps it at **13/13/61 — net zero**. No override recorded, because the debt is pre-existing and I'm not claiming it warranted; it's a genuine hotspot if B-032 ever wants a target.

## Verification

`make ci-local` green — **2753 passed** (2749 baseline + 4 new), 10 skipped.

## Checklist

- [x] Followed the agent-skills lifecycle — `using-agent-skills` → `security-and-hardening` → `test-driven-development` (Prove-It)
- [x] Tests pass and cover the change — 4 new tests, 3 of which failed before the fix
- [x] `ruff check` / `ruff format --check` clean
- [x] Docs/ADRs updated if behaviour or architecture changed — behaviour change is a refusal; documented here and in the docstrings
- [x] Self-review completed; no unrelated changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)