### PR TITLE
chore: stop the Mermaid extension re-offering its artifact (rejects #474)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,12 @@ docs/research/samples/*.html
 # docs/research/ are committed normally; only ones derived from a local-only artifact
 # are ignored, one line each.
 docs/research/sre-quality-governance.md
+
+# The Mermaid VS Code extension writes this unprompted (PR #474, rejected). Nothing in
+# the repo asked for Mermaid tooling, and the extension also appends to
+# .github/copilot-instructions.md — one of the six governed docs B-028 Task 2 corrected
+# after the unreviewed-publish RCA. Ignoring the file stops it being re-offered.
+#
+# Deliberately NOT the whole .github/instructions/ directory: scripts.instructions.md is
+# tracked there and is referenced by docs/RESEARCH_AGENT_EXTRACTION.md.
+.github/instructions/mermaid.instructions.md


### PR DESCRIPTION
## What & why

**This is the "reject" half of PR #474**, which asked for a keep/reject decision on two files the Mermaid VS Code extension wrote into the working tree unprompted during the 2026-08-09 session.

The decision is **reject**: nothing in the repo asked for Mermaid tooling, and the extension also appends to `.github/copilot-instructions.md` — one of the six documents **B-028 Task 2** corrected after the unreviewed-publish RCA. An unprompted tool writing into a governed instruction file is worth a deliberate answer rather than a merge.

## Scoped deliberately to one file

`.github/instructions/mermaid.instructions.md`, **not** the `.github/instructions/` directory.

I had initially recommended ignoring the whole directory. That was wrong, and checking `main` caught it: `.github/instructions/scripts.instructions.md` is tracked there and is referenced by `docs/RESEARCH_AGENT_EXTRACTION.md:299`. Ignoring the directory would have hidden a legitimate governed doc.

## Nothing to revert

Neither artifact reached `main` — #474 captured them from the working tree. Verified: no `mermaid-ai-skills` markers in `.github/copilot-instructions.md` on `main`, and `.github/instructions/` holds only `scripts.instructions.md`.

## Limit worth stating plainly

This stops the **new file** only. The extension also appends a block to `.github/copilot-instructions.md` between its own markers, and that file is *tracked* — gitignore cannot prevent it. A reappearance has to be caught at review time. I have not tried to solve that here; it would need either a pre-commit check for the marker or uninstalling the extension, and neither is my call.

## Follow-up

**PR #474 should be closed** once this merges. I attempted it and report the result in the session; it is not done by this PR.

## How to test

1. `git check-ignore -v .github/instructions/mermaid.instructions.md` → matches the new rule.
2. `git check-ignore .github/instructions/scripts.instructions.md` → **no match** (still tracked).
3. `git ls-files .github/instructions/` → still lists `scripts.instructions.md`.

## Checklist

- [x] Followed the agent-skills lifecycle — routed via `using-agent-skills`; config-only change
- [x] Tests pass — no code touched; `.gitignore`-only diff, pre-commit clean
- [x] `ruff check` / `ruff format --check` clean — no Python touched
- [x] Docs/ADRs updated if behaviour or architecture changed — n/a
- [x] Self-review completed; no unrelated changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)